### PR TITLE
test(yaml): check stringify behavior when skipInvalid specified

### DIFF
--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -184,6 +184,25 @@ Deno.test({
 });
 
 Deno.test({
+  name:
+    "stringify() ignores `!!js/*` yaml types when skipInvalid option is true",
+  fn() {
+    assertEquals(
+      stringify({ undefined: undefined }, { skipInvalid: true }),
+      "{}\n",
+    );
+    assertEquals(
+      stringify({
+        foobar() {
+          return "hello world!";
+        },
+      }, { skipInvalid: true }),
+      "{}\n",
+    );
+  },
+});
+
+Deno.test({
   name: "stringify() handles float types",
   fn() {
     const floats = [


### PR DESCRIPTION
This PR adds test cases which check the behavior of `stringify` when `skipInvalid: true` specified