### PR TITLE
docs(http): fix options argument display

### DIFF
--- a/io/to_readable_stream.ts
+++ b/io/to_readable_stream.ts
@@ -40,12 +40,14 @@ export interface ToReadableStreamOptions {
  */
 export function toReadableStream(
   reader: Reader | (Reader & Closer),
-  {
+  options?: ToReadableStreamOptions,
+): ReadableStream<Uint8Array> {
+  const {
     autoClose = true,
     chunkSize = DEFAULT_CHUNK_SIZE,
     strategy,
-  }: ToReadableStreamOptions = {},
-): ReadableStream<Uint8Array> {
+  } = options ?? {};
+
   return new ReadableStream({
     async pull(controller) {
       const chunk = new Uint8Array(chunkSize);

--- a/io/to_writable_stream.ts
+++ b/io/to_writable_stream.ts
@@ -31,8 +31,10 @@ export interface toWritableStreamOptions {
  */
 export function toWritableStream(
   writer: Writer,
-  { autoClose = true }: toWritableStreamOptions = {},
+  options?: toWritableStreamOptions,
 ): WritableStream<Uint8Array> {
+  const { autoClose = true } = options ?? {};
+
   return new WritableStream({
     async write(chunk, controller) {
       try {


### PR DESCRIPTION
This ensures that the argument is displayed as `options` instead of `unnamed 1` in documentation.