### PR TITLE
chore: remove requirement for `@example`s in constructors

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -409,7 +409,6 @@ function assertConstructorDocs(
       assertHasParamTag(constructor, param.left.name);
     }
   }
-  assertHasExampleTag(constructor);
 }
 
 /**


### PR DESCRIPTION
These aren't needed as JSR doesn't have a dedicated page for class constructors. Also, VSCode merges the documentation for classes and their constructors. In other words, class examples are shown, even if there are no constructor examples, when one hovers over a class.

I'll remove the redundant examples in follow-up PRs.