### PR TITLE
chore: release `fmt@1.0.0`

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -25,7 +25,7 @@
     "@std/dotenv": "jsr:@std/dotenv@^0.224.2",
     "@std/encoding": "jsr:@std/encoding@^1.0.1",
     "@std/expect": "jsr:@std/expect@^1.0.0-rc.2",
-    "@std/fmt": "jsr:@std/fmt@^1.0.0-rc.1",
+    "@std/fmt": "jsr:@std/fmt@^1.0.0",
     "@std/front-matter": "jsr:@std/front-matter@^1.0.0-rc.2",
     "@std/fs": "jsr:@std/fs@^1.0.0-rc.5",
     "@std/html": "jsr:@std/html@^1.0.0",

--- a/fmt/deno.json
+++ b/fmt/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/fmt",
-  "version": "1.0.0-rc.1",
+  "version": "1.0.0",
   "exports": {
     "./bytes": "./bytes.ts",
     "./colors": "./colors.ts",


### PR DESCRIPTION
To be merged July 31

The latest API docs: https://jsr.io/@std/fmt@1.0.0-rc.1/doc

Closes #5005
