### PR TITLE
refactor(yaml): improve `Type.predicate` behavior

### DIFF
--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -26,7 +26,7 @@ export interface Type<D = any> {
   tag: string;
   kind: KindType;
   instanceOf?: new (...args: unknown[]) => D;
-  predicate?: (data: Record<string, unknown>) => boolean;
+  predicate?: (data: unknown) => data is D;
   represent?: RepresentFn<D> | ArrayObject<RepresentFn<D>>;
   defaultStyle?: StyleVariant;
   loadKind?: KindType;

--- a/yaml/_type/float.ts
+++ b/yaml/_type/float.ts
@@ -109,7 +109,7 @@ function representYamlFloat(object: any, style?: StyleVariant): any {
   return SCIENTIFIC_WITHOUT_DOT.test(res) ? res.replace("e", ".e") : res;
 }
 
-function isFloat(object: unknown): boolean {
+function isFloat(object: unknown): object is number {
   return typeof object === "number" &&
     (object % 1 !== 0 || isNegativeZero(object));
 }

--- a/yaml/_type/int.ts
+++ b/yaml/_type/int.ts
@@ -151,7 +151,7 @@ function constructYamlInteger(data: string): number {
   return sign * parseInt(value, 10);
 }
 
-function isInteger(object: unknown): boolean {
+function isInteger(object: unknown): object is number {
   return typeof object === "number" && object % 1 === 0 &&
     !isNegativeZero(object);
 }


### PR DESCRIPTION
Adds type guards and makes the purpose of the method clearer.