### PR TITLE
docs(fs): fix options argument display

### DIFF
--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -23,8 +23,9 @@ export class BaseHandler {
 
   constructor(
     levelName: LevelName,
-    { formatter = DEFAULT_FORMATTER }: BaseHandlerOptions = {},
+    options?: BaseHandlerOptions,
   ) {
+    const { formatter = DEFAULT_FORMATTER } = options ?? {};
     this.#levelName = levelName;
     this.#level = getLevelByName(levelName);
     this.formatter = formatter;


### PR DESCRIPTION
This ensures that the argument is displayed as `options` instead of `unnamed 1` in documentation.