### PR TITLE
refactor(yaml): make `Type.kind` required

### DIFF
--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -63,9 +63,7 @@ function compileMap(...typesList: Type<unknown>[][]): TypeMap {
 
   for (const types of typesList) {
     for (const type of types) {
-      if (type.kind !== null) {
-        result[type.kind][type.tag] = result["fallback"][type.tag] = type;
-      }
+      result[type.kind][type.tag] = result["fallback"][type.tag] = type;
     }
   }
   return result;

--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -24,7 +24,7 @@ export type RepresentFn<D> = (data: D, style?: StyleVariant) => string;
 // deno-lint-ignore no-explicit-any
 export interface Type<D = any> {
   tag: string;
-  kind: KindType | null;
+  kind: KindType;
   instanceOf?: new (...args: unknown[]) => D;
   predicate?: (data: Record<string, unknown>) => boolean;
   represent?: RepresentFn<D> | ArrayObject<RepresentFn<D>>;


### PR DESCRIPTION
All `Type` objects already have this property defined. Users don't have control over this value.

Towards #5340