### PR TITLE
docs(path): cleanup `@std/path/posix` and `@std/path/windows` module documentation

### DIFF
--- a/path/posix/mod.ts
+++ b/path/posix/mod.ts
@@ -4,14 +4,10 @@
 // This module is browser compatible.
 
 /**
- * Utilities for working with OS-specific file paths.
- *
- * Codes in the examples uses POSIX path but it automatically use Windows path
- * on Windows. Use methods under `posix` or `win32` object instead to handle non
- * platform specific path like:
+ * Utilities for working with POSIX-formatted paths.
  *
  * ```ts
- * import { fromFileUrl } from "@std/path/posix";
+ * import { fromFileUrl } from "@std/path/posix/from-file-url";
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals(fromFileUrl("file:///home/foo"), "/home/foo");

--- a/path/windows/mod.ts
+++ b/path/windows/mod.ts
@@ -7,7 +7,7 @@
  * Utilities for working with Windows-specific paths.
  *
  * ```ts
- * import { fromFileUrl } from "@std/path/windows";
+ * import { fromFileUrl } from "@std/path/windows/from-file-url";
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals(fromFileUrl("file:///home/foo"), "\\home\\foo");

--- a/path/windows/mod.ts
+++ b/path/windows/mod.ts
@@ -4,11 +4,7 @@
 // This module is browser compatible.
 
 /**
- * Utilities for working with OS-specific file paths.
- *
- * Codes in the examples uses POSIX path but it automatically use Windows path
- * on Windows. Use methods under `posix` or `win32` object instead to handle non
- * platform specific path like:
+ * Utilities for working with Windows-specific paths.
  *
  * ```ts
  * import { fromFileUrl } from "@std/path/windows";


### PR DESCRIPTION
This is clearer and more accurate.