### PR TITLE
BREAKING(semver): replace `prerelease` and `buildmetadata` arguments with options object

### DIFF
--- a/semver/increment.ts
+++ b/semver/increment.ts
@@ -35,6 +35,14 @@ function bumpPrerelease(
   return values;
 }
 
+/** Options for {@linkcode increment}. */
+export interface IncrementOptions {
+  /** The pre-release metadata of the new version. */
+  prerelease?: string;
+  /** The build metadata of the new version. */
+  build?: string;
+}
+
 /**
  * Returns the new SemVer resulting from an increment by release type.
  *
@@ -73,18 +81,16 @@ function bumpPrerelease(
  *
  * @param version The version to increment
  * @param release The type of increment to perform
- * @param prerelease The pre-release metadata of the new version
- * @param buildmetadata The build metadata of the new version
+ * @param options Additional options
  * @returns The new version
  */
 export function increment(
   version: SemVer,
   release: ReleaseType,
-  prerelease?: string,
-  buildmetadata?: string,
+  options?: IncrementOptions,
 ): SemVer {
-  const build = buildmetadata !== undefined
-    ? parseBuild(buildmetadata)
+  const build = options?.build !== undefined
+    ? parseBuild(options?.build)
     : version.build;
 
   switch (release) {
@@ -93,7 +99,7 @@ export function increment(
         major: version.major + 1,
         minor: 0,
         patch: 0,
-        prerelease: bumpPrerelease(version.prerelease, prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
         build,
       };
     case "preminor":
@@ -101,7 +107,7 @@ export function increment(
         major: version.major,
         minor: version.minor + 1,
         patch: 0,
-        prerelease: bumpPrerelease(version.prerelease, prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
         build,
       };
     case "prepatch":
@@ -109,7 +115,7 @@ export function increment(
         major: version.major,
         minor: version.minor,
         patch: version.patch + 1,
-        prerelease: bumpPrerelease(version.prerelease, prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
         build,
       };
     case "prerelease": {
@@ -120,7 +126,7 @@ export function increment(
         major: version.major,
         minor: version.minor,
         patch,
-        prerelease: bumpPrerelease(version.prerelease, prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
         build,
       };
     }
@@ -180,7 +186,7 @@ export function increment(
         major: version.major,
         minor: version.minor,
         patch: version.patch,
-        prerelease: bumpPrerelease(version.prerelease, prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
         build,
       };
     }

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -963,11 +963,11 @@ Deno.test("increment()", async (t) => {
     ],
   ];
 
-  for (const [version, op, identifier, metadata, expected] of versions) {
+  for (const [version, op, prerelease, build, expected] of versions) {
     await t.step({
       name: `${op} ${format(version)}`,
       fn: () => {
-        const actual = increment(version, op, identifier, metadata);
+        const actual = increment(version, op, { prerelease, build });
         assertEquals(format(actual), expected);
       },
     });

--- a/semver/mod.ts
+++ b/semver/mod.ts
@@ -130,7 +130,7 @@
  * import { increment, parse } from "@std/semver";
  * import { assertEquals } from "@std/assert";
  *
- * assertEquals(increment(parse("1.2.3"), "prerelease", "alpha"), parse("1.2.4-alpha.0"));
+ * assertEquals(increment(parse("1.2.3"), "prerelease", { prerelease: "alpha" }), parse("1.2.4-alpha.0"));
  * ```
  *
  * ### Build Metadata


### PR DESCRIPTION
### What's changed

The `prerelease` and `buildmetadata` arguments for [`increment()`](https://jsr.io/@std/semver/doc/increment/~/increment) into a new optional `IncrementOptions` interface.

### Motivation

This change was made to ensure the symbol adheres to the [Deno Style Guide](https://docs.deno.com/runtime/manual/references/contributing/style_guide/#exported-functions%3A-max-2-args%2C-put-the-rest-into-an-options-object.) which states that optional arguments should go into an options object.

### Migration

To migrate, use the options argument, instead of the positional arguments in `increment()`.

```diff
import { increment, parse } from "./semver/mod.ts";

- increment(parse("1.2.3"), "prerelease", "alpha", "0");
+ increment(parse("1.2.3"), "prerelease", { prerelease: "alpha", build: "0" });
```

### Related

Closes #4420