### PR TITLE
test(yaml): test sortKeys option behavior

### DIFF
--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -5,6 +5,7 @@
 
 import { assertEquals, assertThrows } from "@std/assert";
 import { stringify } from "./stringify.ts";
+import { compare, parse } from "@std/semver";
 
 Deno.test({
   name: "stringify()",
@@ -441,4 +442,43 @@ skills:
 
   const actual = stringify(object);
   assertEquals(actual.trim(), expected.trim());
+});
+
+Deno.test("stringify() changes the key order when the sortKeys option is specified", () => {
+  const object = {
+    "1.0.0": null,
+    "0.0.0-0": null,
+    "0.0.0": null,
+    "1.0.2": null,
+    "1.0.10": null,
+  };
+  assertEquals(
+    stringify(object),
+    `1.0.0: null
+0.0.0-0: null
+0.0.0: null
+1.0.2: null
+1.0.10: null
+`,
+  );
+  // When sortKeys is true, keys are sorted in ASCII char order
+  assertEquals(
+    stringify(object, { sortKeys: true }),
+    `0.0.0: null
+0.0.0-0: null
+1.0.0: null
+1.0.10: null
+1.0.2: null
+`,
+  );
+  // When sortKeys is a function, keys are sorted by the return value of the function
+  assertEquals(
+    stringify(object, { sortKeys: (a, b) => compare(parse(a), parse(b)) }),
+    `0.0.0-0: null
+0.0.0: null
+1.0.0: null
+1.0.2: null
+1.0.10: null
+`,
+  );
 });


### PR DESCRIPTION
This PR adds test cases that check the behavior of `sortKeys` option of `stringify`.