### PR TITLE
test(yaml): add check of merge of list of mapping

### DIFF
--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -752,6 +752,12 @@ c: 3`),
     { a: 1, b: 2, c: 3 },
   );
 
+  assertEquals(
+    parse(`<<: [{ a: 1 }, { b: 2 }]
+c: 1`),
+    { a: 1, b: 2, c: 1 },
+  );
+
   assertThrows(
     () =>
       // number can't be used as merge value


### PR DESCRIPTION
This PR adds the check of `merge` of list of mapping. (Reduces 8 missed lines in `yaml/_loader.ts` coverage report)