### PR TITLE
BREAKING(yaml): remove `default` schema type

### DIFF
--- a/yaml/_dumper.ts
+++ b/yaml/_dumper.ts
@@ -26,7 +26,7 @@ import {
   SINGLE_QUOTE,
   VERTICAL_LINE,
 } from "./_chars.ts";
-import { DEFAULT_SCHEMA, type Schema } from "./_schema.ts";
+import { CORE_SCHEMA, type Schema } from "./_schema.ts";
 import type { KindType, StyleVariant, Type } from "./_type.ts";
 import { type ArrayObject, getObjectTypeString, isObject } from "./_utils.ts";
 
@@ -486,7 +486,7 @@ export class DumperState {
   dump: any;
 
   constructor({
-    schema = DEFAULT_SCHEMA,
+    schema = CORE_SCHEMA,
     indent = 2,
     arrayIndent = true,
     skipInvalid = false,

--- a/yaml/_loader.ts
+++ b/yaml/_loader.ts
@@ -36,7 +36,7 @@ import {
   VERTICAL_LINE,
 } from "./_chars.ts";
 import { Mark } from "./_mark.ts";
-import { DEFAULT_SCHEMA, type Schema, type TypeMap } from "./_schema.ts";
+import { CORE_SCHEMA, type Schema, type TypeMap } from "./_schema.ts";
 import type { KindType, Type } from "./_type.ts";
 import { type ArrayObject, getObjectTypeString, isObject } from "./_utils.ts";
 
@@ -161,7 +161,7 @@ class LoaderState {
   constructor(
     input: string,
     {
-      schema = DEFAULT_SCHEMA,
+      schema = CORE_SCHEMA,
       onWarning,
       allowDuplicateKeys = false,
     }: LoaderStateOptions,

--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -37,17 +37,15 @@ import {
  * strings.
  * - `json`: extends `failsafe` schema by also supporting nulls, booleans,
  * integers and floats.
- * - `core`: extends `json` schema by also supporting tag resolution.
- * - `default`: extends `core` schema by also supporting binary, omap, pairs and
- * set types.
- * - `extended`: extends `default` schema by also supporting regular
- * expressions and undefined values.
+ * - `core` (default): extends `json` schema by also supporting tag resolution.
+ * - `extended`: extends `default` schema by also supporting binary, omap,
+ * pairs, set, regular expressions and undefined types, and anchors and aliases.
  *
  * See
  * {@link https://yaml.org/spec/1.2.2/#chapter-10-recommended-schemas | YAML 1.2 spec}
  * for more details on the `failsafe`, `json` and `core` schemas.
  */
-export type SchemaType = "failsafe" | "json" | "core" | "default" | "extended";
+export type SchemaType = "failsafe" | "json" | "core" | "extended";
 
 // deno-lint-ignore no-explicit-any
 function compileList<K extends KindType, D = any>(
@@ -147,17 +145,8 @@ const JSON_SCHEMA = new Schema({
  *
  * @see {@link http://www.yaml.org/spec/1.2/spec.html#id2804923}
  */
-const CORE_SCHEMA = new Schema({
+export const CORE_SCHEMA = new Schema({
   include: [JSON_SCHEMA],
-});
-
-/**
- * Default YAML schema. It is not described in the YAML specification.
- */
-export const DEFAULT_SCHEMA = new Schema({
-  explicit: [binary, omap, pairs, set],
-  implicit: [timestamp, merge],
-  include: [CORE_SCHEMA],
 });
 
 /***
@@ -186,14 +175,14 @@ export const DEFAULT_SCHEMA = new Schema({
  * ```
  */
 const EXTENDED_SCHEMA = new Schema({
-  explicit: [regexp, undefinedType],
-  include: [DEFAULT_SCHEMA],
+  explicit: [regexp, undefinedType, binary, omap, pairs, set],
+  implicit: [timestamp, merge],
+  include: [CORE_SCHEMA],
 });
 
 export const SCHEMA_MAP = new Map([
-  ["core", CORE_SCHEMA],
-  ["default", DEFAULT_SCHEMA],
   ["failsafe", FAILSAFE_SCHEMA],
   ["json", JSON_SCHEMA],
+  ["core", CORE_SCHEMA],
   ["extended", EXTENDED_SCHEMA],
 ]);

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -39,7 +39,7 @@ test: foobar
 binary: !<tag:yaml.org,2002:binary> SGVsbG8=
 `;
 
-    assertEquals(stringify(FIXTURE), ASSERTS);
+    assertEquals(stringify(FIXTURE, { schema: "extended" }), ASSERTS);
   },
 });
 
@@ -119,19 +119,19 @@ Deno.test({
   name: "stringify() serializes Uint8Array as !!binary",
   fn() {
     assertEquals(
-      stringify(new Uint8Array([1])),
+      stringify(new Uint8Array([1]), { schema: "extended" }),
       "!<tag:yaml.org,2002:binary> AQ==\n",
     );
     assertEquals(
-      stringify(new Uint8Array([1, 2])),
+      stringify(new Uint8Array([1, 2]), { schema: "extended" }),
       "!<tag:yaml.org,2002:binary> AQI=\n",
     );
     assertEquals(
-      stringify(new Uint8Array([1, 2, 3])),
+      stringify(new Uint8Array([1, 2, 3]), { schema: "extended" }),
       "!<tag:yaml.org,2002:binary> AQID\n",
     );
     assertEquals(
-      stringify(new Uint8Array(Array(50).keys())),
+      stringify(new Uint8Array(Array(50).keys()), { schema: "extended" }),
       "!<tag:yaml.org,2002:binary> AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8gISIjJCUmJygpKissLS4vMDE=\n",
     );
   },
@@ -265,7 +265,7 @@ Deno.test({
   name: "stringify() format Date objet into ISO string",
   fn() {
     assertEquals(
-      stringify([new Date("2021-01-01T00:00:00.000Z")]),
+      stringify([new Date("2021-01-01T00:00:00.000Z")], { schema: "extended" }),
       `- 2021-01-01T00:00:00.000Z\n`,
     );
   },


### PR DESCRIPTION
### What's changed

Previously, the `default` schema type was set as the default schema for `parse()` and `stringify()`. Now, this has been changed to `core`, and the configuration of the `default` schema type have been merged with the `extended` schema type`.

### Motivation

This change was made to align with the [YAML spec](https://yaml.org/spec/1.2.2/#103-core-schema), which recommends the `core` schema be the default schema for YAML processors.

> The Core schema is an extension of the [JSON schema](https://yaml.org/spec/1.2.2/#json-schema), allowing for more human-readable [presentation](https://yaml.org/spec/1.2.2/#presentation-stream) of the same types. This is the recommended default [schema](https://yaml.org/spec/1.2.2/#recommended-schemas) that YAML [processor](https://yaml.org/spec/1.2.2/#processes-and-models) should use unless instructed otherwise.

Doing so also provides the benefit of removing one possible value of `SchemaType`, and therefore simplifying configuration for `parse()` and `stringify()`. Use cases which don't require the `extended` schema will also see a slight performance boost.

### Migration guide

To migrate, if parsing or stringifying one of the following types, ensure you're using `option.schema = "extended"`:
1. Binary,
2. Ordered map (omap)
3. Pairs
4. Set
5. Regular expressions
6. Undefined types
7. Anchors and aliases

```diff
import { parse } from "@std/yaml/parse";

- parse('message: !!binary "SGVsbG8=");
+ parse('message: !!binary "SGVsbG8="', { schema: "extended" });
```
```diff
import { stringify } from "@std/yaml/stringify";

- stringify(new Uint8Array([1, 2, 3]));
+ stringify(new Uint8Array([1, 2, 3]), { schema: "extended" });
```