### PR TITLE
fix(assert): `assertObjectMatch` doesn't print whole object

### DIFF
--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -32,75 +32,6 @@ export function assertObjectMatch(
   expected: Record<PropertyKey, unknown>,
   msg?: string,
 ): void {
-  type loose = Record<PropertyKey, unknown>;
-
-  function filter(a: loose, b: loose) {
-    const seen = new WeakMap();
-    return fn(a, b);
-
-    function fn(a: loose, b: loose): loose {
-      // Prevent infinite loop with circular references with same filter
-      if ((seen.has(a)) && (seen.get(a) === b)) {
-        return a;
-      }
-      try {
-        seen.set(a, b);
-      } catch (err) {
-        if (err instanceof TypeError) {
-          throw new TypeError(
-            `Cannot assertObjectMatch ${
-              a === null ? null : `type ${typeof a}`
-            }`,
-          );
-        }
-      }
-      // Filter keys and symbols which are present in both actual and expected
-      const filtered = {} as loose;
-      const entries = [
-        ...Object.getOwnPropertyNames(a),
-        ...Object.getOwnPropertySymbols(a),
-      ]
-        .filter((key) => key in b)
-        .map((key) => [key, a[key as string]]) as Array<[string, unknown]>;
-      for (const [key, value] of entries) {
-        // On array references, build a filtered array and filter nested objects inside
-        if (Array.isArray(value)) {
-          const subset = (b as loose)[key];
-          if (Array.isArray(subset)) {
-            filtered[key] = fn({ ...value }, { ...subset });
-            continue;
-          }
-        } // On regexp references, keep value as it to avoid loosing pattern and flags
-        else if (value instanceof RegExp) {
-          filtered[key] = value;
-          continue;
-        } // On nested objects references, build a filtered object recursively
-        else if (typeof value === "object" && value !== null) {
-          const subset = (b as loose)[key];
-          if ((typeof subset === "object") && subset) {
-            // When both operands are maps, build a filtered map with common keys and filter nested objects inside
-            if ((value instanceof Map) && (subset instanceof Map)) {
-              filtered[key] = new Map(
-                [...value].filter(([k]) => subset.has(k)).map((
-                  [k, v],
-                ) => [k, typeof v === "object" ? fn(v, subset.get(k)) : v]),
-              );
-              continue;
-            }
-            // When both operands are set, build a filtered set with common values
-            if ((value instanceof Set) && (subset instanceof Set)) {
-              filtered[key] = new Set([...value].filter((v) => subset.has(v)));
-              continue;
-            }
-            filtered[key] = fn(value as loose, subset as loose);
-            continue;
-          }
-        }
-        filtered[key] = value;
-      }
-      return filtered;
-    }
-  }
   return assertEquals(
     // get the intersection of "actual" and "expected"
     // side effect: all the instances' constructor field is "Object" now.
@@ -110,4 +41,98 @@ export function assertObjectMatch(
     filter(expected, expected),
     msg,
   );
+}
+
+type loose = Record<PropertyKey, unknown>;
+
+function filter(a: loose, b: loose) {
+  const seen = new WeakMap();
+  return filterObject(a, b);
+
+  function isObject(val: unknown): boolean {
+    return typeof val === "object" && val !== null;
+  }
+
+  function filterObject(a: loose, b: loose): loose {
+    // Prevent infinite loop with circular references with same filter
+    if ((seen.has(a)) && (seen.get(a) === b)) {
+      return a;
+    }
+
+    try {
+      seen.set(a, b);
+    } catch (err) {
+      if (err instanceof TypeError) {
+        throw new TypeError(
+          `Cannot assertObjectMatch ${a === null ? null : `type ${typeof a}`}`,
+        );
+      }
+    }
+
+    // Filter keys and symbols which are present in both actual and expected
+    const filtered = {} as loose;
+    const keysA = Reflect.ownKeys(a);
+    const keysB = Reflect.ownKeys(b);
+    const entries = keysA.filter((key) => keysB.includes(key))
+      .map((key) => [key, a[key as string]]) as Array<[string, unknown]>;
+
+    if (keysA.length && keysB.length && !entries.length) {
+      // If both objects are not empty but don't have the same keys or symbols,
+      // returns the entries in object a.
+      for (const key of keysA) {
+        filtered[key] = a[key];
+      }
+
+      return filtered;
+    }
+
+    for (const [key, value] of entries) {
+      // On regexp references, keep value as it to avoid loosing pattern and flags
+      if (value instanceof RegExp) {
+        filtered[key] = value;
+        continue;
+      }
+
+      const subset = (b as loose)[key];
+
+      // On array references, build a filtered array and filter nested objects inside
+      if (Array.isArray(value) && Array.isArray(subset)) {
+        filtered[key] = filterObject({ ...value }, { ...subset });
+        continue;
+      }
+
+      // On nested objects references, build a filtered object recursively
+      if (isObject(value) && isObject(subset)) {
+        // When both operands are maps, build a filtered map with common keys and filter nested objects inside
+        if ((value instanceof Map) && (subset instanceof Map)) {
+          filtered[key] = new Map(
+            [...value].filter(([k]) => subset.has(k)).map(
+              ([k, v]) => {
+                const v2 = subset.get(k);
+                if (isObject(v) && isObject(v2)) {
+                  return [k, filterObject(v as loose, v2 as loose)];
+                }
+
+                return [k, v];
+              },
+            ),
+          );
+          continue;
+        }
+
+        // When both operands are set, build a filtered set with common values
+        if ((value instanceof Set) && (subset instanceof Set)) {
+          filtered[key] = value.intersection(subset);
+          continue;
+        }
+
+        filtered[key] = filterObject(value as loose, subset as loose);
+        continue;
+      }
+
+      filtered[key] = value;
+    }
+
+    return filtered;
+  }
 }

--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -45,13 +45,13 @@ export function assertObjectMatch(
 
 type loose = Record<PropertyKey, unknown>;
 
+function isObject(val: unknown): boolean {
+  return typeof val === "object" && val !== null;
+}
+
 function filter(a: loose, b: loose) {
   const seen = new WeakMap();
   return filterObject(a, b);
-
-  function isObject(val: unknown): boolean {
-    return typeof val === "object" && val !== null;
-  }
 
   function filterObject(a: loose, b: loose): loose {
     // Prevent infinite loop with circular references with same filter

--- a/assert/object_match_test.ts
+++ b/assert/object_match_test.ts
@@ -293,6 +293,9 @@ Deno.test("assertObjectMatch() throws assertion error when in the first argument
     () => assertObjectMatch({ foo: undefined, bar: null }, { foo: null }),
     AssertionError,
   );
+  assertThrows(
+    () => assertObjectMatch(n, { baz: new Map([["b", null]]) }),
+  );
 });
 
 Deno.test("assertObjectMatch() throws readable type error for non mappable primitive types", () => {
@@ -317,5 +320,45 @@ Deno.test("assertObjectMatch() throws readable type error for non mappable primi
     () => assertObjectMatch("string", "string"),
     TypeError,
     "assertObjectMatch",
+  );
+});
+
+Deno.test("assertObjectMatch() prints inputs correctly", () => {
+  const x = {
+    command: "error",
+    payload: {
+      message: "NodeNotFound",
+    },
+    protocol: "graph",
+  };
+
+  const y = {
+    protocol: "graph",
+    command: "addgroup",
+    payload: {
+      graph: "foo",
+      metadata: {
+        description: "foo",
+      },
+      name: "somegroup",
+    },
+  };
+
+  assertThrows(
+    () => assertObjectMatch(x, y),
+    AssertionError,
+    `    {
++     command: "addgroup",
+-     command: "error",
+      payload: {
++       graph: "foo",
++       metadata: {
++         description: "foo",
++       },
++       name: "somegroup",
+-       message: "NodeNotFound",
+      },
+      protocol: "graph",
+    }`,
   );
 });


### PR DESCRIPTION
Separated from #5408
Fix: #3771

When filtering two objects, the `fn()` function returns an empty object if they don't have the same keys or symbols. This PR adds the logic so that it returns the entries of the first object in this case. (also rename `fn` to 	`filterObject`)