### PR TITLE
fix(text): bail early on timeout for `levenshteinDistance()` (#5465)

### DIFF
--- a/text/levenshtein_distance.ts
+++ b/text/levenshtein_distance.ts
@@ -2,6 +2,23 @@
 // This module is browser compatible.
 
 /**
+ * Options for Levenshtein distance calculation.
+ */
+export type LevenshteinOptions = {
+  /**
+   * The maximum calculation time to allow in milliseconds. If the calculation
+   * takes longer than this, the result will be approximated.
+   *
+   * @default 100
+   */
+  maxTimeElapsed: number;
+};
+
+const defaultOptions: LevenshteinOptions = {
+  maxTimeElapsed: 100,
+};
+
+/**
  * Calculates the
  * {@link https://en.wikipedia.org/wiki/Levenshtein_distance | Levenshtein distance}
  * between two strings.
@@ -15,9 +32,27 @@
  * ```
  * @param str1 The first string.
  * @param str2 The second string.
+ * @param options The options for the calculation.
  * @returns The Levenshtein distance between the two strings.
  */
-export function levenshteinDistance(str1: string, str2: string): number {
+export function levenshteinDistance(
+  str1: string,
+  str2: string,
+  options?: Partial<LevenshteinOptions>,
+): number {
+  if (str1 === str2) {
+    return 0;
+  }
+  if (!str1) {
+    return str2.length;
+  }
+  if (!str2) {
+    return str1.length;
+  }
+
+  const { maxTimeElapsed } = { ...defaultOptions, ...options };
+  const startTime = Date.now();
+
   if (str1.length > str2.length) {
     [str1, str2] = [str2, str1];
   }
@@ -45,6 +80,9 @@ export function levenshteinDistance(str1: string, str2: string): number {
       }
     }
     distances = tempDistances;
+    if (Date.now() - startTime > maxTimeElapsed) {
+      break;
+    }
   }
   return distances.at(-1)!;
 }

--- a/text/levenshtein_distance_test.ts
+++ b/text/levenshtein_distance_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert";
+import {
+  assertAlmostEquals,
+  assertEquals,
+  assertGreaterOrEqual,
+  assertLessOrEqual,
+} from "@std/assert";
 import { levenshteinDistance } from "./mod.ts";
 
 Deno.test("levenshteinDistance() handles basic cases", function () {
@@ -14,4 +19,52 @@ Deno.test("levenshteinDistance() handles same strings", function () {
     levenshteinDistance("aa", "aa"),
     0,
   );
+});
+
+Deno.test("levenshteinDistance() handles empty strings", () => {
+  assertEquals(levenshteinDistance("aa", ""), 2);
+  assertEquals(levenshteinDistance("", "aa"), 2);
+});
+
+Deno.test("levenshteinDistance() handles different-length strings", () => {
+  assertEquals(levenshteinDistance("aab", "cc"), 3);
+});
+
+Deno.test("levenshteinDistance() handles shifted strings", () => {
+  assertEquals(levenshteinDistance("rotation", "nrotatio"), 2);
+});
+
+Deno.test("levenshteinDistance() handles truncated strings", () => {
+  assertEquals(levenshteinDistance("truncation", "runcatio"), 2);
+});
+
+Deno.test("levenshteinDistance() returns early on timeout with an approximate result", async (t) => {
+  const maxTimeElapsed = 20;
+
+  for (
+    const [str1, str2] of [
+      ["a".repeat(1e5), "b".repeat(1e5)],
+      ["a".repeat(1e5), "b".repeat(2e5)],
+      ["a".repeat(2e5), "b".repeat(1e5)],
+      ["ab".repeat(1e5), "ba".repeat(1e5)],
+    ] as const
+  ) {
+    await t.step(
+      `${str1.slice(0, 4)}...${str1.length} / ${
+        str2.slice(0, 4)
+      }...${str2.length}`,
+      () => {
+        const startTime = Date.now();
+
+        const result = levenshteinDistance(str1, str2, { maxTimeElapsed });
+
+        const maxDistance = Math.max(str1.length, str2.length);
+
+        assertGreaterOrEqual(result, 0);
+        assertLessOrEqual(result, maxDistance);
+
+        assertAlmostEquals(Date.now() - startTime, maxTimeElapsed, 100);
+      },
+    );
+  }
 });


### PR DESCRIPTION
Fixes #5465.

This commit adds a `maxTimeElapsed` option to the `levenshteinDistance` function. If the calculation takes longer than this, the result will be approximated. The default is 100ms.