### PR TITLE
docs(fs): fix options argument display

### DIFF
--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -268,7 +268,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  */
 export async function* expandGlob(
   glob: string | URL,
-  options: ExpandGlobOptions = {},
+  options?: ExpandGlobOptions,
 ): AsyncIterableIterator<WalkEntry> {
   let {
     root,
@@ -279,7 +279,7 @@ export async function* expandGlob(
     caseInsensitive,
     followSymlinks,
     canonicalize,
-  } = options;
+  } = options ?? {};
 
   const {
     segments,
@@ -425,7 +425,9 @@ export async function* expandGlob(
  */
 export function* expandGlobSync(
   glob: string | URL,
-  {
+  options?: ExpandGlobOptions,
+): IterableIterator<WalkEntry> {
+  let {
     root,
     exclude = [],
     includeDirs = true,
@@ -434,8 +436,8 @@ export function* expandGlobSync(
     caseInsensitive,
     followSymlinks,
     canonicalize,
-  }: ExpandGlobOptions = {},
-): IterableIterator<WalkEntry> {
+  } = options ?? {};
+
   const {
     segments,
     isAbsolute: isGlobAbsolute,

--- a/fs/move.ts
+++ b/fs/move.ts
@@ -93,8 +93,10 @@ export interface MoveOptions {
 export async function move(
   src: string | URL,
   dest: string | URL,
-  { overwrite = false }: MoveOptions = {},
+  options?: MoveOptions,
 ): Promise<void> {
+  const { overwrite = false } = options ?? {};
+
   const srcStat = await Deno.stat(src);
 
   if (
@@ -165,8 +167,10 @@ export async function move(
 export function moveSync(
   src: string | URL,
   dest: string | URL,
-  { overwrite = false }: MoveOptions = {},
+  options?: MoveOptions,
 ): void {
+  const { overwrite = false } = options ?? {};
+
   const srcStat = Deno.statSync(src);
 
   if (

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -512,7 +512,7 @@ export type { WalkEntry };
  */
 export async function* walk(
   root: string | URL,
-  options: WalkOptions = {},
+  options?: WalkOptions,
 ): AsyncIterableIterator<WalkEntry> {
   let {
     maxDepth = Infinity,
@@ -524,7 +524,7 @@ export async function* walk(
     exts = undefined,
     match = undefined,
     skip = undefined,
-  } = options;
+  } = options ?? {};
 
   if (maxDepth < 0) {
     return;
@@ -938,7 +938,9 @@ export async function* walk(
  */
 export function* walkSync(
   root: string | URL,
-  {
+  options?: WalkOptions,
+): IterableIterator<WalkEntry> {
+  let {
     maxDepth = Infinity,
     includeFiles = true,
     includeDirs = true,
@@ -948,8 +950,8 @@ export function* walkSync(
     exts = undefined,
     match = undefined,
     skip = undefined,
-  }: WalkOptions = {},
-): IterableIterator<WalkEntry> {
+  } = options ?? {};
+
   root = toPathString(root);
   if (exts) {
     exts = exts.map((ext) => ext.startsWith(".") ? ext : `.${ext}`);


### PR DESCRIPTION
This ensures that the argument is displayed as `options` instead of `unnamed 1` in documentation.