### PR TITLE
docs(json): fix options argument display

### DIFF
--- a/json/stringify_stream.ts
+++ b/json/stringify_stream.ts
@@ -92,6 +92,8 @@ export class JsonStringifyStream extends TransformStream<unknown, string> {
   /**
    * Constructs new instance.
    *
+   * @param options Options for the stream.
+   *
    * @example Usage
    * ```ts
    * import { JsonStringifyStream } from "@std/json/stringify-stream";

--- a/json/stringify_stream.ts
+++ b/json/stringify_stream.ts
@@ -106,10 +106,8 @@ export class JsonStringifyStream extends TransformStream<unknown, string> {
    * ]);
    * ```
    */
-  constructor({
-    prefix = "",
-    suffix = "\n",
-  }: StringifyStreamOptions = {}) {
+  constructor(options?: StringifyStreamOptions) {
+    const { prefix = "", suffix = "\n" } = options ?? {};
     super(
       {
         transform(chunk, controller) {


### PR DESCRIPTION
This ensures that the argument is displayed as `options` instead of `unnamed 1` in documentation.