### PR TITLE
docs(http): fix options argument display

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -165,6 +165,7 @@ export interface ServeFileOptions {
  *
  * @param req The server request context used to cleanup the file handle.
  * @param filePath Path of the file to serve.
+ * @param options Additional options.
  * @returns A response for the request.
  */
 export async function serveFile(

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -170,8 +170,10 @@ export interface ServeFileOptions {
 export async function serveFile(
   req: Request,
   filePath: string,
-  { etagAlgorithm: algorithm, fileInfo }: ServeFileOptions = {},
+  options?: ServeFileOptions,
 ): Promise<Response> {
+  let { etagAlgorithm: algorithm, fileInfo } = options ?? {};
+
   try {
     fileInfo ??= await Deno.stat(filePath);
   } catch (error) {


### PR DESCRIPTION
This ensures that the argument is displayed as `options` instead of `unnamed 1` in documentation.