### PR TITLE
BREAKING(dotenv): remove `examplePath` option from `load[Sync]()`

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -152,32 +152,7 @@ export function loadSync(
  * |File|Purpose|
  * |----|-------|
  * |.env|primary file for storing key-value environment entries
- * |.env.example|this file does not set any values, but specifies env variables which must be present in the configuration object or process environment after loading dotenv
  * |.env.defaults|specify default values for env variables to be used when there is no entry in the `.env` file
- *
- * ### Example file
- *
- * The purpose of the example file is to provide a list of environment
- * variables which must be set or already present in the process environment
- * or an exception will be thrown.  These
- * variables may be set externally or loaded via the `.env` or
- * `.env.defaults` files.  A description may also be provided to help
- * understand the purpose of the env variable. The values in this file
- * are for documentation only and are not set in the environment. Example:
- *
- * ```sh
- * # .env.example
- *
- * # With optional description (this is not set in the environment)
- * DATA_KEY=API key for the api.data.com service.
- *
- * # Without description
- * DATA_URL=
- * ```
- *
- * When the above file is present, after dotenv is loaded, if either
- * DATA_KEY or DATA_URL is not present in the environment an exception
- * is thrown.
  *
  * ### Defaults
  *
@@ -230,7 +205,7 @@ export function loadSync(
  * in your `.env` file, you will need the `--allow-env` permission.  E.g.
  *
  * ```sh
- * deno run --allow-read=.env,.env.defaults,.env.example --allow-env=ENV1,ENV2 app.ts
+ * deno run --allow-read=.env,.env.defaults --allow-env=ENV1,ENV2 app.ts
  * ```
  *
  * ## Parsing Rules

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -7,12 +7,7 @@ import {
   assertStrictEquals,
   assertThrows,
 } from "@std/assert";
-import {
-  load,
-  type LoadOptions,
-  loadSync,
-  MissingEnvVarsError,
-} from "./mod.ts";
+import { load, type LoadOptions, loadSync } from "./mod.ts";
 import * as path from "@std/path";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
@@ -30,7 +25,6 @@ Deno.test("load() handles non-existent .env files", async () => {
 
   const loadOptions = {
     envPath: "some.nonexistent.env",
-    examplePath: "some.nonexistent.example",
     defaultsPath: "some.nonexistent.defaults",
   };
   assertEquals({}, await load(loadOptions));
@@ -114,141 +108,6 @@ function validateNotOverridden(conf: Record<string, string>): void {
   }
 }
 
-Deno.test("load() handles example file key in .env, no issues loading", async () => {
-  //Both .env.example.test and .env contain "GREETING"
-  const loadOptions = {
-    ...testOptions,
-    examplePath: path.join(testdataDir, "./.env.example.test"),
-  };
-  loadSync(loadOptions);
-  await load(loadOptions);
-});
-
-Deno.test("load() handles example file key in .env.default, no issues loading", async () => {
-  //Both .env.example3.test and .env.default contain "DEFAULT1"
-  const loadOptions = {
-    ...testOptions,
-    examplePath: path.join(testdataDir, "./.env.example3.test"),
-  };
-  loadSync(loadOptions);
-  await load(loadOptions);
-});
-
-Deno.test("load() handles example file key not in .env or .env.defaults, error thrown", async () => {
-  // Example file key of "ANOTHER" is not present in .env or .env.defaults
-  const error: MissingEnvVarsError = assertThrows(() => {
-    loadSync({
-      ...testOptions,
-      examplePath: path.join(testdataDir, "./.env.example2.test"),
-    });
-  }, MissingEnvVarsError);
-
-  assertEquals(error.missing, ["ANOTHER"]);
-
-  const asyncError: MissingEnvVarsError = await assertRejects(async () => {
-    await load({
-      ...testOptions,
-      examplePath: path.join(testdataDir, "./.env.example2.test"),
-    });
-  }, MissingEnvVarsError);
-
-  assertEquals(asyncError.missing, ["ANOTHER"]);
-});
-
-Deno.test("load() handles omitted allowEmptyValues, empty required keys throw error", async () => {
-  // Example file key of "ANOTHER" is present but empty in .env
-  const error: MissingEnvVarsError = assertThrows(() => {
-    loadSync({
-      envPath: path.join(testdataDir, "./.env.required.empty.test"),
-      examplePath: path.join(testdataDir, "./.env.example2.test"),
-    });
-  }, MissingEnvVarsError);
-
-  assertEquals(error.missing, ["ANOTHER"]);
-
-  const asyncError: MissingEnvVarsError = await assertRejects(async () => {
-    await load({
-      envPath: path.join(testdataDir, "./.env.required.empty.test"),
-      examplePath: path.join(testdataDir, "./.env.example2.test"),
-    });
-  }, MissingEnvVarsError);
-
-  assertEquals(asyncError.missing, ["ANOTHER"]);
-});
-
-Deno.test("load() handles allowEmptyValues, empty required keys do not throw error", async () => {
-  // Example file key of "ANOTHER" is present but empty in .env
-  const loadOptions = {
-    envPath: path.join(testdataDir, "./.env.required.empty.test"),
-    examplePath: path.join(testdataDir, "./.env.example2.test"),
-    allowEmptyValues: true,
-  };
-
-  loadSync(loadOptions);
-  await load(loadOptions);
-});
-
-Deno.test("load() checks that required keys can be sourced from process environment", async () => {
-  try {
-    Deno.env.set("ANOTHER", "VAR");
-
-    // Example file key of "ANOTHER" is not present in .env or .env.defaults
-    const loadOptions = {
-      envPath: path.join(testdataDir, "./.env"),
-      examplePath: path.join(testdataDir, "./.env.example2.test"),
-    };
-
-    loadSync(loadOptions);
-    await load(loadOptions);
-  } finally {
-    Deno.env.delete("ANOTHER");
-  }
-});
-
-Deno.test("load() checks that required keys sourced from process environment cannot be empty", async () => {
-  try {
-    Deno.env.set("ANOTHER", "");
-
-    // Example file key of "ANOTHER" is not present in .env or .env.defaults
-    const loadOptions = {
-      envPath: path.join(testdataDir, "./.env"),
-      examplePath: path.join(testdataDir, "./.env.example2.test"),
-    };
-
-    const error: MissingEnvVarsError = assertThrows(() => {
-      loadSync(loadOptions);
-    }, MissingEnvVarsError);
-
-    assertEquals(error.missing, ["ANOTHER"]);
-
-    const asyncError: MissingEnvVarsError = await assertRejects(async () => {
-      await load(loadOptions);
-    }, MissingEnvVarsError);
-
-    assertEquals(asyncError.missing, ["ANOTHER"]);
-  } finally {
-    Deno.env.delete("ANOTHER");
-  }
-});
-
-Deno.test("load() checks that required keys sourced from process environment can be empty with allowEmptyValues", async () => {
-  try {
-    Deno.env.set("ANOTHER", "");
-
-    // Example file key of "ANOTHER" is not present in .env or .env.defaults
-    const loadOptions = {
-      envPath: path.join(testdataDir, "./.env"),
-      examplePath: path.join(testdataDir, "./.env.example2.test"),
-      allowEmptyValues: true,
-    };
-
-    loadSync(loadOptions);
-    await load(loadOptions);
-  } finally {
-    Deno.env.delete("ANOTHER");
-  }
-});
-
 Deno.test("load() loads .env and .env.defaults successfully from default file names/paths", async () => {
   const command = new Deno.Command(Deno.execPath(), {
     args: [
@@ -276,7 +135,6 @@ Deno.test("load() expands empty values from process env expand as empty value", 
     // .env.single.expand contains one key which expands to the "EMPTY" process env var
     const loadOptions = {
       envPath: path.join(testdataDir, "./.env.single.expand"),
-      allowEmptyValues: true,
     };
 
     const conf = loadSync(loadOptions);
@@ -325,7 +183,6 @@ Deno.test(
     const loadOptions = {
       envPath: path.join(testdataDir, "./.env.single.expand"),
       defaultsPath: null,
-      examplePath: null,
     };
     assertThrows(
       () => loadSync(loadOptions),
@@ -350,7 +207,6 @@ Deno.test(
       const loadOptions = {
         envPath: path.join(testdataDir, "./.env.single.expand"),
         defaultsPath: null,
-        examplePath: null,
       };
       const conf = loadSync(loadOptions);
       assertEquals(
@@ -378,7 +234,6 @@ Deno.test(
     const optsNoPaths = {
       defaultsPath: null,
       envPath: null,
-      examplePath: null,
     } satisfies LoadOptions;
 
     const optsEnvPath = {
@@ -388,7 +243,6 @@ Deno.test(
     const optsOnlyEnvPath = {
       ...optsEnvPath,
       defaultsPath: null,
-      examplePath: null,
     } satisfies LoadOptions;
 
     const assertEnv = (env: Record<string, string>): void => {
@@ -406,18 +260,6 @@ Deno.test(
         Deno.errors.PermissionDenied,
         `Requires read access to ".env.defaults"`,
       );
-
-      await assertRejects(
-        () => load({ ...optsEnvPath, defaultsPath: null }),
-        Deno.errors.PermissionDenied,
-        `Requires read access to ".env.example"`,
-      );
-
-      await assertRejects(
-        () => load({ ...optsEnvPath, examplePath: null }),
-        Deno.errors.PermissionDenied,
-        `Requires read access to ".env.defaults"`,
-      );
     });
 
     await t.step("loadSync", () => {
@@ -426,18 +268,6 @@ Deno.test(
 
       assertThrows(
         () => loadSync(optsEnvPath),
-        Deno.errors.PermissionDenied,
-        `Requires read access to ".env.defaults"`,
-      );
-
-      assertThrows(
-        () => loadSync({ ...optsEnvPath, defaultsPath: null }),
-        Deno.errors.PermissionDenied,
-        `Requires read access to ".env.example"`,
-      );
-
-      assertThrows(
-        () => loadSync({ ...optsEnvPath, examplePath: null }),
         Deno.errors.PermissionDenied,
         `Requires read access to ".env.defaults"`,
       );


### PR DESCRIPTION
### What's changed

The `examplePath` option for `load[Sync]()` from `@std/dotenv` has been removed. The `allowEmptyValues` option and `MissingEnvVarsError` have also been removed, as the basis for their existence was dependent on the `examplePath` option.

### Motivation

See details in #5449.

### Migration guide

To migrate, if environment variables need to be validated, do so in-code instead of using the `examplePath` option.

```env
# .env.example
# Notice: missing `QUX` environment variable
FOO=bar
```

```diff
import "@std/dotenv/load";

+ if (!Deno.env.has("QUX") {
+   // ...
+ }
```

### Related

Closes #5449