### PR TITLE
BREAKING(fs): throw `Deno.errors.NotSupported` instead of `SubdirectoryMoveError` in `move[Sync]()`

### DIFF
--- a/fs/move.ts
+++ b/fs/move.ts
@@ -4,38 +4,6 @@ import { isSamePath } from "./_is_same_path.ts";
 
 const EXISTS_ERROR = new Deno.errors.AlreadyExists("dest already exists.");
 
-/**
- * Error thrown in {@linkcode move} or {@linkcode moveSync} when the destination
- * is a subdirectory of the source.
- *
- * @example Usage
- * ```ts no-eval
- * import { move, SubdirectoryMoveError } from "@std/fs/move";
- *
- * try {
- *   await move("./foo", "./foo/bar");
- * } catch (error) {
- *   if (error instanceof SubdirectoryMoveError) {
- *     console.error(error.message);
- *   }
- * }
- * ```
- */
-export class SubdirectoryMoveError extends Error {
-  /**
-   * Constructs a new instance.
-   *
-   * @param src The source file or directory as a string or URL.
-   * @param dest The destination file or directory as a string or URL.
-   */
-  constructor(src: string | URL, dest: string | URL) {
-    super(
-      `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
-    );
-    this.name = this.constructor.name;
-  }
-}
-
 /** Options for {@linkcode move} and {@linkcode moveSync}. */
 export interface MoveOptions {
   /**
@@ -49,9 +17,6 @@ export interface MoveOptions {
 /**
  * Asynchronously moves a file or directory (along with its contents).
  *
- * If `src` is a sub-directory of `dest`, a {@linkcode SubdirectoryMoveError}
- * will be thrown.
- *
  * Requires `--allow-read` and `--allow-write` permissions.
  *
  * @see {@link https://docs.deno.com/runtime/manual/basics/permissions#file-system-access}
@@ -60,6 +25,9 @@ export interface MoveOptions {
  * @param src The source file or directory as a string or URL.
  * @param dest The destination file or directory as a string or URL.
  * @param options Options for the move operation.
+ * @throws {Deno.errors.AlreadyExists} If `dest` already exists and
+ * `options.overwrite` is `false`.
+ * @throws {Deno.errors.InvalidData} If `src` is a sub-directory of `dest`.
  *
  * @returns A void promise that resolves once the operation completes.
  *
@@ -96,7 +64,9 @@ export async function move(
     srcStat.isDirectory &&
     (isSubdir(src, dest) || isSamePath(src, dest))
   ) {
-    throw new SubdirectoryMoveError(src, dest);
+    throw new Deno.errors.InvalidData(
+      `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
+    );
   }
 
   if (overwrite) {
@@ -123,9 +93,6 @@ export async function move(
 /**
  * Synchronously moves a file or directory (along with its contents).
  *
- * If `src` is a sub-directory of `dest`, a {@linkcode SubdirectoryMoveError}
- * will be thrown.
- *
  * Requires `--allow-read` and `--allow-write` permissions.
  *
  * @see {@link https://docs.deno.com/runtime/manual/basics/permissions#file-system-access}
@@ -134,6 +101,9 @@ export async function move(
  * @param src The source file or directory as a string or URL.
  * @param dest The destination file or directory as a string or URL.
  * @param options Options for the move operation.
+ * @throws {Deno.errors.AlreadyExists} If `dest` already exists and
+ * `options.overwrite` is `false`.
+ * @throws {Deno.errors.InvalidData} If `src` is a sub-directory of `dest`.
  *
  * @returns A void value that returns once the operation completes.
  *
@@ -170,7 +140,9 @@ export function moveSync(
     srcStat.isDirectory &&
     (isSubdir(src, dest) || isSamePath(src, dest))
   ) {
-    throw new SubdirectoryMoveError(src, dest);
+    throw new Deno.errors.InvalidData(
+      `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
+    );
   }
 
   if (overwrite) {

--- a/fs/move.ts
+++ b/fs/move.ts
@@ -27,7 +27,7 @@ export interface MoveOptions {
  * @param options Options for the move operation.
  * @throws {Deno.errors.AlreadyExists} If `dest` already exists and
  * `options.overwrite` is `false`.
- * @throws {Deno.errors.InvalidData} If `src` is a sub-directory of `dest`.
+ * @throws {Deno.errors.NotSupported} If `src` is a sub-directory of `dest`.
  *
  * @returns A void promise that resolves once the operation completes.
  *
@@ -64,7 +64,7 @@ export async function move(
     srcStat.isDirectory &&
     (isSubdir(src, dest) || isSamePath(src, dest))
   ) {
-    throw new Deno.errors.InvalidData(
+    throw new Deno.errors.NotSupported(
       `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
     );
   }
@@ -103,7 +103,7 @@ export async function move(
  * @param options Options for the move operation.
  * @throws {Deno.errors.AlreadyExists} If `dest` already exists and
  * `options.overwrite` is `false`.
- * @throws {Deno.errors.InvalidData} If `src` is a sub-directory of `dest`.
+ * @throws {Deno.errors.NotSupported} If `src` is a sub-directory of `dest`.
  *
  * @returns A void value that returns once the operation completes.
  *
@@ -140,7 +140,7 @@ export function moveSync(
     srcStat.isDirectory &&
     (isSubdir(src, dest) || isSamePath(src, dest))
   ) {
-    throw new Deno.errors.InvalidData(
+    throw new Deno.errors.NotSupported(
       `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
     );
   }

--- a/fs/move_test.ts
+++ b/fs/move_test.ts
@@ -420,7 +420,7 @@ Deno.test("move() accepts overwrite option set to true for directories", async f
       async () => {
         await move(src, dest);
       },
-      Deno.errors.InvalidData,
+      Deno.errors.NotSupported,
       `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
     );
   }
@@ -482,7 +482,7 @@ Deno.test("move() accepts overwrite option set to true for directories", functio
       () => {
         moveSync(src, dest);
       },
-      Deno.errors.InvalidData,
+      Deno.errors.NotSupported,
       `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
     );
   }

--- a/fs/move_test.ts
+++ b/fs/move_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import * as path from "@std/path";
-import { move, moveSync, SubdirectoryMoveError } from "./move.ts";
+import { move, moveSync } from "./move.ts";
 import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { existsSync } from "./exists.ts";
@@ -416,9 +416,13 @@ Deno.test("move() accepts overwrite option set to true for directories", async f
     const src = p[0];
     const dest = p[1];
 
-    await assertRejects(async () => {
-      await move(src, dest);
-    }, SubdirectoryMoveError);
+    await assertRejects(
+      async () => {
+        await move(src, dest);
+      },
+      Deno.errors.InvalidData,
+      `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
+    );
   }
 
   await Deno.remove(dir, { recursive: true });
@@ -474,9 +478,13 @@ Deno.test("move() accepts overwrite option set to true for directories", functio
     const src = p[0];
     const dest = p[1];
 
-    assertThrows(() => {
-      moveSync(src, dest);
-    }, SubdirectoryMoveError);
+    assertThrows(
+      () => {
+        moveSync(src, dest);
+      },
+      Deno.errors.InvalidData,
+      `Cannot move '${src}' to a subdirectory of itself, '${dest}'.`,
+    );
   }
 
   Deno.removeSync(dir, { recursive: true });


### PR DESCRIPTION
### What's changed

Previously, [`@std/fs/move`](https://jsr.io/@std/fs/doc/move/~/) threw `SubdirectoryMoveError`. Now, it throws [`Deno.errors.NotSupported`](https://docs.deno.com/api/deno/~/Deno.errors.NotSupported).

### Motivation

This change was made to reduce the API surface area by using an appropriate error class that's already built into the Deno runtime.

### Migration guide

To migrate, compare against `Deno.error.NotSupported` instead of `SubdirectoryMoveError` when error-handling `move()` or `moveSync()`.

```diff
- import { move, SubdirectoryMoveError } from "@std/fs/move";
+ import { move } from "@std/fs/move";

try {
  await move("./path/to/folder/subdir", "./path/to/folder");
} catch (error) {
- if (error instanceof SubdirectoryMoveError) {
+ if (error instanceof Deno.errors.NotSupported) {
    // ...
  }
}
```

### Related

Towards #5476