### PR TITLE
test(yaml): check the use of reserved characters

### DIFF
--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -1014,3 +1014,16 @@ name: Jane Doe`,
     { name: "Jane Doe", age: 30 },
   );
 });
+
+Deno.test("parse() throws at reseverd characters '`' and '@'", () => {
+  assertThrows(
+    () => parse("`"),
+    SyntaxError,
+    "end of the stream or a document separator is expected at line 1, column 1:\n    `\n    ^",
+  );
+  assertThrows(
+    () => parse("@"),
+    SyntaxError,
+    "end of the stream or a document separator is expected at line 1, column 1:\n    @\n    ^",
+  );
+});


### PR DESCRIPTION
This PR adds test cases which check that `parse` throws with reserved characters '@' and '`'.

This improves the line coverage of `yaml/_loader.ts`, reducing 17 missed lines.