### PR TITLE
refactor(yaml): remove `instanceOf` field of `Type`

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -773,11 +773,7 @@ export class DumperState {
     const typeList = explicit ? this.explicitTypes : this.implicitTypes;
 
     for (const type of typeList) {
-      if (
-        (type.instanceOf &&
-          (isObject(object) && object instanceof type.instanceOf)) ||
-        (type.predicate && type.predicate(object))
-      ) {
+      if (type.predicate?.(object)) {
         this.tag = explicit ? type.tag : "?";
 
         if (type.represent) {

--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -25,7 +25,6 @@ export type RepresentFn<D> = (data: D, style?: StyleVariant) => string;
 export interface Type<K extends KindType, D = any> {
   tag: string;
   kind: K;
-  instanceOf?: new (...args: unknown[]) => D;
   predicate?: (data: unknown) => data is D;
   represent?: RepresentFn<D> | ArrayObject<RepresentFn<D>>;
   defaultStyle?: StyleVariant;

--- a/yaml/_type/timestamp.ts
+++ b/yaml/_type/timestamp.ts
@@ -90,7 +90,9 @@ function representYamlTimestamp(date: Date): string {
 export const timestamp: Type<"scalar", Date> = {
   tag: "tag:yaml.org,2002:timestamp",
   construct: constructYamlTimestamp,
-  instanceOf: Date,
+  predicate(object): object is Date {
+    return object instanceof Date;
+  },
   kind: "scalar",
   represent: representYamlTimestamp,
   resolve: resolveYamlTimestamp,


### PR DESCRIPTION
This PR removes instanceOf field of `Type` type, which is only used by `timestamp` type and can be easily replaced by `object instanceof Date` check.

This simplifies the `detectType` logic in `yaml/_dumper.ts`