### PR TITLE
refactor(yaml): define ScalarType type and use it for implicit types

### DIFF
--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { KindType, Type } from "./_type.ts";
+import type { KindType, ScalarType, Type } from "./_type.ts";
 import type { ArrayObject } from "./_utils.ts";
 import {
   binary,
@@ -69,7 +69,7 @@ function compileMap(...typesList: Type<unknown>[][]): TypeMap {
 }
 
 export class Schema {
-  implicit: Type[];
+  implicit: ScalarType[];
   explicit: Type[];
   include: Schema[];
 
@@ -78,7 +78,7 @@ export class Schema {
   compiledTypeMap: TypeMap;
 
   constructor(definition: {
-    implicit?: Type[];
+    implicit?: ScalarType[];
     explicit?: Type[];
     include?: Schema[];
   }) {

--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -35,3 +35,6 @@ export interface Type<D = any> {
   // deno-lint-ignore no-explicit-any
   construct: (data: any) => D;
 }
+
+// deno-lint-ignore no-explicit-any
+export type ScalarType<D = any> = Omit<Type<D>, "kind"> & { kind: "scalar" };

--- a/yaml/_type/bool.ts
+++ b/yaml/_type/bool.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { Type } from "../_type.ts";
+import type { ScalarType } from "../_type.ts";
 import { isBoolean } from "../_utils.ts";
 
 function resolveYamlBoolean(data: string): boolean {
@@ -17,7 +17,7 @@ function constructYamlBoolean(data: string): boolean {
   return data === "true" || data === "True" || data === "TRUE";
 }
 
-export const bool: Type<boolean> = {
+export const bool: ScalarType<boolean> = {
   tag: "tag:yaml.org,2002:bool",
   construct: constructYamlBoolean,
   defaultStyle: "lowercase",

--- a/yaml/_type/float.ts
+++ b/yaml/_type/float.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { StyleVariant, Type } from "../_type.ts";
+import type { ScalarType, StyleVariant } from "../_type.ts";
 import { isNegativeZero } from "../_utils.ts";
 
 const YAML_FLOAT_PATTERN = new RegExp(
@@ -114,7 +114,7 @@ function isFloat(object: unknown): boolean {
     (object % 1 !== 0 || isNegativeZero(object));
 }
 
-export const float: Type<number> = {
+export const float: ScalarType<number> = {
   tag: "tag:yaml.org,2002:float",
   construct: constructYamlFloat,
   defaultStyle: "lowercase",

--- a/yaml/_type/int.ts
+++ b/yaml/_type/int.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { Type } from "../_type.ts";
+import type { ScalarType } from "../_type.ts";
 import { isNegativeZero } from "../_utils.ts";
 
 function isCharCodeInRange(c: number, lower: number, upper: number): boolean {
@@ -156,7 +156,7 @@ function isInteger(object: unknown): boolean {
     !isNegativeZero(object);
 }
 
-export const int: Type<number> = {
+export const int: ScalarType<number> = {
   tag: "tag:yaml.org,2002:int",
   construct: constructYamlInteger,
   defaultStyle: "decimal",

--- a/yaml/_type/merge.ts
+++ b/yaml/_type/merge.ts
@@ -3,13 +3,13 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { Type } from "../_type.ts";
+import type { ScalarType } from "../_type.ts";
 
 function resolveYamlMerge(data: string): boolean {
   return data === "<<" || data === null;
 }
 
-export const merge: Type<unknown> = {
+export const merge: ScalarType<unknown> = {
   tag: "tag:yaml.org,2002:merge",
   kind: "scalar",
   resolve: resolveYamlMerge,

--- a/yaml/_type/nil.ts
+++ b/yaml/_type/nil.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { Type } from "../_type.ts";
+import type { ScalarType } from "../_type.ts";
 
 function resolveYamlNull(data: string): boolean {
   const max = data.length;
@@ -22,7 +22,7 @@ function isNull(object: unknown): object is null {
   return object === null;
 }
 
-export const nil: Type<null> = {
+export const nil: ScalarType<null> = {
   tag: "tag:yaml.org,2002:null",
   construct: constructYamlNull,
   defaultStyle: "lowercase",

--- a/yaml/_type/regexp.ts
+++ b/yaml/_type/regexp.ts
@@ -3,11 +3,11 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { Type } from "../_type.ts";
+import type { ScalarType } from "../_type.ts";
 
 const REGEXP = /^\/(?<regexp>[\s\S]+)\/(?<modifiers>[gismuy]*)$/;
 
-export const regexp: Type<RegExp> = {
+export const regexp: ScalarType<RegExp> = {
   tag: "tag:yaml.org,2002:js/regexp",
   kind: "scalar",
   // deno-lint-ignore no-explicit-any

--- a/yaml/_type/str.ts
+++ b/yaml/_type/str.ts
@@ -2,9 +2,9 @@
 // https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { Type } from "../_type.ts";
+import type { ScalarType } from "../_type.ts";
 
-export const str: Type<string> = {
+export const str: ScalarType<string> = {
   tag: "tag:yaml.org,2002:str",
   resolve() {
     return true;

--- a/yaml/_type/timestamp.ts
+++ b/yaml/_type/timestamp.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { Type } from "../_type.ts";
+import type { ScalarType } from "../_type.ts";
 
 const YAML_DATE_REGEXP = new RegExp(
   "^([0-9][0-9][0-9][0-9])" + // [1] year
@@ -87,7 +87,7 @@ function representYamlTimestamp(date: Date): string {
   return date.toISOString();
 }
 
-export const timestamp: Type<Date> = {
+export const timestamp: ScalarType<Date> = {
   tag: "tag:yaml.org,2002:timestamp",
   construct: constructYamlTimestamp,
   instanceOf: Date,

--- a/yaml/_type/undefined.ts
+++ b/yaml/_type/undefined.ts
@@ -3,9 +3,9 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import type { Type } from "../_type.ts";
+import type { ScalarType } from "../_type.ts";
 
-export const undefinedType: Type<undefined> = {
+export const undefinedType: ScalarType<undefined> = {
   tag: "tag:yaml.org,2002:js/undefined",
   kind: "scalar",
   resolve() {


### PR DESCRIPTION
We removed the check of non-scalar types in implicit list of schema in #5445

This PR checks that constraint by defining `ScalarType` type and only allowing it for `implicit` types of the schemas.