### PR TITLE
docs(yaml): document different schemas

### DIFF
--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -24,6 +24,26 @@ import {
   undefinedType,
 } from "./_type/mod.ts";
 
+/**
+ * Name of the schema to use.
+ *
+ * Options include:
+ * - `failsafe`: supports generic mappings, generic sequences and generic
+ * strings.
+ * - `json`: extends `failsafe` schema by also supporting nulls, booleans,
+ * integers and floats.
+ * - `core`: extends `json` schema by also supporting tag resolution.
+ * - `default`: extends `core` schema by also supporting binary, omap, pairs and
+ * set types.
+ * - `extended`: extends `default` schema by also supporting regular
+ * expressions and undefined values.
+ *
+ * See
+ * {@link https://yaml.org/spec/1.2.2/#chapter-10-recommended-schemas | YAML 1.2 spec}
+ * for more details on the `failsafe`, `json` and `core` schemas.
+ */
+export type SchemaType = "core" | "default" | "failsafe" | "json" | "extended";
+
 // deno-lint-ignore no-explicit-any
 function compileList<K extends KindType, D = any>(
   schema: Schema,

--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -27,6 +27,11 @@ import {
 /**
  * Name of the schema to use.
  *
+ * > ![NOTE]
+ * > It is recommended to use the schema that is most appropriate for your use
+ * > case. Doing so will avoid any unnecessary processing and benefit
+ * > performance.
+ *
  * Options include:
  * - `failsafe`: supports generic mappings, generic sequences and generic
  * strings.
@@ -42,7 +47,7 @@ import {
  * {@link https://yaml.org/spec/1.2.2/#chapter-10-recommended-schemas | YAML 1.2 spec}
  * for more details on the `failsafe`, `json` and `core` schemas.
  */
-export type SchemaType = "core" | "default" | "failsafe" | "json" | "extended";
+export type SchemaType = "failsafe" | "json" | "core" | "default" | "extended";
 
 // deno-lint-ignore no-explicit-any
 function compileList<K extends KindType, D = any>(

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -5,21 +5,18 @@
 // This module is browser compatible.
 
 import { load, loadDocuments } from "./_loader.ts";
-import { SCHEMA_MAP } from "./_schema.ts";
+import { SCHEMA_MAP, type SchemaType } from "./_schema.ts";
+
+export type { SchemaType };
 
 /** Options for {@linkcode parse}. */
 export interface ParseOptions {
   /**
-   * Name of the schema to use. Options includes:
-   * - `extended` (extends `default` schema)
-   * - `default` (extends `core` schema)
-   * - {@linkcode https://yaml.org/spec/1.2.2/#103-core-schema | core} (extends `json` schema)
-   * - {@linkcode https://yaml.org/spec/1.2.2/#102-json-schema | json} (extends `failsafe` schema)
-   * - {@linkcode https://yaml.org/spec/1.2.2/#101-failsafe-schema | failsafe}
+   * Name of the schema to use.
    *
    * @default {"default"}
    */
-  schema?: "core" | "default" | "failsafe" | "json" | "extended";
+  schema?: SchemaType;
   /**
    * If `true`, duplicate keys will overwrite previous values. Otherwise,
    * duplicate keys will throw a {@linkcode SyntaxError}.

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -5,10 +5,10 @@
 // This module is browser compatible.
 
 import { dump } from "./_dumper.ts";
-import { SCHEMA_MAP } from "./_schema.ts";
+import { SCHEMA_MAP, type SchemaType } from "./_schema.ts";
 import type { StyleVariant } from "./_type.ts";
 
-export type { StyleVariant };
+export type { SchemaType, StyleVariant };
 
 /** Options for {@linkcode stringify}. */
 export type StringifyOptions = {
@@ -41,16 +41,11 @@ export type StringifyOptions = {
   /** Each tag may have own set of styles.	- "tag" => "style" map. */
   styles?: Record<string, StyleVariant>;
   /**
-   * Name of the schema to use. Options includes:
-   * - `extended` (extends `default` schema)
-   * - `default` (extends `core` schema)
-   * - {@linkcode https://yaml.org/spec/1.2.2/#103-core-schema | core} (extends `json` schema)
-   * - {@linkcode https://yaml.org/spec/1.2.2/#102-json-schema | json} (extends `failsafe` schema)
-   * - {@linkcode https://yaml.org/spec/1.2.2/#101-failsafe-schema | failsafe}
+   * Name of the schema to use.
    *
    * @default {"default"}
    */
-  schema?: "core" | "default" | "failsafe" | "json" | "extended";
+  schema?: SchemaType;
   /**
    * If true, sort keys when dumping YAML in ascending, ASCII character order.
    * If a function, use the function to sort the keys.


### PR DESCRIPTION
By adding a `SchemaType` type.

Closes #5443

