### PR TITLE
fix(testing): FakeTime fakes `AbortSignal.timeout`

### DIFF
--- a/testing/_time.ts
+++ b/testing/_time.ts
@@ -7,5 +7,5 @@ export const _internals = {
   clearTimeout,
   setInterval,
   clearInterval,
-  "AbortSignal_timeout": AbortSignal.timeout,
+  AbortSignalTimeout: AbortSignal.timeout,
 };

--- a/testing/_time.ts
+++ b/testing/_time.ts
@@ -7,4 +7,5 @@ export const _internals = {
   clearTimeout,
   setInterval,
   clearInterval,
+  "AbortSignal_timeout": AbortSignal.timeout,
 };

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -220,7 +220,7 @@ function restoreGlobals() {
   globalThis.clearTimeout = _internals.clearTimeout;
   globalThis.setInterval = _internals.setInterval;
   globalThis.clearInterval = _internals.clearInterval;
-  AbortSignal.timeout = _internals.AbortSignal_timeout;
+  AbortSignal.timeout = _internals.AbortSignalTimeout;
 }
 
 function* timerIdGen() {

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -197,12 +197,21 @@ function setTimer(
   return id;
 }
 
+function fakeAbortSignalTimeout(delay: number): AbortSignal {
+  const aborter = new AbortController();
+  fakeSetTimeout(() => {
+    aborter.abort(new DOMException("Signal timed out.", "TimeoutError"));
+  }, delay);
+  return aborter.signal;
+}
+
 function overrideGlobals() {
   globalThis.Date = FakeDate;
   globalThis.setTimeout = fakeSetTimeout;
   globalThis.clearTimeout = fakeClearTimeout;
   globalThis.setInterval = fakeSetInterval;
   globalThis.clearInterval = fakeClearInterval;
+  AbortSignal.timeout = fakeAbortSignalTimeout;
 }
 
 function restoreGlobals() {
@@ -211,6 +220,7 @@ function restoreGlobals() {
   globalThis.clearTimeout = _internals.clearTimeout;
   globalThis.setInterval = _internals.setInterval;
   globalThis.clearInterval = _internals.clearInterval;
+  AbortSignal.timeout = _internals.AbortSignal_timeout;
 }
 
 function* timerIdGen() {

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -724,15 +724,15 @@ Deno.test("time.start returns the started time of the fake time", () => {
 });
 
 Deno.test("FakeTime doesn't affect AbortSignal.timeout unchanged if uninitialized", () => {
-  assertStrictEquals(AbortSignal.timeout, _internals.AbortSignal_timeout);
+  assertStrictEquals(AbortSignal.timeout, _internals.AbortSignalTimeout);
 });
 
 Deno.test("FakeTime fakes AbortSignal.timeout", () => {
   {
     using _time = new FakeTime(9001);
-    assertNotEquals(AbortSignal.timeout, _internals.AbortSignal_timeout);
+    assertNotEquals(AbortSignal.timeout, _internals.AbortSignalTimeout);
   }
-  assertStrictEquals(AbortSignal.timeout, _internals.AbortSignal_timeout);
+  assertStrictEquals(AbortSignal.timeout, _internals.AbortSignalTimeout);
 });
 
 Deno.test("FakeTime controls AbortSignal.timeout", () => {


### PR DESCRIPTION
[`async/deadline` v1.0.0](https://github.com/denoland/std/blob/release-2024.07.19/async/deadline.ts) uses `AbortSignal.timeout`, so `FakeTime` cannot be used for it.

Fixes #5499.