### PR TITLE
fix(media-types): return `video/mp4` for `.mp4` extension

### DIFF
--- a/media_types/_db.ts
+++ b/media_types/_db.ts
@@ -32,6 +32,7 @@ for (const type of Object.keys(db) as KeyOfDb[]) {
 
       if (
         current !== "application/octet-stream" &&
+        current !== "application/mp4" &&
         (from > to ||
           // @ts-ignore work around https://github.com/denoland/dnt/issues/148
           (from === to && current.startsWith("application/")))

--- a/media_types/type_by_extension_test.ts
+++ b/media_types/type_by_extension_test.ts
@@ -16,6 +16,7 @@ Deno.test({
       ["file.json", undefined],
       ["foo", undefined],
       [".foo", undefined],
+      [".mp4", "video/mp4"],
     ] as const;
     for (const [fixture, expected] of fixtures) {
       assertEquals(typeByExtension(fixture), expected);


### PR DESCRIPTION
closes #5433