### PR TITLE
fix(file_server): only show LAN address when `--allow-sys` is provided

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -830,7 +830,13 @@ function main() {
   const useTls = !!(keyFile && certFile);
 
   function onListen({ port, hostname }: { port: number; hostname: string }) {
-    const networkAddress = getNetworkAddress();
+    let networkAddress: string | undefined = undefined;
+    if (
+      Deno.permissions.querySync({ name: "sys", kind: "networkInterfaces" })
+        .state === "granted"
+    ) {
+      networkAddress = getNetworkAddress();
+    }
     const protocol = useTls ? "https" : "http";
     let message = `Listening on:\n- Local: ${protocol}://${hostname}:${port}`;
     if (networkAddress && !DENO_DEPLOYMENT_ID) {

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -8,11 +8,14 @@
  * A small program for serving local files over HTTP.
  *
  * ```sh
- * deno run --allow-net --allow-read --allow-sys jsr:@std/http/file-server
+ * deno run --allow-net --allow-read jsr:@std/http/file-server
  * Listening on:
  * - Local: http://localhost:8000
-
  * ```
+ * 
+ * When the `--allow-sys=networkInterfaces` permission is provided, the file
+ * server will also display the local area network addresses that can be used to
+ * access the server.
  *
  * ## HTTP Status Code and Status Text
  *


### PR DESCRIPTION
This commit changes the behaviour of the file server to only print the LAN address if `--allow-sys=networkInterfaces` is provided. If it is not provided, no permission prompt for `--allow-sys` will be raised, and the LAN address will not be printed. You could think of this as progressive enhancement :)

Alternate for #5540
