### PR TITLE
BREAKING(http): make printing of network IP address opt-in for file server

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -839,21 +839,13 @@ function main() {
     console.log(message);
   }
 
-  if (useTls) {
-    Deno.serve({
-      port,
-      hostname: host,
-      onListen,
-      cert: Deno.readTextFileSync(certFile),
-      key: Deno.readTextFileSync(keyFile),
-    }, handler);
-  } else {
-    Deno.serve({
-      port,
-      hostname: host,
-      onListen,
-    }, handler);
-  }
+  Deno.serve({
+    port,
+    hostname: host,
+    onListen,
+    cert: useTls ? Deno.readTextFileSync(certFile) : undefined,
+    key: useTls ? Deno.readTextFileSync(keyFile) : undefined,
+  }, handler);
 }
 
 function printUsage() {

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -13,7 +13,7 @@
  *
  * ```shell
  * > # start server
- * > deno run --allow-net --allow-read --allow-sys jsr:@std/http/file-server
+ * > deno run --allow-net --allow-read jsr:@std/http/file-server
  * > # show help
  * > deno run jsr:@std/http/file-server --help
  * ```
@@ -22,7 +22,7 @@
  *
  * ```shell
  * > # install
- * > deno install --allow-net --allow-read --allow-sys --global jsr:@std/http/file-server
+ * > deno install --allow-net --allow-read --global jsr:@std/http/file-server
  * > # start server
  * > file-server
  * > # show help
@@ -578,6 +578,14 @@ export interface ServeDirOptions {
    * @default {false}
    */
   enableCors?: boolean;
+  /**
+   * Prints the network IP address of the current machine.
+   *
+   * Requires the `--allow-sys` permissions flag.
+   *
+   * @default {false}
+   */
+  printNetworkIp?: boolean;
   /** Do not print request level logs.
    *
    * @default {false}
@@ -765,13 +773,22 @@ function logError(error: Error) {
 function main() {
   const serverArgs = parseArgs(Deno.args, {
     string: ["port", "host", "cert", "key", "header"],
-    boolean: ["help", "dir-listing", "dotfiles", "cors", "verbose", "version"],
+    boolean: [
+      "help",
+      "dir-listing",
+      "dotfiles",
+      "cors",
+      "ip",
+      "verbose",
+      "version",
+    ],
     negatable: ["dir-listing", "dotfiles", "cors"],
     collect: ["header"],
     default: {
       "dir-listing": true,
       dotfiles: true,
       cors: true,
+      ip: false,
       verbose: false,
       version: false,
       host: "0.0.0.0",
@@ -842,7 +859,7 @@ function main() {
   Deno.serve({
     port,
     hostname: host,
-    onListen,
+    onListen: serverArgs.ip ? onListen : undefined,
     cert: useTls ? Deno.readTextFileSync(certFile) : undefined,
     key: useTls ? Deno.readTextFileSync(keyFile) : undefined,
   }, handler);
@@ -862,6 +879,8 @@ OPTIONS:
   -h, --help            Prints help information
   -p, --port <PORT>     Set port (default is 8000)
   --cors                Enable CORS via the "Access-Control-Allow-Origin" header
+  --ip                  Print network IP address.
+                        Note: requires the \`--allow-sys\` permissions flag.
   --host     <HOST>     Hostname (default is 0.0.0.0)
   -c, --cert <FILE>     TLS certificate file (enables TLS)
   -k, --key  <FILE>     TLS key file (enables TLS)

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -991,6 +991,7 @@ Deno.test("file_server prints local and network urls", async () => {
     "http/file_server.ts",
     "--port",
     `${port}`,
+    "--ip",
   ]);
   const output = await readUntilMatch(process.stdout, "Network:");
   const networkAdress = Deno.networkInterfaces().find((i) =>
@@ -1016,6 +1017,7 @@ Deno.test("file_server prints only local address on Deploy", async () => {
     "http/file_server.ts",
     "--port",
     `${port}`,
+    "--ip",
   ], {
     env: {
       DENO_DEPLOYMENT_ID: "abcdef",


### PR DESCRIPTION
### What's changed

Previously, `@std/http/file-server` printed the current machine's network IP address upon listen, by default. Now, this behavior is opt-in; set by either the `printNetworkIp` option if calling `serveDir()`, or the corresponding `--ip` flag if running as a script.

### Motivation

This change was made to remove the need to set `--allow-sys` permissions.

### Migration guide

If calling `serveDir()`, set the `printNetworkIp` option to `true` to print the network IP address of the current machine on listen.
```diff
import { serveDir } from "@std/http/file-server";

- Deno.serve((req) => serveDir(req));
+ Deno.serve((req) => serveDir(req, { printNetworkIp: true }));
```

If running `@std/http/file-server` as a script, set the `--ip` flag and `--allow-sys` permission flag to print the network IP address of the current machine on listen.
```diff
- $ deno run --allow-net --allow-read --allow-sys jsr:@std/http/file-server
+ $ deno run --allow-net --allow-read --allow-sys jsr:@std/http/file-server --ip
```

If running `@std/http/file-server` as a script, and you don't want to print the network IP address of the current machine on listen, you can remove the `--allow-sys` permission flag.

```diff
- $ deno run --allow-net --allow-read --allow-sys jsr:@std/http/file-server
+ $ deno run --allow-net --allow-read jsr:@std/http/file-server
```