### PR TITLE
docs(cli): fix options arguments display

### DIFF
--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -496,17 +496,7 @@ export function parseArgs<
   TAliasNames extends string = string,
 >(
   args: string[],
-  {
-    "--": doubleDash = false,
-    alias = {} as NonNullable<TAliases>,
-    boolean = false,
-    default: defaults = {} as TDefaults & Defaults<TBooleans, TStrings>,
-    stopEarly = false,
-    string = [],
-    collect = [],
-    negatable = [],
-    unknown: unknownFn = (i: string): unknown => i,
-  }: ParseOptions<
+  options: ParseOptions<
     TBooleans,
     TStrings,
     TCollectable,
@@ -516,6 +506,17 @@ export function parseArgs<
     TDoubleDash
   > = {},
 ): Args<TArgs, TDoubleDash> {
+  const {
+    "--": doubleDash = false,
+    alias = {} as NonNullable<TAliases>,
+    boolean = false,
+    default: defaults = {} as TDefaults & Defaults<TBooleans, TStrings>,
+    stopEarly = false,
+    string = [],
+    collect = [],
+    negatable = [],
+    unknown: unknownFn = (i: string): unknown => i,
+  } = options;
   const aliasMap: Map<string, Set<string>> = new Map();
   const booleanSet = new Set<string>();
   const stringSet = new Set<string>();

--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -449,6 +449,7 @@ const FLAG_REGEXP =
  * or `options.boolean` is set for that argument name.
  *
  * @param args An array of command line arguments.
+ * @param options Options for the parse function.
  *
  * @typeParam TArgs Type of result.
  * @typeParam TDoubleDash Used by `TArgs` for the result.
@@ -496,7 +497,7 @@ export function parseArgs<
   TAliasNames extends string = string,
 >(
   args: string[],
-  options: ParseOptions<
+  options?: ParseOptions<
     TBooleans,
     TStrings,
     TCollectable,
@@ -504,7 +505,7 @@ export function parseArgs<
     TDefaults,
     TAliases,
     TDoubleDash
-  > = {},
+  >,
 ): Args<TArgs, TDoubleDash> {
   const {
     "--": doubleDash = false,
@@ -516,7 +517,7 @@ export function parseArgs<
     collect = [],
     negatable = [],
     unknown: unknownFn = (i: string): unknown => i,
-  } = options;
+  } = options ?? {};
   const aliasMap: Map<string, Set<string>> = new Map();
   const booleanSet = new Set<string>();
   const stringSet = new Set<string>();

--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -29,6 +29,7 @@ export type PromptSecretOptions = {
  * Use an empty `mask` if you don't want to show any character.
  *
  * @param message The prompt message to show to the user.
+ * @param options The options for the prompt.
  * @returns The string that was entered or `null` if stdin is not a TTY.
  *
  * @example Usage
@@ -43,8 +44,10 @@ export type PromptSecretOptions = {
  */
 export function promptSecret(
   message = "Secret",
-  { mask = "*", clear }: PromptSecretOptions = {},
+  options?: PromptSecretOptions,
 ): string | null {
+  const { mask = "*", clear } = options ?? {};
+
   if (!input.isTerminal()) {
     return null;
   }

--- a/cli/spinner.ts
+++ b/cli/spinner.ts
@@ -136,6 +136,8 @@ export class Spinner {
   /**
    * Creates a new spinner.
    *
+   * @param options Options for the spinner.
+   *
    * @example Usage
    * ```ts no-assert
    * import { Spinner } from "@std/cli/spinner";
@@ -144,12 +146,13 @@ export class Spinner {
    * spinner.stop();
    * ```
    */
-  constructor({
-    spinner = DEFAULT_SPINNER,
-    message = "",
-    interval = DEFAULT_INTERVAL,
-    color,
-  }: SpinnerOptions = {}) {
+  constructor(options?: SpinnerOptions) {
+    const {
+      spinner = DEFAULT_SPINNER,
+      message = "",
+      interval = DEFAULT_INTERVAL,
+      color,
+    } = options ?? {};
     this.#spinner = spinner;
     this.message = message;
     this.#interval = interval;


### PR DESCRIPTION
This ensures that the argument is displayed as `options` instead of [`unnamed 1`](https://jsr.io/@std/cli@1.0.0-rc.5/doc/~/parseArgs) in documentation.