### PR TITLE
docs: use caption for doc example titles

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -76,6 +76,7 @@ const ENTRY_POINTS = [
 ] as const;
 
 const TS_SNIPPET = /```ts[\s\S]*?```/g;
+const CAPTION_TAG = /^<caption>.+<\/caption>/s;
 const ASSERTION_IMPORT =
   /from "@std\/(assert(\/[a-z-]+)?|testing\/(mock|snapshot|types))"/g;
 const NEWLINE = "\n";
@@ -252,11 +253,19 @@ function assertHasExampleTag(
      * Otherwise, if the example title is undefined, it is given the title
      * "Example #" by default.
      */
+    const captionMatch = tag.doc.match(CAPTION_TAG)?.[0];
     assert(
-      !tag.doc.startsWith("```ts"),
-      "@example tag must have a title",
+      captionMatch != null,
+      "@example tag must have a title in a `<caption>` tag",
       document,
     );
+    if (captionMatch != null) {
+      assert(
+        tag.doc.slice(captionMatch.length).startsWith("\n\n"),
+        "@example tag caption must be followed by an empty line",
+        document,
+      );
+    }
     assertSnippetsWork(tag.doc, document);
   }
 }

--- a/assert/almost_equals.ts
+++ b/assert/almost_equals.ts
@@ -11,7 +11,9 @@ import { AssertionError } from "./assertion_error.ts";
  * The default tolerance is one hundred thousandth of a percent of the
  * expected value.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertAlmostEquals } from "@std/assert";
  *

--- a/assert/array_includes.ts
+++ b/assert/array_includes.ts
@@ -14,7 +14,9 @@ export type ArrayLikeArg<T> = ArrayLike<T> & object;
  * Type parameter can be specified to ensure values under comparison have the
  * same type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertArrayIncludes } from "@std/assert";
  *

--- a/assert/assert.ts
+++ b/assert/assert.ts
@@ -5,7 +5,9 @@ import { AssertionError } from "./assertion_error.ts";
 /**
  * Make an assertion, error will be thrown if `expr` does not have truthy value.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assert } from "@std/assert";
  *

--- a/assert/assertion_error.ts
+++ b/assert/assertion_error.ts
@@ -4,7 +4,9 @@
 /**
  * Error thrown when an assertion fails.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { AssertionError } from "@std/assert";
  *

--- a/assert/equal.ts
+++ b/assert/equal.ts
@@ -17,7 +17,9 @@ function constructorsEqual(a: object, b: object) {
  * @param d The expected value
  * @returns `true` if the values are deeply equal, `false` otherwise
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { equal } from "@std/assert";
  *

--- a/assert/equals.ts
+++ b/assert/equals.ts
@@ -11,7 +11,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Type parameter can be specified to ensure values under comparison have the
  * same type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertEquals } from "@std/assert";
  *

--- a/assert/exists.ts
+++ b/assert/exists.ts
@@ -6,7 +6,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that actual is not null or undefined.
  * If not then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertExists } from "@std/assert";
  *

--- a/assert/fail.ts
+++ b/assert/fail.ts
@@ -5,7 +5,9 @@ import { AssertionError } from "./assertion_error.ts";
 /**
  * Forcefully throws a failed assertion.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { fail } from "@std/assert";
  *

--- a/assert/false.ts
+++ b/assert/false.ts
@@ -8,7 +8,9 @@ export type Falsy = false | 0 | 0n | "" | null | undefined;
 /**
  * Make an assertion, error will be thrown if `expr` have truthy value.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertFalse } from "@std/assert";
  *

--- a/assert/greater.ts
+++ b/assert/greater.ts
@@ -7,7 +7,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that `actual` is greater than `expected`.
  * If not then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertGreater } from "@std/assert";
  *

--- a/assert/greater_or_equal.ts
+++ b/assert/greater_or_equal.ts
@@ -7,7 +7,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that `actual` is greater than or equal to `expected`.
  * If not then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertGreaterOrEqual } from "@std/assert";
  *

--- a/assert/instance_of.ts
+++ b/assert/instance_of.ts
@@ -14,7 +14,9 @@ new (...args: any) => infer C ? C
  * Make an assertion that `obj` is an instance of `type`.
  * If not then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertInstanceOf } from "@std/assert";
  *

--- a/assert/is_error.ts
+++ b/assert/is_error.ts
@@ -9,7 +9,9 @@ import { stripAnsiCode } from "@std/internal/styles";
  * An error class and a string that should be included in the
  * error message can also be asserted.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertIsError } from "@std/assert";
  *

--- a/assert/less.ts
+++ b/assert/less.ts
@@ -7,7 +7,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that `actual` is less than `expected`.
  * If not then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertLess } from "@std/assert";
  *

--- a/assert/less_or_equal.ts
+++ b/assert/less_or_equal.ts
@@ -7,7 +7,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that `actual` is less than or equal to `expected`.
  * If not then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertLessOrEqual } from "@std/assert";
  *

--- a/assert/match.ts
+++ b/assert/match.ts
@@ -6,7 +6,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that `actual` match RegExp `expected`. If not
  * then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertMatch } from "@std/assert";
  *

--- a/assert/not_equals.ts
+++ b/assert/not_equals.ts
@@ -10,7 +10,9 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * Type parameter can be specified to ensure values under comparison have the same type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertNotEquals } from "@std/assert";
  *

--- a/assert/not_instance_of.ts
+++ b/assert/not_instance_of.ts
@@ -6,7 +6,9 @@ import { assertFalse } from "./false.ts";
  * Make an assertion that `obj` is not an instance of `type`.
  * If so, then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertNotInstanceOf } from "@std/assert";
  *

--- a/assert/not_match.ts
+++ b/assert/not_match.ts
@@ -6,7 +6,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that `actual` not match RegExp `expected`. If match
  * then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertNotMatch } from "@std/assert";
  *

--- a/assert/not_strict_equals.ts
+++ b/assert/not_strict_equals.ts
@@ -8,7 +8,9 @@ import { format } from "@std/internal/format";
  * {@linkcode Object.is} for equality comparison. If the values are strictly
  * equal then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertNotStrictEquals } from "@std/assert";
  *

--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -6,7 +6,9 @@ import { assertEquals } from "./equals.ts";
  * Make an assertion that `expected` object is a subset of `actual` object,
  * deeply. If not, then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertObjectMatch } from "@std/assert";
  *
@@ -14,7 +16,9 @@ import { assertEquals } from "./equals.ts";
  * assertObjectMatch({ foo: "bar" }, { foo: "baz" }); // Throws
  * ```
  *
- * @example Usage with nested objects
+ * @example
+ * <caption>Usage with nested objects</caption>
+
  * ```ts no-eval
  * import { assertObjectMatch } from "@std/assert";
  *

--- a/assert/rejects.ts
+++ b/assert/rejects.ts
@@ -8,7 +8,9 @@ import { assertIsError } from "./is_error.ts";
  *
  * To assert that a synchronous function throws, use {@linkcode assertThrows}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertRejects } from "@std/assert";
  *
@@ -31,7 +33,9 @@ export function assertRejects(
  *
  * To assert that a synchronous function throws, use {@linkcode assertThrows}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertRejects } from "@std/assert";
  *

--- a/assert/strict_equals.ts
+++ b/assert/strict_equals.ts
@@ -7,7 +7,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that `actual` and `expected` are strictly equal, using
  * {@linkcode Object.is} for equality comparison. If not, then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertStrictEquals } from "@std/assert";
  *

--- a/assert/string_includes.ts
+++ b/assert/string_includes.ts
@@ -6,7 +6,9 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion that actual includes expected. If not
  * then throw.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertStringIncludes } from "@std/assert";
  *

--- a/assert/throws.ts
+++ b/assert/throws.ts
@@ -10,7 +10,9 @@ import { AssertionError } from "./assertion_error.ts";
  * To assert that an asynchronous function rejects, use
  * {@linkcode assertRejects}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertThrows } from "@std/assert";
  *
@@ -34,7 +36,9 @@ export function assertThrows(
  * To assert that an asynchronous function rejects, use
  * {@linkcode assertRejects}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { assertThrows } from "@std/assert";
  *

--- a/assert/unimplemented.ts
+++ b/assert/unimplemented.ts
@@ -5,7 +5,9 @@ import { AssertionError } from "./assertion_error.ts";
 /**
  * Use this to stub out methods that will throw when invoked.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { unimplemented } from "@std/assert";
  *

--- a/assert/unreachable.ts
+++ b/assert/unreachable.ts
@@ -5,7 +5,9 @@ import { AssertionError } from "./assertion_error.ts";
 /**
  * Use this to assert unreachable code.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { unreachable } from "@std/assert";
  *

--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -11,7 +11,9 @@
  * @param signal The signal to abort the promise with.
  * @returns A promise that can be aborted.
  *
- * @example Error-handling a timeout
+ * @example
+ * <caption>Error-handling a timeout</caption>
+
  * ```ts
  * import { abortable, delay } from "@std/async";
  * import { assertRejects, assertEquals } from "@std/assert";
@@ -26,7 +28,9 @@
  * );
  * ```
  *
- * @example Error-handling an abort
+ * @example
+ * <caption>Error-handling an abort</caption>
+
  * ```ts
  * import { abortable, delay } from "@std/async";
  * import { assertRejects, assertEquals } from "@std/assert";
@@ -54,7 +58,9 @@ export function abortable<T>(p: Promise<T>, signal: AbortSignal): Promise<T>;
  * @param signal The signal to abort the promise with.
  * @returns An async iterable that can be aborted.
  *
- * @example Error-handling a timeout
+ * @example
+ * <caption>Error-handling a timeout</caption>
+
  * ```ts
  * import { abortable, delay } from "@std/async";
  * import { assertRejects, assertEquals } from "@std/assert";
@@ -79,7 +85,9 @@ export function abortable<T>(p: Promise<T>, signal: AbortSignal): Promise<T>;
  * assertEquals(items, ["Hello"]);
  * ```
  *
- * @example Error-handling an abort
+ * @example
+ * <caption>Error-handling an abort</caption>
+
  * ```ts
  * import { abortable, delay } from "@std/async";
  * import { assertRejects, assertEquals } from "@std/assert";

--- a/async/deadline.ts
+++ b/async/deadline.ts
@@ -27,7 +27,9 @@ export interface DeadlineOptions {
  * @param options Additional options.
  * @returns A promise that will reject if the provided duration runs out before resolving.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { deadline } from "@std/async/deadline";
  * import { delay } from "@std/async/delay";

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -22,7 +22,9 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  * again before the timeout expires, the previous call will be
  * aborted.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { debounce } from "@std/async/debounce";
  *

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -23,8 +23,10 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  * aborted.
  *
  * @example
- * <caption>Usage</caption>
-
+ * <caption>
+ * Usage
+ * </caption>
+ *
  * ```ts no-eval
  * import { debounce } from "@std/async/debounce";
  *

--- a/async/delay.ts
+++ b/async/delay.ts
@@ -20,7 +20,9 @@ export interface DelayOptions {
  * @param ms Duration in milliseconds for how long the delay should last.
  * @param options Additional options.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-assert
  * import { delay } from "@std/async/delay";
  *

--- a/async/mux_async_iterator.ts
+++ b/async/mux_async_iterator.ts
@@ -12,7 +12,9 @@ interface TaggedYieldedValue<T> {
  * yielded from the iterator) does not matter; if there is any result, it is
  * discarded.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { MuxAsyncIterator } from "@std/async/mux-async-iterator";
  * import { assertEquals } from "@std/assert";
@@ -52,7 +54,9 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
    *
    * @param iterable The async iterable to add.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { MuxAsyncIterator } from "@std/async/mux-async-iterator";
    * import { assertEquals } from "@std/assert";
@@ -96,7 +100,9 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
    * Returns an async iterator of the stream.
    * @returns the async iterator for all the added async iterables.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { MuxAsyncIterator } from "@std/async/mux-async-iterator";
    * import { assertEquals } from "@std/assert";
@@ -141,7 +147,9 @@ export class MuxAsyncIterator<T> implements AsyncIterable<T> {
    * Implements an async iterator for the stream.
    * @returns the async iterator for all the added async iterables.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { MuxAsyncIterator } from "@std/async/mux-async-iterator";
    * import { assertEquals } from "@std/assert";

--- a/async/pool.ts
+++ b/async/pool.ts
@@ -14,7 +14,9 @@ const ERROR_WHILE_MAPPING_MESSAGE = "Threw while mapping.";
  * yielded on success. After that, the rejections among them are gathered and
  * thrown by the iterator in an `AggregateError`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { pooledMap } from "@std/async/pool";
  * import { assertEquals } from "@std/assert";

--- a/async/retry.ts
+++ b/async/retry.ts
@@ -7,7 +7,9 @@ import { exponentialBackoffWithJitter } from "./_util.ts";
  * Error thrown in {@linkcode retry} once the maximum number of failed attempts
  * has been reached.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert no-eval
  * import { RetryError } from "@std/async/retry";
  *
@@ -86,7 +88,9 @@ const defaultRetryOptions: Required<RetryOptions> = {
  *
  * When `jitter` is `0`, waits the full backoff time.
  *
- * @example Example configuration 1
+ * @example
+ * <caption>Example configuration 1</caption>
+
  * ```ts no-assert
  * import { retry } from "@std/async/retry";
  * const req = async () => {
@@ -103,7 +107,9 @@ const defaultRetryOptions: Required<RetryOptions> = {
  * });
  * ```
  *
- * @example Example configuration 2
+ * @example
+ * <caption>Example configuration 2</caption>
+
  * ```ts no-assert
  * import { retry } from "@std/async/retry";
  * const req = async () => {

--- a/async/tee.ts
+++ b/async/tee.ts
@@ -59,7 +59,9 @@ class Queue<T> {
 /**
  * Branches the given async iterable into the `n` branches.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { tee } from "@std/async/tee";
  * import { assertEquals } from "@std/assert";

--- a/bytes/concat.ts
+++ b/bytes/concat.ts
@@ -7,7 +7,9 @@
  * @param buffers Array of byte slices to concatenate.
  * @returns A new byte slice containing all the input slices concatenated.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { concat } from "@std/bytes/concat";
  * import { assertEquals } from "@std/assert";

--- a/bytes/copy.ts
+++ b/bytes/copy.ts
@@ -14,7 +14,9 @@
  * to 0.
  * @returns Number of bytes copied.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { copy } from "@std/bytes/copy";
  * import { assertEquals } from "@std/assert";
@@ -26,7 +28,9 @@
  * assertEquals(dst, new Uint8Array([9, 8, 7, 3, 4, 5]));
  * ```
  *
- * @example Copy with offset
+ * @example
+ * <caption>Copy with offset</caption>
+
  * ```ts
  * import { copy } from "@std/bytes/copy";
  * import { assertEquals } from "@std/assert";

--- a/bytes/ends_with.ts
+++ b/bytes/ends_with.ts
@@ -12,7 +12,9 @@
  * @returns `true` if the suffix array appears at the end of the source array,
  * `false` otherwise.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { endsWith } from "@std/bytes/ends-with";
  * import { assertEquals } from "@std/assert";

--- a/bytes/equals.ts
+++ b/bytes/equals.ts
@@ -66,7 +66,9 @@ const THRESHOLD_32_BIT = 160;
  * @param b Second array to check equality.
  * @returns `true` if the arrays are equal, `false` otherwise.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { equals } from "@std/bytes/equals";
  * import { assertEquals } from "@std/assert";

--- a/bytes/includes_needle.ts
+++ b/bytes/includes_needle.ts
@@ -15,7 +15,9 @@ import { indexOfNeedle } from "./index_of_needle.ts";
  * @returns `true` if the source array contains the needle array, `false`
  * otherwise.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { includesNeedle } from "@std/bytes/includes-needle";
  * import { assertEquals } from "@std/assert";
@@ -26,7 +28,9 @@ import { indexOfNeedle } from "./index_of_needle.ts";
  * assertEquals(includesNeedle(source, needle), true);
  * ```
  *
- * @example Start index
+ * @example
+ * <caption>Start index</caption>
+
  * ```ts
  * import { includesNeedle } from "@std/bytes/includes-needle";
  * import { assertEquals } from "@std/assert";

--- a/bytes/index_of_needle.ts
+++ b/bytes/index_of_needle.ts
@@ -17,7 +17,9 @@
  * @returns Index of the first occurrence of the needle array in the source
  * array, or -1 if it is not present.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { indexOfNeedle } from "@std/bytes/index-of-needle";
  * import { assertEquals } from "@std/assert";
@@ -30,7 +32,9 @@
  * assertEquals(indexOfNeedle(source, notNeedle), -1);
  * ```
  *
- * @example Start index
+ * @example
+ * <caption>Start index</caption>
+
  * ```ts
  * import { indexOfNeedle } from "@std/bytes/index-of-needle";
  * import { assertEquals } from "@std/assert";

--- a/bytes/last_index_of_needle.ts
+++ b/bytes/last_index_of_needle.ts
@@ -14,7 +14,9 @@
  * @returns Index of the last occurrence of the needle array in the source
  * array, or -1 if it is not present.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { lastIndexOfNeedle } from "@std/bytes/last-index-of-needle";
  * import { assertEquals } from "@std/assert";
@@ -27,7 +29,9 @@
  * assertEquals(lastIndexOfNeedle(source, notNeedle), -1);
  * ```
  *
- * @example Start index
+ * @example
+ * <caption>Start index</caption>
+
  * ```ts
  * import { lastIndexOfNeedle } from "@std/bytes/last-index-of-needle";
  * import { assertEquals } from "@std/assert";

--- a/bytes/repeat.ts
+++ b/bytes/repeat.ts
@@ -11,7 +11,9 @@ import { copy } from "./copy.ts";
  * @returns A new byte slice composed of `count` repetitions of the `source`
  * array.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { repeat } from "@std/bytes/repeat";
  * import { assertEquals } from "@std/assert";
@@ -21,7 +23,9 @@ import { copy } from "./copy.ts";
  * assertEquals(repeat(source, 3), new Uint8Array([0, 1, 2, 0, 1, 2, 0, 1, 2]));
  * ```
  *
- * @example Zero count
+ * @example
+ * <caption>Zero count</caption>
+
  * ```ts
  * import { repeat } from "@std/bytes/repeat";
  * import { assertEquals } from "@std/assert";

--- a/bytes/starts_with.ts
+++ b/bytes/starts_with.ts
@@ -12,7 +12,9 @@
  * @returns `true` if the prefix array appears at the start of the source array,
  * `false` otherwise.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { startsWith } from "@std/bytes/starts-with";
  * import { assertEquals } from "@std/assert";

--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -464,7 +464,9 @@ const FLAG_REGEXP =
  *
  * @return The parsed arguments.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parseArgs } from "@std/cli/parse-args";
  * import { assertEquals } from "@std/assert";

--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -32,7 +32,9 @@ export type PromptSecretOptions = {
  * @param options The options for the prompt.
  * @returns The string that was entered or `null` if stdin is not a TTY.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { promptSecret } from "@std/cli/prompt-secret";
  *

--- a/cli/spinner.ts
+++ b/cli/spinner.ts
@@ -89,7 +89,9 @@ export interface SpinnerOptions {
  * > [!WARNING]
  * > **UNSTABLE**: New API, yet to be vetted.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { Spinner } from "@std/cli/spinner";
  *
@@ -111,7 +113,9 @@ export class Spinner {
    * The message to display next to the spinner.
    * This can be changed while the spinner is active.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { Spinner } from "@std/cli/spinner";
    *
@@ -162,7 +166,9 @@ export class Spinner {
    *
    * @param value Color to set.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { Spinner } from "@std/cli/spinner";
    *
@@ -182,7 +188,9 @@ export class Spinner {
   /**
    * Get the current color of the spinner.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-assert
    * import { Spinner } from "@std/cli/spinner";
    *
@@ -199,7 +207,9 @@ export class Spinner {
   /**
    * Starts the spinner.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { Spinner } from "@std/cli/spinner";
    *
@@ -238,7 +248,9 @@ export class Spinner {
   /**
    * Stops the spinner.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { Spinner } from "@std/cli/spinner";
    *

--- a/cli/unicode_width.ts
+++ b/cli/unicode_width.ts
@@ -48,7 +48,9 @@ function charWidth(char: string) {
  * @param str The string to measure.
  * @returns The unicode width of the string.
  *
- * @example Calculating the unicode width of a string
+ * @example
+ * <caption>Calculating the unicode width of a string</caption>
+
  * ```ts
  * import { unicodeWidth } from "@std/cli/unicode-width";
  * import { assertEquals } from "@std/assert";
@@ -58,7 +60,9 @@ function charWidth(char: string) {
  * assertEquals(unicodeWidth("ｆｕｌｌｗｉｄｔｈ"), 18);
  * ```
  *
- * @example Calculating the unicode width of a color-encoded string
+ * @example
+ * <caption>Calculating the unicode width of a color-encoded string</caption>
+
  * ```ts
  * import { unicodeWidth } from "@std/cli/unicode-width";
  * import { stripAnsiCode } from "@std/fmt/colors";

--- a/collections/aggregate_groups.ts
+++ b/collections/aggregate_groups.ts
@@ -17,7 +17,9 @@ import { mapEntries } from "./map_entries.ts";
  * @returns A record with the same keys as the input record, but with the values
  * being the result of applying the aggregator to each group.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { aggregateGroups } from "@std/collections/aggregate-groups";
  * import { assertEquals } from "@std/assert";

--- a/collections/associate_by.ts
+++ b/collections/associate_by.ts
@@ -16,7 +16,9 @@
  * @returns A record with the keys produced by the selector and the elements as
  * values.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { associateBy } from "@std/collections/associate-by";
  * import { assertEquals } from "@std/assert";

--- a/collections/associate_with.ts
+++ b/collections/associate_with.ts
@@ -16,7 +16,9 @@
  * @returns An object where each element of the array is associated with a value
  * returned by the selector function.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { associateWith } from "@std/collections/associate-with";
  * import { assertEquals } from "@std/assert";

--- a/collections/chunk.ts
+++ b/collections/chunk.ts
@@ -11,7 +11,9 @@
  *
  * @returns An array of chunks of the given size.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { chunk } from "@std/collections/chunk";
  * import { assertEquals } from "@std/assert";

--- a/collections/deep_merge.ts
+++ b/collections/deep_merge.ts
@@ -18,7 +18,9 @@ import { filterInPlace } from "./_utils.ts";
  *
  * @returns A new record with the merged values.
  *
- * @example Merge objects
+ * @example
+ * <caption>Merge objects</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -33,7 +35,9 @@ import { filterInPlace } from "./_utils.ts";
  * assertEquals(result, expected);
  * ```
  *
- * @example Merge arrays
+ * @example
+ * <caption>Merge arrays</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -48,7 +52,9 @@ import { filterInPlace } from "./_utils.ts";
  * assertEquals(result, expected);
  * ```
  *
- * @example Merge maps
+ * @example
+ * <caption>Merge maps</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -63,7 +69,9 @@ import { filterInPlace } from "./_utils.ts";
  * assertEquals(result, expected);
  * ```
  *
- * @example Merge sets
+ * @example
+ * <caption>Merge sets</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -78,7 +86,9 @@ import { filterInPlace } from "./_utils.ts";
  * assertEquals(result, expected);
  * ```
  *
- * @example Merge with custom options
+ * @example
+ * <caption>Merge with custom options</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -117,7 +127,9 @@ export function deepMerge<
  *
  * @returns A new record with the merged values.
  *
- * @example Merge objects
+ * @example
+ * <caption>Merge objects</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -132,7 +144,9 @@ export function deepMerge<
  * assertEquals(result, expected);
  * ```
  *
- * @example Merge arrays
+ * @example
+ * <caption>Merge arrays</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -147,7 +161,9 @@ export function deepMerge<
  * assertEquals(result, expected);
  * ```
  *
- * @example Merge maps
+ * @example
+ * <caption>Merge maps</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -162,7 +178,9 @@ export function deepMerge<
  * assertEquals(result, expected);
  * ```
  *
- * @example Merge sets
+ * @example
+ * <caption>Merge sets</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";
@@ -177,7 +195,9 @@ export function deepMerge<
  * assertEquals(result, expected);
  * ```
  *
- * @example Merge with custom options
+ * @example
+ * <caption>Merge with custom options</caption>
+
  * ```ts
  * import { deepMerge } from "@std/collections/deep-merge";
  * import { assertEquals } from "@std/assert";

--- a/collections/distinct.ts
+++ b/collections/distinct.ts
@@ -11,7 +11,9 @@
  *
  * @returns An array of distinct elements in the input array.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { distinct } from "@std/collections/distinct";
  * import { assertEquals } from "@std/assert";

--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -14,7 +14,9 @@
  *
  * @returns An array of distinct elements in the input array.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { distinctBy } from "@std/collections/distinct-by";
  * import { assertEquals } from "@std/assert";

--- a/collections/drop_last_while.ts
+++ b/collections/drop_last_while.ts
@@ -13,7 +13,9 @@
  * @returns A new array that drops all elements until the last element that does
  * not match the given predicate.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { dropLastWhile } from "@std/collections/drop-last-while";
  * import { assertEquals } from "@std/assert";

--- a/collections/drop_while.ts
+++ b/collections/drop_while.ts
@@ -13,7 +13,9 @@
  * @returns A new array that drops all elements until the first element that
  * does not match the given predicate.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { dropWhile } from "@std/collections/drop-while";
  * import { assertEquals } from "@std/assert";

--- a/collections/filter_entries.ts
+++ b/collections/filter_entries.ts
@@ -12,7 +12,9 @@
  *
  * @returns A new record with all entries that match the given predicate.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { filterEntries } from "@std/collections/filter-entries";
  * import { assertEquals } from "@std/assert";

--- a/collections/filter_keys.ts
+++ b/collections/filter_keys.ts
@@ -13,7 +13,9 @@
  * @returns A new record with all entries that have a key that matches the given
  * predicate.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { filterKeys } from "@std/collections/filter-keys";
  * import { assertEquals } from "@std/assert";

--- a/collections/filter_values.ts
+++ b/collections/filter_values.ts
@@ -13,7 +13,9 @@
  * @returns A new record with all entries that have a value that matches the
  * given predicate.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { filterValues } from "@std/collections/filter-values";
  * import { assertEquals } from "@std/assert";

--- a/collections/find_single.ts
+++ b/collections/find_single.ts
@@ -13,7 +13,9 @@
  * @returns The single element that matches the given condition or `undefined`
  * if there are zero or more than one matching elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { findSingle } from "@std/collections/find-single";
  * import { assertEquals } from "@std/assert";

--- a/collections/first_not_nullish_of.ts
+++ b/collections/first_not_nullish_of.ts
@@ -15,7 +15,9 @@
  * @returns The first non-`null` and non-`undefined` value produced by the
  * selector function, or `undefined` if no such value is produced.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { firstNotNullishOf } from "@std/collections/first-not-nullish-of";
  * import { assertEquals } from "@std/assert";

--- a/collections/includes_value.ts
+++ b/collections/includes_value.ts
@@ -15,7 +15,9 @@
  *
  * @returns `true` if the value is part of the record, otherwise `false`.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { includesValue } from "@std/collections/includes-value";
  * import { assertEquals } from "@std/assert";

--- a/collections/intersect.ts
+++ b/collections/intersect.ts
@@ -12,7 +12,9 @@
  * @returns An array of distinct elements that appear at least once in each of
  * the given arrays.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { intersect } from "@std/collections/intersect";
  * import { assertEquals } from "@std/assert";

--- a/collections/invert.ts
+++ b/collections/invert.ts
@@ -19,7 +19,9 @@ export type InvertResult<T extends Record<PropertyKey, PropertyKey>> = {
  *
  * @returns A new record with all keys and values inverted.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { invert } from "@std/collections/invert";
  * import { assertEquals } from "@std/assert";

--- a/collections/invert_by.ts
+++ b/collections/invert_by.ts
@@ -24,7 +24,9 @@ export type InvertByResult<
  *
  * @returns A new record with all keys and values inverted.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { invertBy } from "@std/collections/invert-by";
  * import { assertEquals } from "@std/assert";

--- a/collections/join_to_string.ts
+++ b/collections/join_to_string.ts
@@ -53,7 +53,9 @@ export type JoinToStringOptions = {
  *
  * @returns The resulting string.
  *
- * @example Usage with options
+ * @example
+ * <caption>Usage with options</caption>
+
  * ```ts
  * import { joinToString } from "@std/collections/join-to-string";
  * import { assertEquals } from "@std/assert";

--- a/collections/map_entries.ts
+++ b/collections/map_entries.ts
@@ -13,7 +13,9 @@
  *
  * @returns A new record with all entries transformed by the given transformer.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { mapEntries } from "@std/collections/map-entries";
  * import { assertEquals } from "@std/assert";

--- a/collections/map_keys.ts
+++ b/collections/map_keys.ts
@@ -15,7 +15,9 @@
  *
  * @returns A new record with all keys transformed by the given transformer.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { mapKeys } from "@std/collections/map-keys";
  * import { assertEquals } from "@std/assert";

--- a/collections/map_not_nullish.ts
+++ b/collections/map_not_nullish.ts
@@ -15,7 +15,9 @@
  * @returns A new array with all elements transformed by the given transformer,
  * except the ones that were transformed to `null` or `undefined`.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { mapNotNullish } from "@std/collections/map-not-nullish";
  * import { assertEquals } from "@std/assert";

--- a/collections/map_values.ts
+++ b/collections/map_values.ts
@@ -15,7 +15,9 @@
  *
  * @returns A new record with all values transformed by the given transformer.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { mapValues } from "@std/collections/map-values";
  * import { assertEquals } from "@std/assert";
@@ -53,7 +55,9 @@ export function mapValues<T, O, K extends string>(
  *
  * @returns A new record with all values transformed by the given transformer.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { mapValues } from "@std/collections/map-values";
  * import { assertEquals } from "@std/assert";

--- a/collections/max_by.ts
+++ b/collections/max_by.ts
@@ -13,7 +13,9 @@
  * @returns The first element that is the largest value of the given function or
  * undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { maxBy } from "@std/collections/max-by";
  * import { assertEquals } from "@std/assert";
@@ -45,7 +47,9 @@ export function maxBy<T>(
  * @returns The first element that is the largest value of the given function or
  * undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { maxBy } from "@std/collections/max-by";
  * import { assertEquals } from "@std/assert";
@@ -77,7 +81,9 @@ export function maxBy<T>(
  * @returns The first element that is the largest value of the given function or
  * undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { maxBy } from "@std/collections/max-by";
  * import { assertEquals } from "@std/assert";
@@ -109,7 +115,9 @@ export function maxBy<T>(
  * @returns The first element that is the largest value of the given function or
  * undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { maxBy } from "@std/collections/max-by";
  * import { assertEquals } from "@std/assert";

--- a/collections/max_of.ts
+++ b/collections/max_of.ts
@@ -14,7 +14,9 @@
  * @returns The largest value of the given function or undefined if there are no
  * elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { maxOf } from "@std/collections/max-of";
  * import { assertEquals } from "@std/assert";
@@ -47,7 +49,9 @@ export function maxOf<T>(
  * @returns The first element that is the largest value of the given function or
  * undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { maxOf } from "@std/collections/max-of";
  * import { assertEquals } from "@std/assert";

--- a/collections/max_with.ts
+++ b/collections/max_with.ts
@@ -17,7 +17,9 @@
  * @returns The first element that is the largest value of the given function or
  * undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { maxWith } from "@std/collections/max-with";
  * import { assertEquals } from "@std/assert";

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -13,7 +13,9 @@
  * @returns The first element that is the smallest value of the given function
  * or undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { minBy } from "@std/collections/min-by";
  * import { assertEquals } from "@std/assert";
@@ -45,7 +47,9 @@ export function minBy<T>(
  * @returns The first element that is the smallest value of the given function
  * or undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { minBy } from "@std/collections/min-by";
  * import { assertEquals } from "@std/assert";
@@ -77,7 +81,9 @@ export function minBy<T>(
  * @returns The first element that is the smallest value of the given function
  * or undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { minBy } from "@std/collections/min-by";
  * import { assertEquals } from "@std/assert";
@@ -109,7 +115,9 @@ export function minBy<T>(
  * @returns The first element that is the smallest value of the given function
  * or undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { minBy } from "@std/collections/min-by";
  * import { assertEquals } from "@std/assert";

--- a/collections/min_of.ts
+++ b/collections/min_of.ts
@@ -14,7 +14,9 @@
  * @returns The smallest value of the given function or undefined if there are
  * no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { minOf } from "@std/collections/min-of";
  * import { assertEquals } from "@std/assert";
@@ -47,7 +49,9 @@ export function minOf<T>(
  * @returns The first element that is the smallest value of the given function
  * or undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { minOf } from "@std/collections/min-of";
  * import { assertEquals } from "@std/assert";

--- a/collections/min_with.ts
+++ b/collections/min_with.ts
@@ -13,7 +13,9 @@
  * @returns The first element that is the smallest value of the given function
  * or undefined if there are no elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { minWith } from "@std/collections/min-with";
  * import { assertEquals } from "@std/assert";

--- a/collections/omit.ts
+++ b/collections/omit.ts
@@ -12,7 +12,9 @@
  *
  * @returns A new object with the specified keys omitted.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { omit } from "@std/collections/omit";
  * import { assertEquals } from "@std/assert";

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -15,7 +15,9 @@
  * @returns A tuple of two arrays. The first array contains all elements that
  * match the predicate, the second contains all elements that do not.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { partition } from "@std/collections/partition";
  * import { assertEquals } from "@std/assert";
@@ -50,7 +52,9 @@ export function partition<T>(
  * @returns A tuple of two arrays. The first array contains all elements that
  * match the predicate, the second contains all elements that do not.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { partition } from "@std/collections/partition";
  * import { assertEquals } from "@std/assert";

--- a/collections/partition_entries.ts
+++ b/collections/partition_entries.ts
@@ -14,7 +14,9 @@
  * @returns A tuple containing two records, the first one containing all entries
  * that match the predicate and the second one containing all that do not.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { partitionEntries } from "@std/collections/partition-entries";
  * import { assertEquals } from "@std/assert";

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -12,7 +12,9 @@
  *
  * @returns An array of all possible permutations of the given array.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { permutations } from "@std/collections/permutations";
  * import { assertEquals } from "@std/assert";

--- a/collections/pick.ts
+++ b/collections/pick.ts
@@ -13,7 +13,9 @@
  *
  * @returns A new object with the specified keys from the provided object.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { pick } from "@std/collections/pick";
  * import { assertEquals } from "@std/assert";

--- a/collections/reduce_groups.ts
+++ b/collections/reduce_groups.ts
@@ -18,7 +18,9 @@ import { mapValues } from "./map_values.ts";
  * @returns A record with the same keys as the input grouping, where each value
  * is the result of applying the reducer to the respective group.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { reduceGroups } from "@std/collections/reduce-groups";
  * import { assertEquals } from "@std/assert";

--- a/collections/running_reduce.ts
+++ b/collections/running_reduce.ts
@@ -15,7 +15,9 @@
  *
  * @returns An array of all intermediate accumulator results.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { runningReduce } from "@std/collections/running-reduce";
  * import { assertEquals } from "@std/assert";

--- a/collections/sample.ts
+++ b/collections/sample.ts
@@ -19,7 +19,9 @@ function randomInteger(lower: number, upper: number): number {
  * @returns A random element from the given array, or `undefined` if the array
  * is empty.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { sample } from "@std/collections/sample";
  * import { assertArrayIncludes } from "@std/assert";

--- a/collections/sliding_windows.ts
+++ b/collections/sliding_windows.ts
@@ -37,7 +37,9 @@ export interface SlidingWindowsOptions {
  *
  * @returns A new array containing all sliding windows of the given size.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { slidingWindows } from "@std/collections/sliding-windows";
  * import { assertEquals } from "@std/assert";

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -28,7 +28,9 @@ export type SortByOptions = {
  *
  * @returns A new array containing all elements sorted by the selector.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { sortBy } from "@std/collections/sort-by";
  * import { assertEquals } from "@std/assert";
@@ -74,7 +76,9 @@ export function sortBy<T>(
  *
  * @returns A new array containing all elements sorted by the selector.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { sortBy } from "@std/collections/sort-by";
  * import { assertEquals } from "@std/assert";
@@ -112,7 +116,9 @@ export function sortBy<T>(
  *
  * @returns A new array containing all elements sorted by the selector.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { sortBy } from "@std/collections/sort-by";
  * import { assertEquals } from "@std/assert";
@@ -152,7 +158,9 @@ export function sortBy<T>(
  *
  * @returns A new array containing all elements sorted by the selector.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { sortBy } from "@std/collections/sort-by";
  * import { assertEquals } from "@std/assert";

--- a/collections/sum_of.ts
+++ b/collections/sum_of.ts
@@ -12,7 +12,9 @@
  *
  * @returns The sum of all elements in the collection.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { sumOf } from "@std/collections/sum-of";
  * import { assertEquals } from "@std/assert";

--- a/collections/take_last_while.ts
+++ b/collections/take_last_while.ts
@@ -14,7 +14,9 @@
  * @returns A new array containing all elements after the last element that does
  * not match the predicate.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { takeLastWhile } from "@std/collections/take-last-while";
  * import { assertEquals } from "@std/assert";

--- a/collections/take_while.ts
+++ b/collections/take_while.ts
@@ -14,7 +14,9 @@
  * @returns A new array containing all elements until the first element that
  * does not match the predicate.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { takeWhile } from "@std/collections/take-while";
  * import { assertEquals } from "@std/assert";

--- a/collections/union.ts
+++ b/collections/union.ts
@@ -10,7 +10,9 @@
  *
  * @returns A new array containing all distinct elements from the given arrays.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { union } from "@std/collections/union";
  * import { assertEquals } from "@std/assert";

--- a/collections/unzip.ts
+++ b/collections/unzip.ts
@@ -14,7 +14,9 @@
  * @returns A tuple containing two arrays, the first one holding all first tuple
  * elements and the second one holding all second elements.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { unzip } from "@std/collections/unzip";
  * import { assertEquals } from "@std/assert";

--- a/collections/without_all.ts
+++ b/collections/without_all.ts
@@ -12,7 +12,9 @@
  * @returns A new array containing all elements from the given array except the
  * ones that are in the values array.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { withoutAll } from "@std/collections/without-all";
  * import { assertEquals } from "@std/assert";

--- a/collections/zip.ts
+++ b/collections/zip.ts
@@ -13,7 +13,9 @@ import { minOf } from "./min_of.ts";
  *
  * @returns A new array containing N-tuples of elements from the given arrays.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { zip } from "@std/collections/zip";
  * import { assertEquals } from "@std/assert";

--- a/crypto/crypto.ts
+++ b/crypto/crypto.ts
@@ -83,7 +83,8 @@
  * );
  * ```
  *
- * @example Convert hash to a string
+ * @example
+ * <caption>Convert hash to a string</caption>
  *
  * ```ts
  * import {

--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -23,7 +23,9 @@ function toDataView(
  * {@link https://github.com/w3c/webcrypto/issues/270 | w3c/webcrypto#270}), but until
  * that time, `timingSafeEqual()` is provided:
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { timingSafeEqual } from "@std/crypto/timing-safe-equal";
  * import { assert } from "@std/assert";

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -309,7 +309,9 @@ export interface ParseOptions {
  * Csv parse helper to manipulate data.
  * Provides an auto/custom mapper for columns.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/csv/parse";
  * import { assertEquals } from "@std/assert";
@@ -327,7 +329,9 @@ export function parse(input: string): string[][];
  * Csv parse helper to manipulate data.
  * Provides an auto/custom mapper for columns.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/csv/parse";
  * import { assertEquals } from "@std/assert";

--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -108,7 +108,9 @@ export type RowType<T> = T extends undefined ? string[]
  * A `CsvParseStream` expects input conforming to
  * {@link https://www.rfc-editor.org/rfc/rfc4180.html | RFC 4180}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { CsvParseStream } from "@std/csv/parse-stream";
  *
@@ -219,7 +221,9 @@ export class CsvParseStream<
   /**
    * The instance's {@linkcode ReadableStream}.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-assert
    * import { CsvParseStream } from "@std/csv/parse-stream";
    *
@@ -245,7 +249,9 @@ export class CsvParseStream<
   /**
    * The instance's {@linkcode WritableStream}.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-assert
    * import { CsvParseStream } from "@std/csv/parse-stream";
    *

--- a/csv/stringify.ts
+++ b/csv/stringify.ts
@@ -219,7 +219,9 @@ function getValuesFromItem(
 /**
  * Converts an array of objects into a CSV string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   Column,

--- a/csv/stringify_stream.ts
+++ b/csv/stringify_stream.ts
@@ -24,7 +24,9 @@ export interface CsvStringifyStreamOptions {
 /**
  * Convert each chunk to a CSV record.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { CsvStringifyStream } from "@std/csv/stringify-stream";
  *

--- a/data_structures/binary_heap.ts
+++ b/data_structures/binary_heap.ts
@@ -26,7 +26,9 @@ function getParentIndex(index: number) {
  * | pop()       | O(log n)     | O(log n)   |
  * | push(value) | O(1)         | O(log n)   |
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   ascend,
@@ -80,7 +82,9 @@ export class BinaryHeap<T> implements Iterable<T> {
   /**
    * Returns the underlying cloned array in arbitrary order without sorting.
    *
-   * @example Getting the underlying array
+   * @example
+   * <caption>Getting the underlying array</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -105,21 +109,27 @@ export class BinaryHeap<T> implements Iterable<T> {
    * unless a {@link BinaryHeap} is passed, in which case the comparison
    * function is copied from the input heap.
    *
-   * @example Creating a binary heap from an array like
+   * @example
+   * <caption>Creating a binary heap from an array like</caption>
+
    * ```ts no-assert
    * import { BinaryHeap } from "@std/data-structures";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2]);
    * ```
    *
-   * @example Creating a binary heap from an iterable object
+   * @example
+   * <caption>Creating a binary heap from an iterable object</caption>
+
    * ```ts no-assert
    * import { BinaryHeap } from "@std/data-structures";
    *
    * const heap = BinaryHeap.from((function*() { yield* [4, 1, 3, 5, 2]; })());
    * ```
    *
-   * @example Creating a binary heap from an existing binary heap
+   * @example
+   * <caption>Creating a binary heap from an existing binary heap</caption>
+
    * ```ts no-assert
    * import { BinaryHeap } from "@std/data-structures";
    *
@@ -127,7 +137,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    * const copy = BinaryHeap.from(heap);
    * ```
    *
-   * @example Creating a binary heap from an array like with a custom comparison function
+   * @example
+   * <caption>Creating a binary heap from an array like with a custom comparison function</caption>
+
    * ```ts no-assert
    * import { BinaryHeap, ascend } from "@std/data-structures";
    *
@@ -158,7 +170,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    * function is copied from the input heap. The comparison operator is used to
    * sort the values in the heap after mapping the values.
    *
-   * @example Creating a binary heap from an array like with a custom mapping function
+   * @example
+   * <caption>Creating a binary heap from an array like with a custom mapping function</caption>
+
    * ```ts no-eval
    * import { BinaryHeap } from "@std/data-structures";
    *
@@ -217,7 +231,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    *
    * The complexity of this operation is O(1).
    *
-   * @example Getting the length of the binary heap
+   * @example
+   * <caption>Getting the length of the binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -239,7 +255,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    *
    * The complexity of this operation is O(1).
    *
-   * @example Getting the greatest value from the binary heap
+   * @example
+   * <caption>Getting the greatest value from the binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -249,7 +267,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    * assertEquals(heap.peek(), 5);
    * ```
    *
-   * @example Getting the greatest value from an empty binary heap
+   * @example
+   * <caption>Getting the greatest value from an empty binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -269,7 +289,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    * Remove the greatest value from the binary heap and return it, or return
    * undefined if the heap is empty.
    *
-   * @example Removing the greatest value from the binary heap
+   * @example
+   * <caption>Removing the greatest value from the binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -283,7 +305,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    * The complexity of this operation is on average and worst case O(log n),
    * where n is the count of values stored in the binary heap.
    *
-   * @example Removing the greatest value from an empty binary heap
+   * @example
+   * <caption>Removing the greatest value from an empty binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -325,7 +349,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    * The complexity of this operation is O(1) on average and O(log n) in the
    * worst case, where n is the count of values stored in the binary heap.
    *
-   * @example Adding values to the binary heap
+   * @example
+   * <caption>Adding values to the binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -359,7 +385,9 @@ export class BinaryHeap<T> implements Iterable<T> {
   /**
    * Remove all values from the binary heap.
    *
-   * @example Clearing the binary heap
+   * @example
+   * <caption>Clearing the binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -377,7 +405,9 @@ export class BinaryHeap<T> implements Iterable<T> {
   /**
    * Check if the binary heap is empty.
    *
-   * @example Checking if the binary heap is empty
+   * @example
+   * <caption>Checking if the binary heap is empty</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -405,7 +435,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    * {@link BinaryHeap.from} and then call {@link BinaryHeap.prototype.drain}
    * on the copy.
    *
-   * @example Draining the binary heap
+   * @example
+   * <caption>Draining the binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -428,7 +460,9 @@ export class BinaryHeap<T> implements Iterable<T> {
    * Create an iterator that retrieves values from the binary heap in order
    * from greatest to least. The binary heap is drained in the process.
    *
-   * @example Getting an iterator for the binary heap
+   * @example
+   * <caption>Getting an iterator for the binary heap</caption>
+
    * ```ts
    * import { BinaryHeap } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";

--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -24,7 +24,9 @@ type Direction = "left" | "right";
  * | min()         | O(log n)     | O(n)       |
  * | max()         | O(log n)     | O(n)       |
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   BinarySearchTree,
@@ -151,14 +153,18 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * unless a {@link BinarySearchTree} is passed, in which case the comparison
    * function is copied from the input tree.
    *
-   * @example Creating a binary search tree from an array like
+   * @example
+   * <caption>Creating a binary search tree from an array like</caption>
+
    * ```ts no-assert
    * import { BinarySearchTree } from "@std/data-structures";
    *
    * const tree = BinarySearchTree.from<number>([42, 43, 41]);
    * ```
    *
-   * @example Creating a binary search tree from an iterable object
+   * @example
+   * <caption>Creating a binary search tree from an iterable object</caption>
+
    * ```ts no-assert
    * import { BinarySearchTree } from "@std/data-structures";
    *
@@ -169,7 +175,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * })());
    * ```
    *
-   * @example Creating a binary search tree from an existing binary search tree
+   * @example
+   * <caption>Creating a binary search tree from an existing binary search tree</caption>
+
    * ```ts no-assert
    * import { BinarySearchTree } from "@std/data-structures";
    *
@@ -177,7 +185,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * const copy = BinarySearchTree.from(tree);
    * ```
    *
-   * @example Creating a binary search tree from an array like with a custom comparison function
+   * @example
+   * <caption>Creating a binary search tree from an array like with a custom comparison function</caption>
+
    * ```ts no-assert
    * import { BinarySearchTree, descend } from "@std/data-structures";
    *
@@ -213,7 +223,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * comparison operator is used to sort the values in the tree after mapping
    * the values.
    *
-   * @example Creating a binary search tree from an array like with a custom mapping function
+   * @example
+   * <caption>Creating a binary search tree from an array like with a custom mapping function</caption>
+
    * ```ts no-assert
    * import { BinarySearchTree } from "@std/data-structures";
    *
@@ -300,7 +312,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    *
    * The complexity of this operation is O(1).
    *
-   * @example Getting the size of the tree
+   * @example
+   * <caption>Getting the size of the tree</caption>
+
    * ```ts no-assert
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -417,7 +431,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * The complexity of this operation is on average O(log n), where n is the
    * number of values in the tree. In the worst case, the complexity is O(n).
    *
-   * @example Inserting values into the tree
+   * @example
+   * <caption>Inserting values into the tree</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -441,7 +457,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * The complexity of this operation is on average O(log n), where n is the
    * number of values in the tree. In the worst case, the complexity is O(n).
    *
-   * @example Removing values from the tree
+   * @example
+   * <caption>Removing values from the tree</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -467,7 +485,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * The complexity of this operation depends on the underlying structure of the
    * tree. Refer to the documentation of the structure itself for more details.
    *
-   * @example Finding values in the tree
+   * @example
+   * <caption>Finding values in the tree</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -492,7 +512,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * The complexity of this operation depends on the underlying structure of the
    * tree. Refer to the documentation of the structure itself for more details.
    *
-   * @example Finding the minimum value in the tree
+   * @example
+   * <caption>Finding the minimum value in the tree</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -515,7 +537,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * The complexity of this operation depends on the underlying structure of the
    * tree. Refer to the documentation of the structure itself for more details.
    *
-   * @example Finding the maximum value in the tree
+   * @example
+   * <caption>Finding the maximum value in the tree</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -536,7 +560,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    *
    * The complexity of this operation is O(1).
    *
-   * @example Clearing the tree
+   * @example
+   * <caption>Clearing the tree</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -558,7 +584,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    *
    * The complexity of this operation is O(1).
    *
-   * @example Checking if the tree is empty
+   * @example
+   * <caption>Checking if the tree is empty</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -582,7 +610,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * Create an iterator over this tree that traverses the tree in-order (LNR,
    * Left-Node-Right).
    *
-   * @example Using the in-order LNR iterator
+   * @example
+   * <caption>Using the in-order LNR iterator</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -613,7 +643,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * Create an iterator over this tree that traverses the tree in reverse
    * in-order (RNL, Right-Node-Left).
    *
-   * @example Using the reverse in-order RNL iterator
+   * @example
+   * <caption>Using the reverse in-order RNL iterator</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -643,7 +675,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * Create an iterator over this tree that traverses the tree in pre-order (NLR,
    * Node-Left-Right).
    *
-   * @example Using the pre-order NLR iterator
+   * @example
+   * <caption>Using the pre-order NLR iterator</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -670,7 +704,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * Create an iterator over this tree that traverses the tree in post-order (LRN,
    * Left-Right-Node).
    *
-   * @example Using the post-order LRN iterator
+   * @example
+   * <caption>Using the post-order LRN iterator</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -706,7 +742,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * Create an iterator over this tree that traverses the tree in level-order (BFS,
    * Breadth-First Search).
    *
-   * @example Using the level-order BFS iterator
+   * @example
+   * <caption>Using the level-order BFS iterator</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -733,7 +771,9 @@ export class BinarySearchTree<T> implements Iterable<T> {
    * Create an iterator over this tree that traverses the tree in-order (LNR,
    * Left-Node-Right).
    *
-   * @example Using the in-order iterator
+   * @example
+   * <caption>Using the in-order iterator</caption>
+
    * ```ts
    * import { BinarySearchTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";

--- a/data_structures/comparators.ts
+++ b/data_structures/comparators.ts
@@ -5,7 +5,9 @@
  * Compare two values in ascending order using JavaScript's built in comparison
  * operators.
  *
- * @example Comparing numbers
+ * @example
+ * <caption>Comparing numbers</caption>
+
  * ```ts
  * import { ascend } from "@std/data-structures";
  * import { assertEquals } from "@std/assert";
@@ -28,7 +30,9 @@ export function ascend<T>(a: T, b: T): -1 | 0 | 1 {
  * Compare two values in descending order using JavaScript's built in comparison
  * operators.
  *
- * @example Comparing numbers
+ * @example
+ * <caption>Comparing numbers</caption>
+
  * ```ts
  * import { descend } from "@std/data-structures";
  * import { assertEquals } from "@std/assert";

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -34,7 +34,9 @@ const {
  * | min()         | O(log n)     | O(log n)   |
  * | max()         | O(log n)     | O(log n)   |
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   ascend,
@@ -124,14 +126,18 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * unless a {@link RedBlackTree} is passed, in which case the comparison
    * function is copied from the input tree.
    *
-   * @example Creating a red-black tree from an array like
+   * @example
+   * <caption>Creating a red-black tree from an array like</caption>
+
    * ```ts no-assert
    * import { RedBlackTree } from "@std/data-structures";
    *
    * const tree = RedBlackTree.from<number>([3, 10, 13, 4, 6, 7, 1, 14]);
    * ```
    *
-   * @example Creating a red-black tree from an iterable object
+   * @example
+   * <caption>Creating a red-black tree from an iterable object</caption>
+
    * ```ts no-assert
    * import { RedBlackTree } from "@std/data-structures";
    *
@@ -142,7 +148,9 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * })());
    * ```
    *
-   * @example Creating a red-black tree from an existing red-black tree
+   * @example
+   * <caption>Creating a red-black tree from an existing red-black tree</caption>
+
    * ```ts no-assert
    * import { RedBlackTree } from "@std/data-structures";
    *
@@ -150,7 +158,9 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * const copy = RedBlackTree.from(tree);
    * ```
    *
-   * @example Creating a red-black tree from an array like with a custom comparison function
+   * @example
+   * <caption>Creating a red-black tree from an array like with a custom comparison function</caption>
+
    * ```ts no-assert
    * import { RedBlackTree, descend } from "@std/data-structures";
    *
@@ -185,7 +195,9 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * comparison operator is used to sort the values in the tree after mapping
    * the values.
    *
-   * @example Creating a red-black tree from an array like with a custom mapping function
+   * @example
+   * <caption>Creating a red-black tree from an array like with a custom mapping function</caption>
+
    * ```ts no-assert
    * import { RedBlackTree } from "@std/data-structures";
    *
@@ -312,7 +324,9 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * The complexity of this operation is on average and at worst O(log n), where
    * n is the number of values in the tree.
    *
-   * @example Inserting a value into the tree
+   * @example
+   * <caption>Inserting a value into the tree</caption>
+
    * ```ts
    * import { RedBlackTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";
@@ -369,7 +383,9 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
    * The complexity of this operation is on average and at worst O(log n), where
    * n is the number of values in the tree.
    *
-   * @example Removing values from the tree
+   * @example
+   * <caption>Removing values from the tree</caption>
+
    * ```ts
    * import { RedBlackTree } from "@std/data-structures";
    * import { assertEquals } from "@std/assert";

--- a/datetime/day_of_year.ts
+++ b/datetime/day_of_year.ts
@@ -9,7 +9,9 @@ import { DAY } from "./constants.ts";
  * @param date Date to get the day of the year of.
  * @return Number of the day in the year in the local time zone.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { dayOfYear } from "@std/datetime/day-of-year";
  * import { assertEquals } from "@std/assert";
@@ -36,7 +38,9 @@ export function dayOfYear(date: Date): number {
  * @param date Date to get the day of the year of.
  * @return Number of the day in the year in UTC time.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { dayOfYearUtc } from "@std/datetime/day-of-year";
  * import { assertEquals } from "@std/assert";

--- a/datetime/difference.ts
+++ b/datetime/difference.ts
@@ -47,7 +47,9 @@ function calculateMonthsDifference(from: Date, to: Date): number {
  * @param options Options such as units to calculate difference in.
  * @returns The difference of the 2 given dates in various units.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { difference } from "@std/datetime/difference";
  * import { assertEquals } from "@std/assert";

--- a/datetime/format.ts
+++ b/datetime/format.ts
@@ -45,7 +45,9 @@ export interface FormatOptions {
  * @param options The options to customize the formatting of the date.
  * @return The formatted date string.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-eval
  * import { format } from "@std/datetime/format";
  * import { assertEquals } from "@std/assert";

--- a/datetime/is_leap.ts
+++ b/datetime/is_leap.ts
@@ -19,7 +19,9 @@ function isYearNumberALeapYear(yearNumber: number): boolean {
  * @param year The year in number or `Date` format.
  * @returns `true` if the given year is a leap year; `false` otherwise.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { isLeap } from "@std/datetime/is-leap";
  * import { assertEquals } from "@std/assert";
@@ -33,7 +35,9 @@ function isYearNumberALeapYear(yearNumber: number): boolean {
  * assertEquals(isLeap(1972), true);
  * ```
  *
- * @example Accounting for timezones
+ * @example
+ * <caption>Accounting for timezones</caption>
+
  * ```ts no-assert
  * import { isLeap } from "@std/datetime/is-leap";
  *
@@ -60,7 +64,9 @@ export function isLeap(year: Date | number): boolean {
  * @param year The year in number or `Date` format.
  * @returns `true` if the given year is a leap year; `false` otherwise.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { isUtcLeap } from "@std/datetime/is-leap";
  * import { assertEquals } from "@std/assert";

--- a/datetime/parse.ts
+++ b/datetime/parse.ts
@@ -34,7 +34,9 @@ import { DateTimeFormatter } from "./_date_time_formatter.ts";
  * @param formatString The date time string format.
  * @return The parsed date.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { parse } from "@std/datetime/parse";
  * import { assertEquals } from "@std/assert";

--- a/datetime/week_of_year.ts
+++ b/datetime/week_of_year.ts
@@ -21,7 +21,9 @@ const Day = {
  * @param date Date to get the week number of.
  * @returns The week number of the provided date.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { weekOfYear } from "@std/datetime/week-of-year";
  * import { assertEquals } from "@std/assert";

--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -47,7 +47,9 @@ export interface LoadOptions {
 /**
  * Works identically to {@linkcode load}, but synchronously.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { loadSync } from "@std/dotenv";
  *
@@ -92,7 +94,9 @@ export function loadSync(
  *
  * Then import the environment variables using the `load` function.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-eval
  * // app.ts
  * import { load } from "@std/dotenv";
@@ -110,7 +114,9 @@ export function loadSync(
  * Import the `load.ts` module to auto-import from the `.env` file and into
  * the process environment.
  *
- * @example Auto-loading
+ * @example
+ * <caption>Auto-loading</caption>
+
  * ```ts no-eval
  * // app.ts
  * import "@std/dotenv/load";
@@ -140,7 +146,9 @@ export function loadSync(
  *
  * ### Example configuration
  *
- * @example Using with options
+ * @example
+ * <caption>Using with options</caption>
+
  * ```ts no-eval
  * import { load } from "@std/dotenv";
  *

--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -57,7 +57,9 @@ function expand(str: string, variablesMap: { [key: string]: string }): string {
 /**
  * Parse `.env` file output in an object.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/dotenv/parse";
  * import { assertEquals } from "@std/assert";

--- a/dotenv/stringify.ts
+++ b/dotenv/stringify.ts
@@ -4,7 +4,9 @@
 /**
  * Stringify an object into a valid `.env` file format.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { stringify } from "@std/dotenv/stringify";
  * import { assertEquals } from "@std/assert";

--- a/encoding/ascii85.ts
+++ b/encoding/ascii85.ts
@@ -58,7 +58,9 @@ const Z85 =
  *
  * @returns The ascii85-encoded string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { encodeAscii85 } from "@std/encoding/ascii85";
  * import { assertEquals } from "@std/assert";
@@ -142,7 +144,9 @@ export type DecodeAscii85Options = Omit<EncodeAscii85Options, "delimiter">;
  * @param options Options for decoding.
  * @returns The decoded data.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decodeAscii85 } from "@std/encoding/ascii85";
  * import { assertEquals } from "@std/assert";

--- a/encoding/base32.ts
+++ b/encoding/base32.ts
@@ -67,7 +67,9 @@ function getByteLength(validLen: number, placeHoldersLen: number): number {
  * @param b32 The base32-encoded string to decode.
  * @returns The decoded data.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decodeBase32 } from "@std/encoding/base32";
  * import { assertEquals } from "@std/assert";
@@ -176,7 +178,9 @@ function encodeChunk(uint8: Uint8Array, start: number, end: number): string {
  * @param data The data to encode.
  * @returns The base32-encoded string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { encodeBase32 } from "@std/encoding/base32";
  * import { assertEquals } from "@std/assert";

--- a/encoding/base58.ts
+++ b/encoding/base58.ts
@@ -43,7 +43,9 @@ const base58alphabet =
  * @param data The data to encode.
  * @returns The base58-encoded string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { encodeBase58 } from "@std/encoding/base58";
  * import { assertEquals } from "@std/assert";
@@ -109,7 +111,9 @@ export function encodeBase58(data: ArrayBuffer | Uint8Array | string): string {
  * @param b58 The base58-encoded string to decode.
  * @returns The decoded data.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decodeBase58 } from "@std/encoding/base58";
  * import { assertEquals } from "@std/assert";

--- a/encoding/base64.ts
+++ b/encoding/base64.ts
@@ -99,7 +99,9 @@ const base64abc = [
  * @param data The data to encode.
  * @returns The base64-encoded string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { encodeBase64 } from "@std/encoding/base64";
  * import { assertEquals } from "@std/assert";
@@ -152,7 +154,9 @@ export function encodeBase64(data: ArrayBuffer | Uint8Array | string): string {
  * @param b64 The base64-encoded string to decode.
  * @returns The decoded data.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decodeBase64 } from "@std/encoding/base64";
  * import { assertEquals } from "@std/assert";

--- a/encoding/base64url.ts
+++ b/encoding/base64url.ts
@@ -50,7 +50,9 @@ function convertBase64ToBase64url(b64: string) {
  * @param data The data to encode.
  * @returns The base64url-encoded string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { encodeBase64Url } from "@std/encoding/base64url";
  * import { assertEquals } from "@std/assert";
@@ -72,7 +74,9 @@ export function encodeBase64Url(
  * @param b64url The base64url-encoded string to decode.
  * @returns The decoded data.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decodeBase64Url } from "@std/encoding/base64url";
  * import { assertEquals } from "@std/assert";

--- a/encoding/hex.ts
+++ b/encoding/hex.ts
@@ -59,7 +59,9 @@ function fromHexChar(byte: number): number {
  *
  * @returns The hex-encoded string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { encodeHex } from "@std/encoding/hex";
  * import { assertEquals } from "@std/assert";
@@ -87,7 +89,9 @@ export function encodeHex(src: string | Uint8Array | ArrayBuffer): string {
  *
  * @returns The decoded data.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decodeHex } from "@std/encoding/hex";
  * import { assertEquals } from "@std/assert";

--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -71,7 +71,9 @@ const U64_VIEW = new BigUint64Array(AB);
  * @param offset The offset to start decoding from.
  * @returns A tuple of the decoded varint 64-bit number, and the new offset.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decodeVarint } from "@std/encoding/varint";
  * import { assertEquals } from "@std/assert";
@@ -157,7 +159,9 @@ export function decodeVarint(buf: Uint8Array, offset = 0): [bigint, number] {
  * @param offset The offset to start decoding from.
  * @returns A tuple of the decoded varint 32-bit number, and the new offset.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decodeVarint32 } from "@std/encoding/varint";
  * import { assertEquals } from "@std/assert";
@@ -199,7 +203,9 @@ export function decodeVarint32(buf: Uint8Array, offset = 0): [number, number] {
  * @param offset The offset to start writing at.
  * @returns A tuple of the encoded Varint `Uint8Array` and the new offset.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { encodeVarint } from "@std/encoding/varint";
  * import { assertEquals } from "@std/assert";

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -112,7 +112,9 @@ const matchers: Record<MatcherKey, Matcher> = {
  * The `expect` function is used to test a value. You will use `expect` along with a
  * "matcher" function to assert something about a value.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { expect } from "@std/expect";
  *

--- a/expect/fn.ts
+++ b/expect/fn.ts
@@ -29,7 +29,9 @@ import { MOCK_SYMBOL, type MockCall } from "./_mock_util.ts";
  * @param stubs Functions to be used as stubs for different calls.
  * @returns A mock function that keeps track of calls and returns values based on the provided stubs.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { fn, expect } from "@std/expect";
  *

--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -92,7 +92,8 @@ export interface FormatOptions {
  * assertEquals(format(100), "100 B");
  * ```
  *
- * @example Include bits representation
+ * @example
+ * <caption>Include bits representation</caption>
  *
  * ```ts
  * import { format } from "@std/fmt/bytes";
@@ -101,7 +102,8 @@ export interface FormatOptions {
  * assertEquals(format(1337, { bits: true }), "1.34 kbit");
  * ```
  *
- * @example Include sign
+ * @example
+ * <caption>Include sign</caption>
  *
  * ```ts
  * import { format } from "@std/fmt/bytes";
@@ -111,7 +113,8 @@ export interface FormatOptions {
  * assertEquals(format(-42, { signed: true }), "-42 B");
  * ```
  *
- * @example Change locale
+ * @example
+ * <caption>Change locale</caption>
  *
  * ```ts
  * import { format } from "@std/fmt/bytes";

--- a/fmt/bytes.ts
+++ b/fmt/bytes.ts
@@ -81,7 +81,9 @@ export interface FormatOptions {
  * @param options The options for formatting
  * @returns The formatted string
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { format } from "@std/fmt/bytes";
  * import { assertEquals } from "@std/assert";

--- a/fmt/colors.ts
+++ b/fmt/colors.ts
@@ -83,7 +83,9 @@ let enabled = !noColor;
  * and disables text color. Use this API only when the automatic detection
  * doesn't work.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { setColorEnabled } from "@std/fmt/colors";
  *
@@ -107,7 +109,9 @@ export function setColorEnabled(value: boolean) {
 /**
  * Get whether text color change is enabled or disabled.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { getColorEnabled } from "@std/fmt/colors";
  *
@@ -146,7 +150,9 @@ function run(str: string, code: Code): string {
 /**
  * Reset the text modified.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { reset } from "@std/fmt/colors";
  *
@@ -163,7 +169,9 @@ export function reset(str: string): string {
 /**
  * Make the text bold.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bold } from "@std/fmt/colors";
  *
@@ -180,7 +188,9 @@ export function bold(str: string): string {
 /**
  * The text emits only a small amount of light.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { dim } from "@std/fmt/colors";
  *
@@ -200,7 +210,9 @@ export function dim(str: string): string {
 /**
  * Make the text italic.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { italic } from "@std/fmt/colors";
  *
@@ -217,7 +229,9 @@ export function italic(str: string): string {
 /**
  * Make the text underline.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { underline } from "@std/fmt/colors";
  *
@@ -234,7 +248,9 @@ export function underline(str: string): string {
 /**
  * Invert background color and text color.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { inverse } from "@std/fmt/colors";
  *
@@ -251,7 +267,9 @@ export function inverse(str: string): string {
 /**
  * Make the text hidden.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { hidden } from "@std/fmt/colors";
  *
@@ -268,7 +286,9 @@ export function hidden(str: string): string {
 /**
  * Put horizontal line through the center of the text.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { strikethrough } from "@std/fmt/colors";
  *
@@ -285,7 +305,9 @@ export function strikethrough(str: string): string {
 /**
  * Set text color to black.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { black } from "@std/fmt/colors";
  *
@@ -302,7 +324,9 @@ export function black(str: string): string {
 /**
  * Set text color to red.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { red } from "@std/fmt/colors";
  *
@@ -319,7 +343,9 @@ export function red(str: string): string {
 /**
  * Set text color to green.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { green } from "@std/fmt/colors";
  *
@@ -336,7 +362,9 @@ export function green(str: string): string {
 /**
  * Set text color to yellow.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { yellow } from "@std/fmt/colors";
  *
@@ -353,7 +381,9 @@ export function yellow(str: string): string {
 /**
  * Set text color to blue.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { blue } from "@std/fmt/colors";
  *
@@ -370,7 +400,9 @@ export function blue(str: string): string {
 /**
  * Set text color to magenta.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { magenta } from "@std/fmt/colors";
  *
@@ -387,7 +419,9 @@ export function magenta(str: string): string {
 /**
  * Set text color to cyan.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { cyan } from "@std/fmt/colors";
  *
@@ -404,7 +438,9 @@ export function cyan(str: string): string {
 /**
  * Set text color to white.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { white } from "@std/fmt/colors";
  *
@@ -421,7 +457,9 @@ export function white(str: string): string {
 /**
  * Set text color to gray.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { gray } from "@std/fmt/colors";
  *
@@ -438,7 +476,9 @@ export function gray(str: string): string {
 /**
  * Set text color to bright black.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightBlack } from "@std/fmt/colors";
  *
@@ -455,7 +495,9 @@ export function brightBlack(str: string): string {
 /**
  * Set text color to bright red.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightRed } from "@std/fmt/colors";
  *
@@ -472,7 +514,9 @@ export function brightRed(str: string): string {
 /**
  * Set text color to bright green.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightGreen } from "@std/fmt/colors";
  *
@@ -489,7 +533,9 @@ export function brightGreen(str: string): string {
 /**
  * Set text color to bright yellow.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightYellow } from "@std/fmt/colors";
  *
@@ -506,7 +552,9 @@ export function brightYellow(str: string): string {
 /**
  * Set text color to bright blue.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightBlue } from "@std/fmt/colors";
  *
@@ -523,7 +571,9 @@ export function brightBlue(str: string): string {
 /**
  * Set text color to bright magenta.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightMagenta } from "@std/fmt/colors";
  *
@@ -540,7 +590,9 @@ export function brightMagenta(str: string): string {
 /**
  * Set text color to bright cyan.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightCyan } from "@std/fmt/colors";
  *
@@ -557,7 +609,9 @@ export function brightCyan(str: string): string {
 /**
  * Set text color to bright white.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightWhite } from "@std/fmt/colors";
  *
@@ -574,7 +628,9 @@ export function brightWhite(str: string): string {
 /**
  * Set background color to black.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBlack } from "@std/fmt/colors";
  *
@@ -591,7 +647,9 @@ export function bgBlack(str: string): string {
 /**
  * Set background color to red.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgRed } from "@std/fmt/colors";
  *
@@ -608,7 +666,9 @@ export function bgRed(str: string): string {
 /**
  * Set background color to green.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgGreen } from "@std/fmt/colors";
  *
@@ -625,7 +685,9 @@ export function bgGreen(str: string): string {
 /**
  * Set background color to yellow.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgYellow } from "@std/fmt/colors";
  *
@@ -642,7 +704,9 @@ export function bgYellow(str: string): string {
 /**
  * Set background color to blue.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBlue } from "@std/fmt/colors";
  *
@@ -659,7 +723,9 @@ export function bgBlue(str: string): string {
 /**
  *  Set background color to magenta.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgMagenta } from "@std/fmt/colors";
  *
@@ -676,7 +742,9 @@ export function bgMagenta(str: string): string {
 /**
  * Set background color to cyan.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgCyan } from "@std/fmt/colors";
  *
@@ -693,7 +761,9 @@ export function bgCyan(str: string): string {
 /**
  * Set background color to white.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgWhite } from "@std/fmt/colors";
  *
@@ -710,7 +780,9 @@ export function bgWhite(str: string): string {
 /**
  * Set background color to bright black.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBrightBlack } from "@std/fmt/colors";
  *
@@ -727,7 +799,9 @@ export function bgBrightBlack(str: string): string {
 /**
  * Set background color to bright red.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBrightRed } from "@std/fmt/colors";
  *
@@ -744,7 +818,9 @@ export function bgBrightRed(str: string): string {
 /**
  * Set background color to bright green.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBrightGreen } from "@std/fmt/colors";
  *
@@ -761,7 +837,9 @@ export function bgBrightGreen(str: string): string {
 /**
  * Set background color to bright yellow.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBrightYellow } from "@std/fmt/colors";
  *
@@ -778,7 +856,9 @@ export function bgBrightYellow(str: string): string {
 /**
  * Set background color to bright blue.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBrightBlue } from "@std/fmt/colors";
  *
@@ -795,7 +875,9 @@ export function bgBrightBlue(str: string): string {
 /**
  * Set background color to bright magenta.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBrightMagenta } from "@std/fmt/colors";
  *
@@ -812,7 +894,9 @@ export function bgBrightMagenta(str: string): string {
 /**
  * Set background color to bright cyan.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBrightCyan } from "@std/fmt/colors";
  *
@@ -829,7 +913,9 @@ export function bgBrightCyan(str: string): string {
 /**
  * Set background color to bright white.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgBrightWhite } from "@std/fmt/colors";
  *
@@ -859,7 +945,9 @@ function clampAndTruncate(n: number, max = 255, min = 0): number {
  * Set text color using paletted 8bit colors.
  * https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { rgb8 } from "@std/fmt/colors";
  *
@@ -878,7 +966,9 @@ export function rgb8(str: string, color: number): string {
  * Set background color using paletted 8bit colors.
  * https://en.wikipedia.org/wiki/ANSI_escape_code#8-bit
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgRgb8 } from "@std/fmt/colors";
  *
@@ -898,7 +988,9 @@ export function bgRgb8(str: string, color: number): string {
  * `color` can be a number in range `0x000000` to `0xffffff` or
  * an `Rgb`.
  *
- * @example To produce the color magenta:
+ * @example
+ * <caption>To produce the color magenta:</caption>
+
  * ```ts no-assert
  * import { rgb24 } from "@std/fmt/colors";
  *
@@ -939,7 +1031,9 @@ export function rgb24(str: string, color: number | Rgb): string {
  * `color` can be a number in range `0x000000` to `0xffffff` or
  * an `Rgb`.
  *
- * @example To produce the color magenta:
+ * @example
+ * <caption>To produce the color magenta:</caption>
+
  * ```ts no-assert
  * import { bgRgb24 } from "@std/fmt/colors";
  *
@@ -987,7 +1081,9 @@ const ANSI_PATTERN = new RegExp(
 /**
  * Remove ANSI escape codes from the string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { stripAnsiCode, red } from "@std/fmt/colors";
  *

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -92,7 +92,9 @@ export interface PrettyDurationOptions {
 /**
  * Format milliseconds to time duration.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { format } from "@std/fmt/duration";
  * import { assertEquals } from "@std/assert";

--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -931,7 +931,9 @@ class Printf {
  *
  * See the module documentation for the available format strings.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { sprintf } from "@std/fmt/printf";
  * import { assertEquals } from "@std/assert";
@@ -960,7 +962,9 @@ export function sprintf(format: string, ...args: unknown[]): string {
  *
  * See the module documentation for the available format strings.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { printf } from "@std/fmt/printf";
  *

--- a/front_matter/json.ts
+++ b/front_matter/json.ts
@@ -10,7 +10,9 @@ export type { Extract };
  * Extracts and parses {@link https://www.json.org/ | JSON } from the metadata
  * of front matter content.
  *
- * @example Extract JSON front matter
+ * @example
+ * <caption>Extract JSON front matter</caption>
+
  * ```ts
  * import { extract } from "@std/front-matter/json";
  * import { assertEquals } from "@std/assert";

--- a/front_matter/test.ts
+++ b/front_matter/test.ts
@@ -14,7 +14,9 @@ export type { Format };
  * @param formats A list of formats to test for. Defaults to all supported formats.
  * @returns `true` if the string has valid front matter, otherwise `false`.
  *
- * @example Test for valid YAML front matter
+ * @example
+ * <caption>Test for valid YAML front matter</caption>
+
  * ```ts
  * import { test } from "@std/front-matter/test";
  * import { assert } from "@std/assert";
@@ -27,7 +29,9 @@ export type { Format };
  * assert(result);
  * ```
  *
- * @example Test for valid TOML front matter
+ * @example
+ * <caption>Test for valid TOML front matter</caption>
+
  * ```ts
  * import { test } from "@std/front-matter/test";
  * import { assert } from "@std/assert";
@@ -40,7 +44,9 @@ export type { Format };
  * assert(result);
  * ```
  *
- * @example Test for valid JSON front matter
+ * @example
+ * <caption>Test for valid JSON front matter</caption>
+
  * ```ts
  * import { test } from "@std/front-matter/test";
  * import { assert } from "@std/assert";
@@ -53,7 +59,9 @@ export type { Format };
  * assert(result);
  * ```
  *
- * @example JSON front matter is not valid as YAML
+ * @example
+ * <caption>JSON front matter is not valid as YAML</caption>
+
  * ```ts
  * import { test } from "@std/front-matter/test";
  * import { assertFalse } from "@std/assert";

--- a/front_matter/toml.ts
+++ b/front_matter/toml.ts
@@ -11,7 +11,9 @@ export type { Extract };
  * Extracts and parses {@link https://toml.io | TOML} from the metadata of
  * front matter content.
  *
- * @example Extract TOML front matter
+ * @example
+ * <caption>Extract TOML front matter</caption>
+
  * ```ts
  * import { extract } from "@std/front-matter/toml";
  * import { assertEquals } from "@std/assert";

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -11,7 +11,9 @@ export type { Extract };
  * Extracts and parses {@link https://yaml.org | YAML} from the metadata of
  * front matter content.
  *
- * @example Extract YAML front matter
+ * @example
+ * <caption>Extract YAML front matter</caption>
+
  * ```ts
  * import { extract } from "@std/front-matter/yaml";
  * import { assertEquals } from "@std/assert";

--- a/fs/copy.ts
+++ b/fs/copy.ts
@@ -274,7 +274,9 @@ function copyDirSync(
  *
  * @returns A promise that resolves once the copy operation completes.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-eval
  * import { copy } from "@std/fs/copy";
  *
@@ -284,7 +286,9 @@ function copyDirSync(
  * This will copy the file or directory at `./foo` to `./bar` without
  * overwriting.
  *
- * @example Overwriting files/directories
+ * @example
+ * <caption>Overwriting files/directories</caption>
+
  * ```ts no-eval
  * import { copy } from "@std/fs/copy";
  *
@@ -294,7 +298,9 @@ function copyDirSync(
  * This will copy the file or directory at `./foo` to `./bar` and overwrite
  * any existing files or directories.
  *
- * @example Preserving timestamps
+ * @example
+ * <caption>Preserving timestamps</caption>
+
  * ```ts no-eval
  * import { copy } from "@std/fs/copy";
  *
@@ -350,7 +356,9 @@ export async function copy(
  *
  * @returns A void value that returns once the copy operation completes.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-eval
  * import { copySync } from "@std/fs/copy";
  *
@@ -360,7 +368,9 @@ export async function copy(
  * This will copy the file or directory at `./foo` to `./bar` without
  * overwriting.
  *
- * @example Overwriting files/directories
+ * @example
+ * <caption>Overwriting files/directories</caption>
+
  * ```ts no-eval
  * import { copySync } from "@std/fs/copy";
  *
@@ -370,7 +380,9 @@ export async function copy(
  * This will copy the file or directory at `./foo` to `./bar` and overwrite
  * any existing files or directories.
  *
- * @example Preserving timestamps
+ * @example
+ * <caption>Preserving timestamps</caption>
+
  * ```ts no-eval
  * import { copySync } from "@std/fs/copy";
  *

--- a/fs/empty_dir.ts
+++ b/fs/empty_dir.ts
@@ -17,7 +17,9 @@ import { toPathString } from "./_to_path_string.ts";
  *
  * @returns A void promise that resolves once the directory is empty.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { emptyDir } from "@std/fs/empty-dir";
  *
@@ -60,7 +62,9 @@ export async function emptyDir(dir: string | URL) {
  *
  * @returns A void value that returns once the directory is empty.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { emptyDirSync } from "@std/fs/empty-dir";
  *

--- a/fs/ensure_dir.ts
+++ b/fs/ensure_dir.ts
@@ -17,7 +17,9 @@ import { getFileInfoType } from "./_get_file_info_type.ts";
  *
  * @returns A promise that resolves once the directory exists.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { ensureDir } from "@std/fs/ensure-dir";
  *
@@ -65,7 +67,9 @@ export async function ensureDir(dir: string | URL) {
  *
  * @returns A void value that returns once the directory exists.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { ensureDirSync } from "@std/fs/ensure-dir";
  *

--- a/fs/ensure_file.ts
+++ b/fs/ensure_file.ts
@@ -19,7 +19,9 @@ import { toPathString } from "./_to_path_string.ts";
  *
  * @returns A void promise that resolves once the file exists.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { ensureFile } from "@std/fs/ensure-file";
  *
@@ -64,7 +66,9 @@ export async function ensureFile(filePath: string | URL): Promise<void> {
  *
  * @returns A void value that returns once the file exists.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { ensureFileSync } from "@std/fs/ensure-file";
  *

--- a/fs/ensure_link.ts
+++ b/fs/ensure_link.ts
@@ -19,7 +19,9 @@ import { toPathString } from "./_to_path_string.ts";
  *
  * @returns A void promise that resolves once the hard link exists.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { ensureLink } from "@std/fs/ensure-link";
  *
@@ -49,7 +51,9 @@ export async function ensureLink(src: string | URL, dest: string | URL) {
  *
  * @returns A void value that returns once the hard link exists.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { ensureLinkSync } from "@std/fs/ensure-link";
  *

--- a/fs/ensure_symlink.ts
+++ b/fs/ensure_symlink.ts
@@ -40,7 +40,9 @@ function getSymlinkOption(
  *
  * @returns A void promise that resolves once the link exists.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { ensureSymlink } from "@std/fs/ensure-symlink";
  *
@@ -99,7 +101,9 @@ export async function ensureSymlink(
  * @param linkName The destination link path as a string or URL.
  * @returns A void value that returns once the link exists.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { ensureSymlinkSync } from "@std/fs/ensure-symlink";
  *

--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -9,7 +9,9 @@ export const CRLF = "\r\n" as const;
 /**
  * End-of-line character evaluated for the current platform.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { EOL } from "@std/fs/eol";
  *
@@ -28,7 +30,9 @@ const regDetect = /(?:\r?\n)/g;
  *
  * @returns The detected EOL character(s) or `null` if no EOL character is detected.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { detect } from "@std/fs/eol";
  *
@@ -56,7 +60,9 @@ export function detect(content: string): typeof EOL | null {
  *
  * @returns The input string normalized to the targeted EOL.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { LF, format } from "@std/fs/eol";
  *

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -47,7 +47,9 @@ export interface ExistsOptions {
  * @returns A promise that resolves with `true` if the path exists, `false`
  * otherwise.
  *
- * @example Recommended method
+ * @example
+ * <caption>Recommended method</caption>
+
  * ```ts no-eval
  * // Notice no use of exists
  * try {
@@ -63,7 +65,9 @@ export interface ExistsOptions {
  * Notice that `exists()` is not used in the above example. Doing so avoids a
  * possible race condition. See the above note for details.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -71,7 +75,9 @@ export interface ExistsOptions {
  * await exists("./does_not_exist"); // false
  * ```
  *
- * @example Check if a path is readable
+ * @example
+ * <caption>Check if a path is readable</caption>
+
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -79,7 +85,9 @@ export interface ExistsOptions {
  * await exists("./not_readable", { isReadable: true }); // false
  * ```
  *
- * @example Check if a path is a directory
+ * @example
+ * <caption>Check if a path is a directory</caption>
+
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -87,7 +95,9 @@ export interface ExistsOptions {
  * await exists("./file", { isDirectory: true }); // false
  * ```
  *
- * @example Check if a path is a file
+ * @example
+ * <caption>Check if a path is a file</caption>
+
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -95,7 +105,9 @@ export interface ExistsOptions {
  * await exists("./directory", { isFile: true }); // false
  * ```
  *
- * @example Check if a path is a readable directory
+ * @example
+ * <caption>Check if a path is a readable directory</caption>
+
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -103,7 +115,9 @@ export interface ExistsOptions {
  * await exists("./not_readable_directory", { isReadable: true, isDirectory: true }); // false
  * ```
  *
- * @example Check if a path is a readable file
+ * @example
+ * <caption>Check if a path is a readable file</caption>
+
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -176,7 +190,9 @@ export async function exists(
  *
  * @returns `true` if the path exists, `false` otherwise.
  *
- * @example Recommended method
+ * @example
+ * <caption>Recommended method</caption>
+
  * ```ts no-eval
  * // Notice no use of exists
  * try {
@@ -192,7 +208,9 @@ export async function exists(
  * Notice that `existsSync()` is not used in the above example. Doing so avoids
  * a possible race condition. See the above note for details.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *
@@ -200,7 +218,9 @@ export async function exists(
  * existsSync("./does_not_exist"); // false
  * ```
  *
- * @example Check if a path is readable
+ * @example
+ * <caption>Check if a path is readable</caption>
+
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *
@@ -208,7 +228,9 @@ export async function exists(
  * existsSync("./not_readable", { isReadable: true }); // false
  * ```
  *
- * @example Check if a path is a directory
+ * @example
+ * <caption>Check if a path is a directory</caption>
+
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *
@@ -216,7 +238,9 @@ export async function exists(
  * existsSync("./file", { isDirectory: true }); // false
  * ```
  *
- * @example Check if a path is a file
+ * @example
+ * <caption>Check if a path is a file</caption>
+
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *
@@ -224,7 +248,9 @@ export async function exists(
  * existsSync("./directory", { isFile: true }); // false
  * ```
  *
- * @example Check if a path is a readable directory
+ * @example
+ * <caption>Check if a path is a readable directory</caption>
+
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *
@@ -232,7 +258,9 @@ export async function exists(
  * existsSync("./not_readable_directory", { isReadable: true, isDirectory: true }); // false
  * ```
  *
- * @example Check if a path is a readable file
+ * @example
+ * <caption>Check if a path is a readable file</caption>
+
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *

--- a/fs/move.ts
+++ b/fs/move.ts
@@ -31,7 +31,9 @@ export interface MoveOptions {
  *
  * @returns A void promise that resolves once the operation completes.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-eval
  * import { move } from "@std/fs/move";
  *
@@ -41,7 +43,9 @@ export interface MoveOptions {
  * This will move the file or directory at `./foo` to `./bar` without
  * overwriting.
  *
- * @example Overwriting
+ * @example
+ * <caption>Overwriting</caption>
+
  * ```ts no-eval
  * import { move } from "@std/fs/move";
  *
@@ -107,7 +111,9 @@ export async function move(
  *
  * @returns A void value that returns once the operation completes.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts no-eval
  * import { moveSync } from "@std/fs/move";
  *
@@ -117,7 +123,9 @@ export async function move(
  * This will move the file or directory at `./foo` to `./bar` without
  * overwriting.
  *
- * @example Overwriting
+ * @example
+ * <caption>Overwriting</caption>
+
  * ```ts no-eval
  * import { moveSync } from "@std/fs/move";
  *

--- a/html/entities.ts
+++ b/html/entities.ts
@@ -25,7 +25,9 @@ const rawRe = new RegExp(`[${[...rawToEntity.keys()].join("")}]`, "g");
 /**
  * Escapes text for safe interpolation into HTML text content and quoted attributes.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { escape } from "@std/html/entities";
  * import { assertEquals } from "@std/assert";
@@ -63,7 +65,9 @@ const entityListRegexCache = new WeakMap<EntityList, RegExp>();
  *
  * Default options only handle `&<>'"` and numeric entities.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { unescape } from "@std/html/entities";
  * import { assertEquals } from "@std/assert";

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -235,7 +235,9 @@ function validateDomain(domain: string) {
 /**
  * Parse cookies of a header
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { getCookies } from "@std/http/cookie";
  * import { assertEquals } from "@std/assert";
@@ -271,7 +273,9 @@ export function getCookies(headers: Headers): Record<string, string> {
 /**
  * Set the cookie header properly in the headers
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { Cookie, setCookie } from "@std/http/cookie";
  * import { assertEquals } from "@std/assert";
@@ -306,7 +310,9 @@ export function setCookie(headers: Headers, cookie: Cookie) {
  * > Note: Deleting a `Cookie` will set its expiration date before now. Forcing
  * > the browser to delete it.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { deleteCookie } from "@std/http/cookie";
  * import { assertEquals } from "@std/assert";
@@ -427,7 +433,9 @@ function parseSetCookie(value: string): Cookie | null {
 /**
  * Parse set-cookies of a header
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { getSetCookies } from "@std/http/cookie";
  * import { assertEquals } from "@std/assert";

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -18,7 +18,8 @@ export interface Cookie {
    * milliseconds. If `undefined`, the cookie will expire when the client's
    * session ends.
    *
-   * @example <caption>Explicit date:</caption>
+   * @example
+   * <caption><caption>Explicit date:</caption></caption>
    *
    * ```ts
    * import { Cookie } from "@std/http/cookie";
@@ -30,7 +31,8 @@ export interface Cookie {
    * }
    * ```
    *
-   * @example <caption>UTC milliseconds</caption>
+   * @example
+   * <caption><caption>UTC milliseconds</caption></caption>
    *
    * ```ts
    * import { Cookie } from "@std/http/cookie";

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -99,7 +99,9 @@ async function calcFileInfo(
  * it will be fingerprinted as a "strong" tag, otherwise if it is just file
  * information, it will be calculated as a weak tag.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { eTag } from "@std/http/etag";
  * import { assert } from "@std/assert";
@@ -136,7 +138,9 @@ export async function eTag(
  * See MDN's [`If-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Match)
  * article for more information on how to use this function.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import {
  *   eTag,
@@ -184,7 +188,9 @@ export function ifMatch(
  * See MDN's [`If-None-Match`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match)
  * article for more information on how to use this function.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import {
  *   eTag,

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -154,7 +154,9 @@ export interface ServeFileOptions {
 /**
  * Resolves a {@linkcode Response} with the requested file as the body.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { serveFile } from "@std/http/file-server";
  *
@@ -598,7 +600,9 @@ export interface ServeDirOptions {
 /**
  * Serves the files under the given directory root (opts.fsRoot).
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { serveDir } from "@std/http/file-server";
  *

--- a/http/negotiation.ts
+++ b/http/negotiation.ts
@@ -17,7 +17,9 @@ import { preferredMediaTypes } from "./_negotiation/media_type.ts";
  * preference. If there are no media types supplied in the request, then any
  * media type selector will be returned.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { accepts } from "@std/http/negotiation";
  * import { assertEquals } from "@std/assert";
@@ -46,7 +48,9 @@ export function accepts(request: Request): string[];
  * For a given set of media types, return the best match accepted in the
  * request. If no media type matches, then the function returns `undefined`.
  *
- *  @example Usage
+ *  @example
+ *  <caption>Usage</caption>
+
  * ```ts
  * import { accepts } from "@std/http/negotiation";
  * import { assertEquals } from "@std/assert";
@@ -86,7 +90,9 @@ export function accepts(
  * preference. If there are no encoding supplied in the request, then `["*"]`
  * is returned, implying any encoding is accepted.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { acceptsEncodings } from "@std/http/negotiation";
  * import { assertEquals } from "@std/assert";
@@ -111,7 +117,9 @@ export function acceptsEncodings(request: Request): string[];
  * to ensure that there is a match when the `Accept-Encoding` header is part
  * of the request.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { acceptsEncodings } from "@std/http/negotiation";
  * import { assertEquals } from "@std/assert";
@@ -150,7 +158,9 @@ export function acceptsEncodings(
  * preference. If there are no languages supplied in the request, then `["*"]`
  * is returned, imply any language is accepted.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { acceptsLanguages } from "@std/http/negotiation";
  * import { assertEquals } from "@std/assert";
@@ -172,7 +182,9 @@ export function acceptsLanguages(request: Request): string[];
  * For a given set of languages, return the best match accepted in the request.
  * If no languages match, then the function returns `undefined`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { acceptsLanguages } from "@std/http/negotiation";
  * import { assertEquals } from "@std/assert";

--- a/http/server_sent_event_stream.ts
+++ b/http/server_sent_event_stream.ts
@@ -61,7 +61,9 @@ function stringify(message: ServerSentEventMessage): Uint8Array {
  *
  * @see {@link https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events}
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import {
  *   type ServerSentEventMessage,

--- a/http/signed_cookie.ts
+++ b/http/signed_cookie.ts
@@ -20,7 +20,9 @@ function splitByLast(value: string, separator: string): [string, string] {
  *
  * @experimental
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval no-assert
  * import { signCookie } from "@std/http/signed-cookie";
  * import { setCookie } from "@std/http/cookie";
@@ -63,7 +65,9 @@ export async function signCookie(
  *
  * @experimental
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval no-assert
  * import { verifySignedCookie } from "@std/http/signed-cookie";
  * import { getCookies } from "@std/http/cookie";
@@ -109,7 +113,9 @@ export async function verifySignedCookie(
  *
  * @experimental
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval no-assert
  * import { verifySignedCookie, parseSignedCookie } from "@std/http/signed-cookie";
  * import { getCookies } from "@std/http/cookie";

--- a/http/status.ts
+++ b/http/status.ts
@@ -6,7 +6,9 @@
  * status codes and provides several type guards for handling status codes
  * with type safety.
  *
- * @example The status code and status text
+ * @example
+ * <caption>The status code and status text</caption>
+
  * ```ts
  * import {
  *   STATUS_CODE,
@@ -17,7 +19,9 @@
  * console.log(STATUS_TEXT[STATUS_CODE.NotFound]); // Returns "Not Found"
  * ```
  *
- * @example Checking the status code type
+ * @example
+ * <caption>Checking the status code type</caption>
+
  * ```ts
  * import { isErrorStatus } from "@std/http/status";
  *
@@ -316,7 +320,9 @@ export type ErrorStatus = ClientErrorStatus | ServerErrorStatus;
 /**
  * Returns whether the provided number is a valid HTTP status code.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isStatus } from "@std/http/status";
  * import { assert } from "@std/assert";
@@ -334,7 +340,9 @@ export function isStatus(status: number): status is StatusCode {
 /**
  * A type guard that determines if the status code is informational.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isInformationalStatus } from "@std/http/status";
  * import { assert } from "@std/assert";
@@ -354,7 +362,9 @@ export function isInformationalStatus(
 /**
  * A type guard that determines if the status code is successful.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isSuccessfulStatus } from "@std/http/status";
  * import { assert } from "@std/assert";
@@ -374,7 +384,9 @@ export function isSuccessfulStatus(
 /**
  * A type guard that determines if the status code is a redirection.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isRedirectStatus } from "@std/http/status";
  * import { assert } from "@std/assert";
@@ -392,7 +404,9 @@ export function isRedirectStatus(status: number): status is RedirectStatus {
 /**
  * A type guard that determines if the status code is a client error.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isClientErrorStatus } from "@std/http/status";
  * import { assert } from "@std/assert";
@@ -412,7 +426,9 @@ export function isClientErrorStatus(
 /**
  * A type guard that determines if the status code is a server error.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isServerErrorStatus } from "@std/http/status";
  * import { assert } from "@std/assert";
@@ -432,7 +448,9 @@ export function isServerErrorStatus(
 /**
  * A type guard that determines if the status code is an error.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isErrorStatus } from "@std/http/status";
  * import { assert } from "@std/assert";

--- a/http/user_agent.ts
+++ b/http/user_agent.ts
@@ -968,7 +968,9 @@ const matchers: Matchers = {
  * environmental information represented by the string. All properties are
  * determined lazily.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { UserAgent } from "@std/http/user-agent";
  *
@@ -1000,7 +1002,9 @@ export class UserAgent {
    * The name and version of the browser extracted from the user agent
    * string.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1026,7 +1030,9 @@ export class UserAgent {
   /**
    * The architecture of the CPU extracted from the user agent string.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1051,7 +1057,9 @@ export class UserAgent {
    * The model, type, and vendor of a device if present in a user agent
    * string.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1075,7 +1083,9 @@ export class UserAgent {
   /**
    * The name and version of the browser engine in a user agent string.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1099,7 +1109,9 @@ export class UserAgent {
   /**
    * The name and version of the operating system in a user agent string.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1123,7 +1135,9 @@ export class UserAgent {
   /**
    * A read only version of the user agent string related to the instance.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1142,7 +1156,9 @@ export class UserAgent {
   /**
    * Converts the current instance to a JSON representation.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1169,7 +1185,9 @@ export class UserAgent {
   /**
    * Converts the current instance to a string.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1188,7 +1206,9 @@ export class UserAgent {
   /**
    * Custom output for {@linkcode Deno.inspect}.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    *
@@ -1216,7 +1236,9 @@ export class UserAgent {
    * Custom output for Node's
    * {@linkcode https://nodejs.org/api/util.html#utilinspectobject-options | util.inspect}.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts no-eval
    * import { UserAgent } from "@std/http/user-agent";
    * import { inspect } from "node:util";

--- a/ini/parse.ts
+++ b/ini/parse.ts
@@ -13,7 +13,9 @@ interface ParseOptions {
 /**
  * Parse an INI config string into an object. Provide formatting options to override the default assignment operator.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/ini/parse";
  * import { assertEquals } from "@std/assert";
@@ -29,7 +31,9 @@ interface ParseOptions {
  * assertEquals(parsed, { key: "value", "section 1": { foo: "Hello", baz: "World" } })
  * ```
  *
- * @example Using custom reviver
+ * @example
+ * <caption>Using custom reviver</caption>
+
  * ```ts
  * import { parse } from "@std/ini/parse";
  * import { assertEquals } from "@std/assert";

--- a/ini/stringify.ts
+++ b/ini/stringify.ts
@@ -18,7 +18,9 @@ export type { FormattingOptions, ReplacerFunction };
 /**
  * Compile an object into an INI config string. Provide formatting options to modify the output.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { stringify } from "@std/ini/stringify";
  * import { assertEquals } from "@std/assert";
@@ -42,7 +44,9 @@ export type { FormattingOptions, ReplacerFunction };
  * hello=world`);
  * ```
  *
- * @example Using replacer option
+ * @example
+ * <caption>Using replacer option</caption>
+
  * ```ts
  * import { stringify } from "@std/ini/stringify";
  * import { assertEquals } from "@std/assert";

--- a/internal/build_message.ts
+++ b/internal/build_message.ts
@@ -12,7 +12,9 @@ import type { DiffResult, DiffType } from "./types.ts";
  *
  * @returns A function that colors the input string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { createColor } from "@std/internal";
  * import { assertEquals } from "@std/assert";
@@ -48,7 +50,9 @@ export function createColor(
  *
  * @returns A string representing the sign.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { createSign } from "@std/internal";
  * import { assertEquals } from "@std/assert";
@@ -87,7 +91,9 @@ export interface BuildMessageOptions {
  *
  * @returns An array of strings representing the built message.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { diffStr, buildMessage } from "@std/internal";
  *

--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -25,7 +25,9 @@ const ADDED = 3;
  *
  * @returns An array containing the common elements between the two arrays.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { createCommon } from "@std/internal/diff";
  * import { assertEquals } from "@std/assert";
@@ -59,7 +61,9 @@ export function createCommon<T>(A: T[], B: T[]): T[] {
  *
  * @returns A void value that returns once the assertion completes.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertFp } from "@std/internal/diff";
  * import { assertThrows } from "@std/assert";
@@ -95,7 +99,9 @@ export function assertFp(value: unknown): asserts value is FarthestPoint {
  *
  * @returns An array of backtraced differences.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { backTrace } from "@std/internal/diff";
  * import { assertEquals } from "@std/assert";
@@ -163,7 +169,9 @@ export function backTrace<T>(
  *
  * @returns A {@linkcode FarthestPoint}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { createFp } from "@std/internal/diff";
  * import { assertEquals } from "@std/assert";
@@ -224,7 +232,9 @@ export function createFp(
  *
  * @returns An array of differences between the actual and expected values.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { diff } from "@std/internal/diff";
  * import { assertEquals } from "@std/assert";

--- a/internal/diff_str.ts
+++ b/internal/diff_str.ts
@@ -11,7 +11,9 @@ import { diff } from "./diff.ts";
  *
  * @returns Unescaped string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { unescape } from "@std/internal/diff-str";
  * import { assertEquals } from "@std/assert";
@@ -42,7 +44,9 @@ const WHITESPACE_SYMBOLS = /([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/;
  *
  * @returns An array of tokens.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { tokenize } from "@std/internal/diff-str";
  * import { assertEquals } from "@std/assert";
@@ -78,7 +82,9 @@ export function tokenize(string: string, wordDiff = false): string[] {
  *
  * @returns Array of diff results.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { createDetails } from "@std/internal/diff-str";
  * import { assertEquals } from "@std/assert";
@@ -123,7 +129,9 @@ export function createDetails(
  *
  * @returns Array of diff results.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { diffStr } from "@std/internal/diff-str";
  * import { assertEquals } from "@std/assert";

--- a/internal/format.ts
+++ b/internal/format.ts
@@ -9,7 +9,9 @@
  *
  * @returns The formatted string
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { format } from "@std/internal/format";
  * import { assertEquals } from "@std/assert";

--- a/internal/styles.ts
+++ b/internal/styles.ts
@@ -42,7 +42,9 @@ function run(str: string, code: Code): string {
  *
  * @returns Bold text for printing
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bold } from "@std/internal/styles";
  *
@@ -62,7 +64,9 @@ export function bold(str: string): string {
  *
  * @returns Red text for printing
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { red } from "@std/internal/styles";
  *
@@ -82,7 +86,9 @@ export function red(str: string): string {
  *
  * @returns Green text for print
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { green } from "@std/internal/styles";
  *
@@ -102,7 +108,9 @@ export function green(str: string): string {
  *
  * @returns Yellow text for print
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { yellow } from "@std/internal/styles";
  *
@@ -120,7 +128,9 @@ export function yellow(str: string): string {
  *
  * @returns White text for print
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { white } from "@std/internal/styles";
  *
@@ -138,7 +148,9 @@ export function white(str: string): string {
  *
  * @returns Gray text for print
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { gray } from "@std/internal/styles";
  *
@@ -156,7 +168,9 @@ export function gray(str: string): string {
  *
  * @returns Bright-black text for print
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { brightBlack } from "@std/internal/styles";
  *
@@ -174,7 +188,9 @@ export function brightBlack(str: string): string {
  *
  * @returns Red background text for print
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgRed } from "@std/internal/styles";
  *
@@ -192,7 +208,9 @@ export function bgRed(str: string): string {
  *
  * @returns Green background text for print
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { bgGreen } from "@std/internal/styles";
  *
@@ -219,7 +237,9 @@ const ANSI_PATTERN = new RegExp(
  *
  * @returns Text without ANSI escape codes
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-assert
  * import { red, stripAnsiCode } from "@std/internal/styles";
  *

--- a/json/concatenated_json_parse_stream.ts
+++ b/json/concatenated_json_parse_stream.ts
@@ -15,7 +15,8 @@ const primitives = new Map(
  * Stream to parse
  * {@link https://en.wikipedia.org/wiki/JSON_streaming#Concatenated_JSON | Concatenated JSON}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
  *
  * ```ts
  * import { ConcatenatedJsonParseStream } from "@std/json/concatenated-json-parse-stream";

--- a/json/concatenated_json_parse_stream.ts
+++ b/json/concatenated_json_parse_stream.ts
@@ -37,7 +37,9 @@ export class ConcatenatedJsonParseStream
   /**
    * A writable stream of byte data.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { ConcatenatedJsonParseStream } from "@std/json/concatenated-json-parse-stream";
    * import { assertEquals } from "@std/assert";
@@ -57,7 +59,9 @@ export class ConcatenatedJsonParseStream
   /**
    * A readable stream of byte data.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { ConcatenatedJsonParseStream } from "@std/json/concatenated-json-parse-stream";
    * import { assertEquals } from "@std/assert";

--- a/json/parse_stream.ts
+++ b/json/parse_stream.ts
@@ -34,7 +34,9 @@ function isBrankString(str: string) {
  * ]);
  * ```
  *
- * @example parse JSON lines or NDJSON from a file
+ * @example
+ * <caption>parse JSON lines or NDJSON from a file</caption>
+
  * ```ts
  * import { TextLineStream } from "@std/streams/text-line-stream";
  * import { JsonParseStream } from "@std/json/parse-stream";

--- a/json/parse_stream.ts
+++ b/json/parse_stream.ts
@@ -17,7 +17,8 @@ function isBrankString(str: string) {
  * {@link https://www.rfc-editor.org/rfc/rfc7464.html | JSON Text Sequences}.
  * Chunks consisting of spaces, tab characters, or newline characters will be ignored.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
  *
  * ```ts
  * import { JsonParseStream } from "@std/json/parse-stream";

--- a/json/stringify_stream.ts
+++ b/json/stringify_stream.ts
@@ -27,7 +27,8 @@ export interface StringifyStreamOptions {
  *
  * You can optionally specify a prefix and suffix for each chunk. The default prefix is `""` and the default suffix is `"\n"`.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
  *
  * ```ts
  * import { JsonStringifyStream } from "@std/json/stringify-stream";
@@ -60,7 +61,8 @@ export interface StringifyStreamOptions {
  * ]);
  * ```
  *
- * @example Stringify JSON lines from a server
+ * @example
+ * <caption>Stringify JSON lines from a server</caption>
  *
  * ```ts no-eval no-assert
  * import { JsonStringifyStream } from "@std/json/stringify-stream";

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -7,7 +7,9 @@ export type { JsonValue };
 /**
  * Converts a JSON with Comments (JSONC) string into an object.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/jsonc";
  * import { assertEquals } from "@std/assert";

--- a/media_types/all_extensions.ts
+++ b/media_types/all_extensions.ts
@@ -15,7 +15,9 @@ import { extensions } from "./_db.ts";
  * @returns The extensions for the given media type, or `undefined` if no
  * extensions are found.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { allExtensions } from "@std/media-types/all-extensions";
  * import { assertEquals } from "@std/assert";

--- a/media_types/content_type.ts
+++ b/media_types/content_type.ts
@@ -42,7 +42,9 @@ export type KnownExtensionOrType =
  * @returns The full `Content-Type` or `Content-Disposition` header value, or
  * `undefined` if unable to resolve the media type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { contentType } from "@std/media-types/content-type";
  * import { assertEquals } from "@std/assert";

--- a/media_types/extension.ts
+++ b/media_types/extension.ts
@@ -14,7 +14,9 @@ import { allExtensions } from "./all_extensions.ts";
  * @returns The extension for the given media type, or `undefined` if no
  * extension is found.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { extension } from "@std/media-types/extension";
  * import { assertEquals } from "@std/assert";

--- a/media_types/format_media_type.ts
+++ b/media_types/format_media_type.ts
@@ -18,7 +18,9 @@ import { isIterator, isToken, needsEncoding } from "./_util.ts";
  *
  * @returns The serialized media type.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { formatMediaType } from "@std/media-types/format-media-type";
  * import { assertEquals } from "@std/assert";
@@ -26,7 +28,9 @@ import { isIterator, isToken, needsEncoding } from "./_util.ts";
  * assertEquals(formatMediaType("text/plain"), "text/plain");
  * ```
  *
- * @example With parameters
+ * @example
+ * <caption>With parameters</caption>
+
  * ```ts
  * import { formatMediaType } from "@std/media-types/format-media-type";
  * import { assertEquals } from "@std/assert";

--- a/media_types/get_charset.ts
+++ b/media_types/get_charset.ts
@@ -14,7 +14,9 @@ import { db, type KeyOfDb } from "./_db.ts";
  * @returns The charset for the given media type or header value, or `undefined`
  * if the charset cannot be determined.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { getCharset } from "@std/media-types/get-charset";
  * import { assertEquals } from "@std/assert";

--- a/media_types/parse_media_type.ts
+++ b/media_types/parse_media_type.ts
@@ -23,7 +23,9 @@ import { consumeMediaParam, decode2331Encoding } from "./_util.ts";
  * @returns A tuple where the first element is the media type and the second
  * element is the optional parameters or `undefined` if there are none.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parseMediaType } from "@std/media-types/parse-media-type";
  * import { assertEquals } from "@std/assert";

--- a/media_types/type_by_extension.ts
+++ b/media_types/type_by_extension.ts
@@ -15,7 +15,9 @@ import { types } from "./_db.ts";
  * @returns The media type associated with the file extension, or `undefined` if
  * no media type is found.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { typeByExtension } from "@std/media-types/type-by-extension";
  * import { assertEquals } from "@std/assert";

--- a/msgpack/decode.ts
+++ b/msgpack/decode.ts
@@ -8,7 +8,9 @@ import type { ValueType } from "./encode.ts";
  *
  * If the input is not in valid message pack format, an error will be thrown.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { decode } from "@std/msgpack/decode";
  * import { assertEquals } from "@std/assert";

--- a/msgpack/encode.ts
+++ b/msgpack/encode.ts
@@ -40,7 +40,9 @@ const encoder = new TextEncoder();
 /**
  * Encode a value to {@link https://msgpack.org/ | MessagePack} binary format.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { encode } from "@std/msgpack/encode";
  * import { assertEquals } from "@std/assert";

--- a/net/get_network_address.ts
+++ b/net/get_network_address.ts
@@ -15,7 +15,9 @@
  * @param family The IP protocol version of the interface to get the address of.
  * @returns The IPv4 network address of the machine or `undefined` if not found.
  *
- * @example Get the IPv4 network address (default)
+ * @example
+ * <caption>Get the IPv4 network address (default)</caption>
+
  * ```ts no-assert no-eval
  * import { getNetworkAddress } from "@std/net/get-network-address";
  *
@@ -24,7 +26,9 @@
  * Deno.serve({ port: 0, hostname }, () => new Response("Hello, world!"));
  * ```
  *
- * @example Get the IPv6 network address
+ * @example
+ * <caption>Get the IPv6 network address</caption>
+
  * ```ts no-assert no-eval
  * import { getNetworkAddress } from "@std/net/get-network-address";
  *

--- a/path/basename.ts
+++ b/path/basename.ts
@@ -11,7 +11,9 @@ import { basename as windowsBasename } from "./windows/basename.ts";
  * The trailing directory separators are ignored, and optional suffix is
  * removed.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { basename } from "@std/path/basename";
  * import { assertEquals } from "@std/assert";

--- a/path/common.ts
+++ b/path/common.ts
@@ -10,7 +10,9 @@ import { SEPARATOR } from "./constants.ts";
  * @param paths Paths to search for common path.
  * @returns The common path.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { common } from "@std/path/common";
  * import { assertEquals } from "@std/assert";

--- a/path/dirname.ts
+++ b/path/dirname.ts
@@ -8,7 +8,9 @@ import { dirname as windowsDirname } from "./windows/dirname.ts";
 /**
  * Return the directory path of a path.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { dirname } from "@std/path/dirname";
  * import { assertEquals } from "@std/assert";

--- a/path/extname.ts
+++ b/path/extname.ts
@@ -7,7 +7,9 @@ import { extname as windowsExtname } from "./windows/extname.ts";
 /**
  * Return the extension of the path with leading period (".").
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { extname } from "@std/path/extname";
  * import { assertEquals } from "@std/assert";

--- a/path/format.ts
+++ b/path/format.ts
@@ -10,7 +10,9 @@ import type { ParsedPath } from "./types.ts";
  * Generate a path from a {@linkcode ParsedPath} object. It does the
  * opposite of {@linkcode https://jsr.io/@std/path/doc/~/parse | parse()}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { format } from "@std/path/format";
  * import { assertEquals } from "@std/assert";

--- a/path/from_file_url.ts
+++ b/path/from_file_url.ts
@@ -8,7 +8,9 @@ import { fromFileUrl as windowsFromFileUrl } from "./windows/from_file_url.ts";
 /**
  * Converts a file URL to a path string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { fromFileUrl } from "@std/path/from-file-url";
  * import { assertEquals } from "@std/assert";

--- a/path/glob_to_regexp.ts
+++ b/path/glob_to_regexp.ts
@@ -68,7 +68,9 @@ export type { GlobOptions };
  *   `!(foo|bar)` is treated like `!(@(foo|bar)*)`. This will work correctly if
  *   the group occurs not nested at the end of the segment.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { globToRegExp } from "@std/path/glob-to-regexp";
  * import { assertEquals } from "@std/assert";

--- a/path/is_absolute.ts
+++ b/path/is_absolute.ts
@@ -8,7 +8,9 @@ import { isAbsolute as windowsIsAbsolute } from "./windows/is_absolute.ts";
 /**
  * Verifies whether provided path is absolute.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isAbsolute } from "@std/path/is-absolute";
  * import { assert, assertFalse } from "@std/assert";

--- a/path/is_glob.ts
+++ b/path/is_glob.ts
@@ -4,7 +4,9 @@
 /**
  * Test whether the given string is a glob.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isGlob } from "@std/path/is-glob";
  * import { assert } from "@std/assert";

--- a/path/join.ts
+++ b/path/join.ts
@@ -8,7 +8,9 @@ import { join as windowsJoin } from "./windows/join.ts";
 /**
  * Joins a sequence of paths, then normalizes the resulting path.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { join } from "@std/path/join";
  * import { assertEquals } from "@std/assert";

--- a/path/join_globs.ts
+++ b/path/join_globs.ts
@@ -14,7 +14,9 @@ export type { GlobOptions };
  * Behaves like {@linkcode https://jsr.io/@std/path/doc/~/join | join()}, but
  * doesn't collapse `**\/..` when `globstar` is true.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { joinGlobs } from "@std/path/join-globs";
  * import { assertEquals } from "@std/assert";

--- a/path/normalize.ts
+++ b/path/normalize.ts
@@ -11,7 +11,9 @@ import { normalize as windowsNormalize } from "./windows/normalize.ts";
  * eliminated. A `'..'` at the top-level will be preserved, and an empty path is
  * canonically `'.'`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { normalize } from "@std/path/normalize";
  * import { assertEquals } from "@std/assert";

--- a/path/normalize_glob.ts
+++ b/path/normalize_glob.ts
@@ -17,7 +17,9 @@ export type { GlobOptions };
  * {@linkcode https://jsr.io/@std/path/doc/~/normalize | normalize()}, but
  * doesn't collapse "**\/.." when `globstar` is true.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { normalizeGlob } from "@std/path/normalize-glob";
  * import { assertEquals } from "@std/assert";

--- a/path/parse.ts
+++ b/path/parse.ts
@@ -14,7 +14,9 @@ export type { ParsedPath } from "./types.ts";
  * Use {@linkcode https://jsr.io/@std/path/doc/~/format | format()} to reverse
  * the result.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/path/parse";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/basename.ts
+++ b/path/posix/basename.ts
@@ -13,7 +13,9 @@ import { isPosixPathSeparator } from "./_util.ts";
  * Return the last portion of a `path`.
  * Trailing directory separators are ignored, and optional suffix is removed.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { basename } from "@std/path/posix/basename";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/common.ts
+++ b/path/posix/common.ts
@@ -6,7 +6,9 @@ import { SEPARATOR } from "./constants.ts";
 
 /** Determines the common path from a set of paths for POSIX systems.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { common } from "@std/path/posix/common";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -20,7 +20,8 @@ import { isPosixPathSeparator } from "./_util.ts";
  * assertEquals(dirname("https://deno.land/std/path/mod.ts"), "https://deno.land/std/path");
  * ```
  *
- * @example Working with URLs
+ * @example
+ * <caption>Working with URLs</caption>
  *
  * ```ts
  * import { dirname } from "@std/path/posix/dirname";

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -8,7 +8,9 @@ import { isPosixPathSeparator } from "./_util.ts";
 /**
  * Return the directory path of a `path`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { dirname } from "@std/path/posix/dirname";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/extname.ts
+++ b/path/posix/extname.ts
@@ -8,7 +8,9 @@ import { isPosixPathSeparator } from "./_util.ts";
 /**
  * Return the extension of the `path` with leading period.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { extname } from "@std/path/posix/extname";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/format.ts
+++ b/path/posix/format.ts
@@ -7,7 +7,9 @@ import type { ParsedPath } from "../types.ts";
 /**
  * Generate a path from `ParsedPath` object.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { format } from "@std/path/posix/format";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/from_file_url.ts
+++ b/path/posix/from_file_url.ts
@@ -6,7 +6,9 @@ import { assertArg } from "../_common/from_file_url.ts";
 /**
  * Converts a file URL to a path string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { fromFileUrl } from "@std/path/posix/from-file-url";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/glob_to_regexp.ts
+++ b/path/posix/glob_to_regexp.ts
@@ -74,7 +74,9 @@ const constants: GlobConstants = {
  *   `!(foo|bar)` is treated like `!(@(foo|bar)*)`. This will work correctly if
  *   the group occurs not nested at the end of the segment.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { globToRegExp } from "@std/path/posix/glob-to-regexp";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/is_absolute.ts
+++ b/path/posix/is_absolute.ts
@@ -7,7 +7,9 @@ import { isPosixPathSeparator } from "./_util.ts";
 /**
  * Verifies whether provided path is absolute.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isAbsolute } from "@std/path/posix/is-absolute";
  * import { assert, assertFalse } from "@std/assert";

--- a/path/posix/join.ts
+++ b/path/posix/join.ts
@@ -7,7 +7,9 @@ import { normalize } from "./normalize.ts";
 /**
  * Join all given a sequence of `paths`,then normalizes the resulting path.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { join } from "@std/path/posix/join";
  * import { assertEquals } from "@std/assert";
@@ -16,7 +18,9 @@ import { normalize } from "./normalize.ts";
  * assertEquals(path, "/foo/bar/baz/asdf");
  * ```
  *
- * @example Working with URLs
+ * @example
+ * <caption>Working with URLs</caption>
+
  * ```ts
  * import { join } from "@std/path/posix/join";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/join_globs.ts
+++ b/path/posix/join_globs.ts
@@ -11,7 +11,9 @@ export type { GlobOptions };
 /**
  * Like join(), but doesn't collapse "**\/.." when `globstar` is true.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { joinGlobs } from "@std/path/posix/join-globs";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/normalize.ts
+++ b/path/posix/normalize.ts
@@ -10,7 +10,9 @@ import { isPosixPathSeparator } from "./_util.ts";
  * Note that resolving these segments does not necessarily mean that all will be eliminated.
  * A `'..'` at the top-level will be preserved, and an empty path is canonically `'.'`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { normalize } from "@std/path/posix/normalize";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/normalize_glob.ts
+++ b/path/posix/normalize_glob.ts
@@ -10,7 +10,9 @@ export type { GlobOptions };
 /**
  * Like normalize(), but doesn't collapse "**\/.." when `globstar` is true.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { normalizeGlob } from "@std/path/posix/normalize-glob";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/parse.ts
+++ b/path/posix/parse.ts
@@ -12,7 +12,9 @@ export type { ParsedPath } from "../types.ts";
 /**
  * Return a `ParsedPath` object of the `path`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/path/posix/parse";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/relative.ts
+++ b/path/posix/relative.ts
@@ -10,7 +10,9 @@ import { assertArgs } from "../_common/relative.ts";
  *
  * If `from` and `to` are the same, return an empty string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { relative } from "@std/path/posix/relative";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/resolve.ts
+++ b/path/posix/resolve.ts
@@ -8,7 +8,9 @@ import { isPosixPathSeparator } from "./_util.ts";
 /**
  * Resolves path segments into a `path`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { resolve } from "@std/path/posix/resolve";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/to_file_url.ts
+++ b/path/posix/to_file_url.ts
@@ -7,7 +7,9 @@ import { isAbsolute } from "./is_absolute.ts";
 /**
  * Converts a path string to a file URL.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toFileUrl } from "@std/path/posix/to-file-url";
  * import { assertEquals } from "@std/assert";

--- a/path/posix/to_namespaced_path.ts
+++ b/path/posix/to_namespaced_path.ts
@@ -4,7 +4,9 @@
 /**
  * Converts a path to a namespaced path. This function returns the path as is on posix.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toNamespacedPath } from "@std/path/posix/to-namespaced-path";
  * import { assertEquals } from "@std/assert";

--- a/path/relative.ts
+++ b/path/relative.ts
@@ -9,7 +9,9 @@ import { relative as windowsRelative } from "./windows/relative.ts";
  * Return the relative path from `from` to `to` based on current working
  * directory.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { relative } from "@std/path/relative";
  * import { assertEquals } from "@std/assert";

--- a/path/resolve.ts
+++ b/path/resolve.ts
@@ -8,7 +8,9 @@ import { resolve as windowsResolve } from "./windows/resolve.ts";
 /**
  * Resolves path segments into a path.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { resolve } from "@std/path/resolve";
  * import { assertEquals } from "@std/assert";

--- a/path/to_file_url.ts
+++ b/path/to_file_url.ts
@@ -8,7 +8,9 @@ import { toFileUrl as windowsToFileUrl } from "./windows/to_file_url.ts";
 /**
  * Converts a path string to a file URL.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toFileUrl } from "@std/path/to-file-url";
  * import { assertEquals } from "@std/assert";

--- a/path/to_namespaced_path.ts
+++ b/path/to_namespaced_path.ts
@@ -9,7 +9,9 @@ import { toNamespacedPath as windowsToNamespacedPath } from "./windows/to_namesp
  * Resolves path to a namespace path.  This is a no-op on
  * non-windows systems.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toNamespacedPath } from "@std/path/to-namespaced-path";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/basename.ts
+++ b/path/windows/basename.ts
@@ -14,7 +14,9 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * Return the last portion of a `path`.
  * Trailing directory separators are ignored, and optional suffix is removed.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { basename } from "@std/path/windows/basename";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/common.ts
+++ b/path/windows/common.ts
@@ -7,7 +7,9 @@ import { SEPARATOR } from "./constants.ts";
 /**
  * Determines the common path from a set of paths for Windows systems.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { common } from "@std/path/windows/common";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -13,7 +13,9 @@ import {
 /**
  * Return the directory path of a `path`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { dirname } from "@std/path/windows/dirname";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/extname.ts
+++ b/path/windows/extname.ts
@@ -8,7 +8,9 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
 /**
  * Return the extension of the `path` with leading period.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { extname } from "@std/path/windows/extname";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/format.ts
+++ b/path/windows/format.ts
@@ -7,7 +7,9 @@ import type { ParsedPath } from "../types.ts";
 /**
  * Generate a path from `ParsedPath` object.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { format } from "@std/path/windows/format";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/from_file_url.ts
+++ b/path/windows/from_file_url.ts
@@ -6,7 +6,9 @@ import { assertArg } from "../_common/from_file_url.ts";
 /**
  * Converts a file URL to a path string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { fromFileUrl } from "@std/path/windows/from-file-url";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/glob_to_regexp.ts
+++ b/path/windows/glob_to_regexp.ts
@@ -72,7 +72,9 @@ const constants: GlobConstants = {
  *   `!(foo|bar)` is treated like `!(@(foo|bar)*)`. This will work correctly if
  *   the group occurs not nested at the end of the segment.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { globToRegExp } from "@std/path/windows/glob-to-regexp";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/is_absolute.ts
+++ b/path/windows/is_absolute.ts
@@ -8,7 +8,9 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
 /**
  * Verifies whether provided path is absolute.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isAbsolute } from "@std/path/windows/is-absolute";
  * import { assert, assertFalse } from "@std/assert";

--- a/path/windows/join.ts
+++ b/path/windows/join.ts
@@ -8,7 +8,9 @@ import { normalize } from "./normalize.ts";
 /**
  * Join all given a sequence of `paths`,then normalizes the resulting path.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { join } from "@std/path/windows/join";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/join_globs.ts
+++ b/path/windows/join_globs.ts
@@ -11,7 +11,8 @@ export type { GlobOptions };
 /**
  * Like join(), but doesn't collapse "**\/.." when `globstar` is true.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
  *
  * ```ts
  * import { joinGlobs } from "@std/path/windows/join-globs";

--- a/path/windows/normalize.ts
+++ b/path/windows/normalize.ts
@@ -11,7 +11,9 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * Note that resolving these segments does not necessarily mean that all will be eliminated.
  * A `'..'` at the top-level will be preserved, and an empty path is canonically `'.'`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { normalize } from "@std/path/windows/normalize";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/normalize_glob.ts
+++ b/path/windows/normalize_glob.ts
@@ -10,7 +10,9 @@ export type { GlobOptions };
 /**
  * Like normalize(), but doesn't collapse "**\/.." when `globstar` is true.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { normalizeGlob } from "@std/path/windows/normalize-glob";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/parse.ts
+++ b/path/windows/parse.ts
@@ -11,7 +11,9 @@ export type { ParsedPath } from "../types.ts";
 /**
  * Return a `ParsedPath` object of the `path`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/path/windows/parse";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/relative.ts
+++ b/path/windows/relative.ts
@@ -13,7 +13,9 @@ import { assertArgs } from "../_common/relative.ts";
  *  to = 'C:\\orandea\\impl\\bbb'
  * The output of the function should be: '..\\..\\impl\\bbb'
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { relative } from "@std/path/windows/relative";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/resolve.ts
+++ b/path/windows/resolve.ts
@@ -9,7 +9,9 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
 /**
  * Resolves path segments into a `path`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { resolve } from "@std/path/windows/resolve";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/to_file_url.ts
+++ b/path/windows/to_file_url.ts
@@ -7,7 +7,9 @@ import { isAbsolute } from "./is_absolute.ts";
 /**
  * Converts a path string to a file URL.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toFileUrl } from "@std/path/windows/to-file-url";
  * import { assertEquals } from "@std/assert";

--- a/path/windows/to_namespaced_path.ts
+++ b/path/windows/to_namespaced_path.ts
@@ -13,7 +13,9 @@ import { resolve } from "./resolve.ts";
 /**
  * Resolves path to a namespace path
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toNamespacedPath } from "@std/path/windows/to-namespaced-path";
  * import { assertEquals } from "@std/assert";

--- a/regexp/escape.ts
+++ b/regexp/escape.ts
@@ -74,7 +74,9 @@ const RX_REGEXP_ESCAPE = new RegExp(
  * Escapes arbitrary text for interpolation into a regexp, such that it will
  * match exactly that text and nothing else.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { escape } from "@std/regexp/escape";
  * import { assertEquals, assertMatch, assertNotMatch } from "@std/assert";

--- a/semver/can_parse.ts
+++ b/semver/can_parse.ts
@@ -5,7 +5,9 @@ import { parse } from "./parse.ts";
 /**
  * Returns true if the string can be parsed as SemVer.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { canParse } from "@std/semver/can-parse";
  * import { assert, assertFalse } from "@std/assert";

--- a/semver/compare.ts
+++ b/semver/compare.ts
@@ -15,7 +15,9 @@ import {
  *
  * Sorts in ascending order if passed to {@linkcode Array.sort}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, compare } from "@std/semver";
  * import { assertEquals } from "@std/assert";

--- a/semver/difference.ts
+++ b/semver/difference.ts
@@ -7,7 +7,9 @@ import { compareIdentifier } from "./_shared.ts";
  * Returns difference between two SemVers by the release type,
  * or `undefined` if the SemVers are the same.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, difference } from "@std/semver";
  * import { assertEquals } from "@std/assert";

--- a/semver/equals.ts
+++ b/semver/equals.ts
@@ -8,7 +8,9 @@ import type { SemVer } from "./types.ts";
  *
  * This is equal to `compare(s0, s1) === 0`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, equals } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/format.ts
+++ b/semver/format.ts
@@ -20,7 +20,9 @@ function formatNumber(value: number) {
  *
  * If any number is positive or negative infinity then '∞' or '⧞' will be printed instead.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { format } from "@std/semver/format";
  * import { assertEquals } from "@std/assert";

--- a/semver/format_range.ts
+++ b/semver/format_range.ts
@@ -11,7 +11,9 @@ function formatComparator(comparator: Comparator): string {
 /**
  * Formats the SemVerrange into a string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { formatRange, parseRange } from "@std/semver";
  * import { assertEquals } from "@std/assert";

--- a/semver/greater_or_equal.ts
+++ b/semver/greater_or_equal.ts
@@ -8,7 +8,9 @@ import { compare } from "./compare.ts";
  *
  * This is equal to `compare(s0, s1) >= 0`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, greaterOrEqual } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/greater_than.ts
+++ b/semver/greater_than.ts
@@ -9,7 +9,9 @@ import { compare } from "./compare.ts";
  *
  * This is equal to `compare(s0, s1) > 0`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, greaterThan } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/greater_than_range.ts
+++ b/semver/greater_than_range.ts
@@ -9,7 +9,9 @@ import { compare } from "./compare.ts";
 /**
  * Check if the SemVer is greater than the range.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, parseRange, greaterThanRange } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/increment.ts
+++ b/semver/increment.ts
@@ -64,7 +64,9 @@ export interface IncrementOptions {
  * unless a new build parameter is specified. Specifying `""` will unset existing build
  * metadata.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { increment, parse } from "@std/semver";
  * import { assertEquals } from "@std/assert";

--- a/semver/is_range.ts
+++ b/semver/is_range.ts
@@ -27,7 +27,9 @@ function isComparator(value: unknown): value is Comparator {
  *
  * Adds a type assertion if true.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isRange } from "@std/semver/is-range";
  * import { assert } from "@std/assert";

--- a/semver/is_semver.ts
+++ b/semver/is_semver.ts
@@ -17,7 +17,9 @@ import { isValidNumber, isValidString } from "./_shared.ts";
  *
  * A type assertion is added to the value.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isSemVer } from "@std/semver/is-semver";
  * import { assert } from "@std/assert";

--- a/semver/less_or_equal.ts
+++ b/semver/less_or_equal.ts
@@ -8,7 +8,9 @@ import { compare } from "./compare.ts";
  *
  * This is equal to `compare(s0, s1) <= 0`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, lessOrEqual } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/less_than.ts
+++ b/semver/less_than.ts
@@ -8,7 +8,9 @@ import { compare } from "./compare.ts";
  *
  * This is equal to `compare(s0, s1) < 0`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, lessThan } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/less_than_range.ts
+++ b/semver/less_than_range.ts
@@ -9,7 +9,9 @@ import { compare } from "./compare.ts";
 /**
  * Check if the SemVer is less than the range.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, parseRange, lessThanRange } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/max_satisfying.ts
+++ b/semver/max_satisfying.ts
@@ -8,7 +8,9 @@ import { greaterThan } from "./greater_than.ts";
  * Returns the highest SemVer in the list that satisfies the range, or `undefined`
  * if none of them do.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, parseRange, maxSatisfying } from "@std/semver";
  * import { assertEquals } from "@std/assert";

--- a/semver/min_satisfying.ts
+++ b/semver/min_satisfying.ts
@@ -8,7 +8,9 @@ import { lessThan } from "./less_than.ts";
  * Returns the lowest SemVer in the list that satisfies the range, or `undefined` if
  * none of them do.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, parseRange, minSatisfying } from "@std/semver";
  * import { assertEquals } from "@std/assert";

--- a/semver/not_equals.ts
+++ b/semver/not_equals.ts
@@ -8,7 +8,9 @@ import { compare } from "./compare.ts";
  *
  * This is equal to `compare(s0, s1) !== 0`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, notEquals } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -7,7 +7,9 @@ import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
 /**
  * Attempt to parse a string as a semantic version, returning a SemVer object.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/semver/parse";
  * import { assertEquals } from "@std/assert";

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -382,7 +382,9 @@ function parseOperatorRanges(string: string): Comparator[] {
 /**
  * Parses a range string into a {@linkcode Range} object.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parseRange } from "@std/semver/parse-range";
  * import { assertEquals } from "@std/assert";

--- a/semver/range_intersects.ts
+++ b/semver/range_intersects.ts
@@ -69,7 +69,9 @@ function comparatorsSatisfiable(comparators: Comparator[]): boolean {
  * The ranges intersect every range of AND comparators intersects with a least
  * one range of OR ranges.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parseRange, rangeIntersects } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/satisfies.ts
+++ b/semver/satisfies.ts
@@ -6,7 +6,9 @@ import { testComparatorSet } from "./_test_comparator_set.ts";
 /**
  * Test to see if the SemVer satisfies the range.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse, parseRange, satisfies } from "@std/semver";
  * import { assert } from "@std/assert";

--- a/semver/try_parse.ts
+++ b/semver/try_parse.ts
@@ -6,7 +6,9 @@ import { parse } from "./parse.ts";
 /**
  * Returns the parsed SemVer, or `undefined` if it's not valid.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { tryParse } from "@std/semver/try-parse";
  * import { assertEquals } from "@std/assert";

--- a/semver/try_parse_range.ts
+++ b/semver/try_parse_range.ts
@@ -8,7 +8,9 @@ import { parseRange } from "./parse_range.ts";
  * Parses the given range string and returns a Range object. If the range string
  * is invalid, `undefined` is returned.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { tryParseRange } from "@std/semver";
  * import { assertEquals } from "@std/assert";

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -35,7 +35,9 @@ export interface BufferBytesOptions {
  *
  * Based on {@link https://golang.org/pkg/bytes/#Buffer | Go Buffer}.
  *
- * @example Buffer input bytes and convert it to a string
+ * @example
+ * <caption>Buffer input bytes and convert it to a string</caption>
+
  * ```ts
  * import { Buffer } from "@std/streams/buffer";
  * import { toText } from "@std/streams/to-text";
@@ -91,7 +93,9 @@ export class Buffer {
    *
    * @returns A `ReadableStream` of the buffer.
    *
-   * @example Read the content out of the buffer to stdout
+   * @example
+   * <caption>Read the content out of the buffer to stdout</caption>
+
    * ```ts no-assert
    * import { Buffer } from "@std/streams/buffer";
    *
@@ -115,7 +119,9 @@ export class Buffer {
    *
    * @returns A `WritableStream` of the buffer.
    *
-   * @example Write the data from stdin to the buffer
+   * @example
+   * <caption>Write the data from stdin to the buffer</caption>
+
    * ```ts no-assert
    * import { Buffer } from "@std/streams/buffer";
    *
@@ -151,7 +157,9 @@ export class Buffer {
    * @param options Options for the bytes method.
    * @returns A copy or a slice of the buffer.
    *
-   * @example Copy the buffer
+   * @example
+   * <caption>Copy the buffer</caption>
+
    * ```ts
    * import { assertEquals } from "@std/assert";
    * import { assertNotEquals } from "@std/assert";
@@ -170,7 +178,9 @@ export class Buffer {
    * assertEquals(copied[2], array[2]);
    * ```
    *
-   * @example Get a slice to the buffer
+   * @example
+   * <caption>Get a slice to the buffer</caption>
+
    * ```ts
    * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -198,7 +208,9 @@ export class Buffer {
    *
    * @returns Whether the buffer is empty.
    *
-   * @example Empty buffer
+   * @example
+   * <caption>Empty buffer</caption>
+
    * ```ts
    * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -207,7 +219,9 @@ export class Buffer {
    * assert(buf.empty());
    * ```
    *
-   * @example Non-empty buffer
+   * @example
+   * <caption>Non-empty buffer</caption>
+
    * ```ts
    * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -217,7 +231,9 @@ export class Buffer {
    * assert(!buf.empty());
    * ```
    *
-   * @example Non-empty, but the content was already read
+   * @example
+   * <caption>Non-empty, but the content was already read</caption>
+
    * ```ts
    * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -240,7 +256,9 @@ export class Buffer {
    *
    * @returns The number of bytes in the unread portion of the buffer.
    *
-   * @example Basic usage
+   * @example
+   * <caption>Basic usage</caption>
+
    * ```ts
    * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -250,7 +268,9 @@ export class Buffer {
    * assertEquals(buf.length, 3);
    * ```
    *
-   * @example Length becomes 0 after the content is read
+   * @example
+   * <caption>Length becomes 0 after the content is read</caption>
+
    * ```ts
    * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -274,7 +294,9 @@ export class Buffer {
    *
    * @returns The number of allocated bytes for the buffer.
    *
-   * @example Basic usage
+   * @example
+   * <caption>Basic usage</caption>
+
    * ```ts
    * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -295,7 +317,9 @@ export class Buffer {
    *
    * @param n The number of bytes to keep.
    *
-   * @example Basic usage
+   * @example
+   * <caption>Basic usage</caption>
+
    * ```ts
    * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -323,7 +347,9 @@ export class Buffer {
   /**
    * Resets to an empty buffer.
    *
-   * @example Basic usage
+   * @example
+   * <caption>Basic usage</caption>
+
    * ```ts
    * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
@@ -398,7 +424,9 @@ export class Buffer {
    * Based on Go Lang's
    * {@link https://golang.org/pkg/bytes/#Buffer.Grow | Buffer.Grow}.
    *
-   * @example Basic usage
+   * @example
+   * <caption>Basic usage</caption>
+
    * ```ts
    * import { assert } from "@std/assert";
    * import { assertEquals } from "@std/assert";

--- a/streams/byte_slice_stream.ts
+++ b/streams/byte_slice_stream.ts
@@ -5,7 +5,9 @@
  * A transform stream that only transforms from the zero-indexed `start` and
  * `end` bytes (both inclusive).
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { ByteSliceStream } from "@std/streams/byte-slice-stream";
  * import { assertEquals } from "@std/assert";
@@ -22,7 +24,9 @@
  * );
  * ```
  *
- * @example Get a range of bytes from a fetch response body
+ * @example
+ * <caption>Get a range of bytes from a fetch response body</caption>
+
  * ```ts
  * import { ByteSliceStream } from "@std/streams/byte-slice-stream";
  * import { assertEquals } from "@std/assert";

--- a/streams/concat_readable_streams.ts
+++ b/streams/concat_readable_streams.ts
@@ -10,7 +10,9 @@
  * @param streams An iterable of `ReadableStream`s to concat.
  * @returns A `ReadableStream` that will emit the concatenated chunks.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { concatReadableStreams } from "@std/streams/concat-readable-streams";
  * import { assertEquals } from "@std/assert";

--- a/streams/early_zip_readable_streams.ts
+++ b/streams/early_zip_readable_streams.ts
@@ -14,7 +14,9 @@
  * @typeparam T The type of the chunks in the input streams.
  * @returns A `ReadableStream` that will emit the zipped chunks
  *
- * @example Zip 2 streams with the same length
+ * @example
+ * <caption>Zip 2 streams with the same length</caption>
+
  * ```ts
  * import { earlyZipReadableStreams } from "@std/streams/early-zip-readable-streams";
  * import { assertEquals } from "@std/assert";
@@ -29,7 +31,9 @@
  * );
  * ```
  *
- * @example Zip 2 streams with different length (first one is shorter)
+ * @example
+ * <caption>Zip 2 streams with different length (first one is shorter)</caption>
+
  * ```ts
  * import { earlyZipReadableStreams } from "@std/streams/early-zip-readable-streams";
  * import { assertEquals } from "@std/assert";
@@ -47,7 +51,9 @@
  * );
  * ```
  *
- * @example Zip 2 streams with different length (first one is longer)
+ * @example
+ * <caption>Zip 2 streams with different length (first one is longer)</caption>
+
  * ```ts
  * import { earlyZipReadableStreams } from "@std/streams/early-zip-readable-streams";
  * import { assertEquals } from "@std/assert";
@@ -65,7 +71,9 @@
  * );
  * ```
  *
- * @example Zip 3 streams
+ * @example
+ * <caption>Zip 3 streams</caption>
+
  * ```ts
  * import { earlyZipReadableStreams } from "@std/streams/early-zip-readable-streams";
  * import { assertEquals } from "@std/assert";

--- a/streams/limited_bytes_transform_stream.ts
+++ b/streams/limited_bytes_transform_stream.ts
@@ -19,7 +19,9 @@ export interface LimitedBytesTransformStreamOptions {
  * is thrown when `options.error` is set to true, otherwise the stream is just
  * terminated.
  *
- * @example `size` is equal to the total byte length of the chunks
+ * @example
+ * <caption>`size` is equal to the total byte length of the chunks</caption>
+
  * ```ts
  * import { LimitedBytesTransformStream } from "@std/streams/limited-bytes-transform-stream";
  * import { assertEquals } from "@std/assert";

--- a/streams/limited_transform_stream.ts
+++ b/streams/limited_transform_stream.ts
@@ -22,7 +22,9 @@ export interface LimitedTransformStreamOptions {
  *
  * @typeparam T The type the chunks in the stream.
  *
- * @example `size` is equal to the total number of chunks
+ * @example
+ * <caption>`size` is equal to the total number of chunks</caption>
+
  * ```ts
  * import { LimitedTransformStream } from "@std/streams/limited-transform-stream";
  * import { assertEquals } from "@std/assert";
@@ -39,7 +41,9 @@ export interface LimitedTransformStreamOptions {
  * );
  * ```
  *
- * @example `size` is less than the total number of chunks
+ * @example
+ * <caption>`size` is less than the total number of chunks</caption>
+
  * ```ts
  * import { LimitedTransformStream } from "@std/streams/limited-transform-stream";
  * import { assertEquals } from "@std/assert";

--- a/streams/merge_readable_streams.ts
+++ b/streams/merge_readable_streams.ts
@@ -9,7 +9,9 @@
  * @param streams An iterable of `ReadableStream`s to merge.
  * @returns A `ReadableStream` that will emit the merged chunks.
  *
- * @example Merge 2 streams
+ * @example
+ * <caption>Merge 2 streams</caption>
+
  * ```ts
  * import { mergeReadableStreams } from "@std/streams/merge-readable-streams";
  * import { assertEquals } from "@std/assert";
@@ -22,7 +24,9 @@
  * assertEquals(merged.toSorted(), [1, 2, 3, 4, 5]);
  * ```
  *
- * @example Merge 3 streams
+ * @example
+ * <caption>Merge 3 streams</caption>
+
  * ```ts
  * import { mergeReadableStreams } from "@std/streams/merge-readable-streams";
  * import { assertEquals } from "@std/assert";

--- a/streams/text_delimiter_stream.ts
+++ b/streams/text_delimiter_stream.ts
@@ -16,7 +16,9 @@ import type {
  *
  * If you want to split by a newline, consider using {@linkcode TextLineStream}.
  *
- * @example Comma-separated values
+ * @example
+ * <caption>Comma-separated values</caption>
+
  * ```ts
  * import { TextDelimiterStream } from "@std/streams/text-delimiter-stream";
  * import { assertEquals } from "@std/assert";
@@ -34,7 +36,9 @@ import type {
  * );
  * ```
  *
- * @example Semicolon-separated values with suffix disposition
+ * @example
+ * <caption>Semicolon-separated values with suffix disposition</caption>
+
  * ```ts
  * import { TextDelimiterStream } from "@std/streams/text-delimiter-stream";
  * import { assertEquals } from "@std/assert";

--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -17,7 +17,9 @@ export interface TextLineStreamOptions {
  *
  * If you want to split by a custom delimiter, consider using {@linkcode TextDelimiterStream}.
  *
- * @example JSON Lines
+ * @example
+ * <caption>JSON Lines</caption>
+
  * ```ts
  * import { TextLineStream } from "@std/streams/text-line-stream";
  * import { toTransformStream } from "@std/streams/to-transform-stream";

--- a/streams/text_line_stream.ts
+++ b/streams/text_line_stream.ts
@@ -50,7 +50,8 @@ export interface TextLineStreamOptions {
  * );
  * ```
  *
- * @example Allow splitting by `\r`
+ * @example
+ * <caption>Allow splitting by `\r`</caption>
  *
  * ```ts
  * import { TextLineStream } from "@std/streams/text-line-stream";

--- a/streams/to_array_buffer.ts
+++ b/streams/to_array_buffer.ts
@@ -10,7 +10,9 @@ import { concat } from "@std/bytes/concat";
  * @param readableStream A `ReadableStream` of `Uint8Array`s to convert into an `ArrayBuffer`.
  * @returns A promise that resolves with the `ArrayBuffer` containing all the data from the stream.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { toArrayBuffer } from "@std/streams/to-array-buffer";
  * import { assertEquals } from "@std/assert";

--- a/streams/to_blob.ts
+++ b/streams/to_blob.ts
@@ -8,7 +8,9 @@
  * @param stream A `ReadableStream` of `Uint8Array`s to convert into a `Blob`.
  * @returns A `Promise` that resolves to the `Blob`.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { toBlob } from "@std/streams/to-blob";
  * import { assertEquals } from "@std/assert";

--- a/streams/to_json.ts
+++ b/streams/to_json.ts
@@ -13,7 +13,9 @@ import { toText } from "./to_text.ts";
  * @param stream A `ReadableStream` whose chunks compose a JSON.
  * @returns A promise that resolves to the parsed JSON.
  *
- * @example Usage with a stream of strings
+ * @example
+ * <caption>Usage with a stream of strings</caption>
+
  * ```ts
  * import { toJson } from "@std/streams/to-json";
  * import { assertEquals } from "@std/assert";
@@ -26,7 +28,9 @@ import { toText } from "./to_text.ts";
  * assertEquals(await toJson(stream), [1, true, [], {}, "hello", null]);
  * ```
  *
- * @example Usage with a stream of `Uint8Array`s
+ * @example
+ * <caption>Usage with a stream of `Uint8Array`s</caption>
+
  * ```ts
  * import { toJson } from "@std/streams/to-json";
  * import { assertEquals } from "@std/assert";

--- a/streams/to_text.ts
+++ b/streams/to_text.ts
@@ -9,7 +9,9 @@
  * @param stream A `ReadableStream` to convert into a `string`.
  * @returns A `Promise` that resolves to the `string`.
  *
- * @example Basic usage with a stream of strings
+ * @example
+ * <caption>Basic usage with a stream of strings</caption>
+
  * ```ts
  * import { toText } from "@std/streams/to-text";
  * import { assertEquals } from "@std/assert";
@@ -18,7 +20,9 @@
  * assertEquals(await toText(stream), "Hello, world!");
  * ```
  *
- * @example Basic usage with a stream of `Uint8Array`s
+ * @example
+ * <caption>Basic usage with a stream of `Uint8Array`s</caption>
+
  * ```ts
  * import { toText } from "@std/streams/to-text";
  * import { assertEquals } from "@std/assert";

--- a/streams/to_transform_stream.ts
+++ b/streams/to_transform_stream.ts
@@ -11,7 +11,9 @@
  * @param readableStrategy An object that optionally defines a queuing strategy for the stream.
  * @returns A {@linkcode TransformStream} that transforms the source stream as defined by the provided transformer.
  *
- * @example Build a transform stream that multiplies each value by 100
+ * @example
+ * <caption>Build a transform stream that multiplies each value by 100</caption>
+
  * ```ts
  * import { toTransformStream } from "@std/streams/to-transform-stream";
  * import { assertEquals } from "@std/assert";
@@ -29,7 +31,9 @@
  * );
  * ```
  *
- * @example JSON Lines
+ * @example
+ * <caption>JSON Lines</caption>
+
  * ```ts
  * import { TextLineStream } from "@std/streams/text-line-stream";
  * import { toTransformStream } from "@std/streams/to-transform-stream";

--- a/streams/zip_readable_streams.ts
+++ b/streams/zip_readable_streams.ts
@@ -13,7 +13,9 @@
  * @typeparam T The type of the chunks in the input/output streams.
  * @returns A `ReadableStream` that will emit the zipped chunks.
  *
- * @example Zip 2 streams with the same length
+ * @example
+ * <caption>Zip 2 streams with the same length</caption>
+
  * ```ts
  * import { zipReadableStreams } from "@std/streams/zip-readable-streams";
  * import { assertEquals } from "@std/assert";
@@ -28,7 +30,9 @@
  * );
  * ```
  *
- * @example Zip 2 streams with different length (first one is shorter)
+ * @example
+ * <caption>Zip 2 streams with different length (first one is shorter)</caption>
+
  * ```ts
  * import { zipReadableStreams } from "@std/streams/zip-readable-streams";
  * import { assertEquals } from "@std/assert";
@@ -43,7 +47,9 @@
  * );
  * ```
  *
- * @example Zip 2 streams with different length (first one is longer)
+ * @example
+ * <caption>Zip 2 streams with different length (first one is longer)</caption>
+
  * ```ts
  * import { zipReadableStreams } from "@std/streams/zip-readable-streams";
  * import { assertEquals } from "@std/assert";
@@ -58,7 +64,9 @@
  * );
  * ```
  *
- * @example Zip 3 streams
+ * @example
+ * <caption>Zip 3 streams</caption>
+
  * ```ts
  * import { zipReadableStreams } from "@std/streams/zip-readable-streams";
  * import { assertEquals } from "@std/assert";

--- a/testing/bdd.ts
+++ b/testing/bdd.ts
@@ -543,7 +543,9 @@ export interface it {
 /**
  * Registers an individual test case.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -608,7 +610,9 @@ export function it<T>(...args: ItArgs<T>) {
 /**
  * Only execute this test case.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -637,7 +641,9 @@ it.only = function itOnly<T>(...args: ItArgs<T>): void {
 /**
  * Ignore this test case.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -665,7 +671,9 @@ it.ignore = function itIgnore<T>(...args: ItArgs<T>): void {
 
 /** Skip this test case.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -692,7 +700,9 @@ it.skip = function itSkip<T>(...args: ItArgs<T>): void {
  *
  * Registers an individual test case.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { test } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -732,7 +742,9 @@ function addHook<T>(
 /**
  * Run some shared setup before all of the tests in the suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, beforeAll } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -763,7 +775,9 @@ export function beforeAll<T>(
  *
  * Run some shared setup before all of the tests in the suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, before } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -792,7 +806,9 @@ export function before<T>(
 /**
  * Run some shared teardown after all of the tests in the suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, afterAll } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -823,7 +839,9 @@ export function afterAll<T>(
  *
  * Run some shared teardown after all of the tests in the suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, after } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -852,7 +870,9 @@ export function after<T>(
 /**
  * Run some shared setup before each test in the suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, beforeEach } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -881,7 +901,9 @@ export function beforeEach<T>(
 /**
  * Run some shared teardown after each test in the suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, afterEach } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -1048,7 +1070,9 @@ export interface describe {
 /**
  * Registers a test suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -1082,7 +1106,9 @@ export function describe<T>(
 /**
  * Only execute this test suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, beforeAll } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -1116,7 +1142,9 @@ describe.only = function describeOnly<T>(
 /**
  * Ignore the test suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, beforeAll } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";
@@ -1149,7 +1177,9 @@ describe.ignore = function describeIgnore<T>(
 /**
  * Skip the test suite.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { describe, it, beforeAll } from "@std/testing/bdd";
  * import { assertEquals } from "@std/assert";

--- a/testing/mock.ts
+++ b/testing/mock.ts
@@ -327,7 +327,9 @@ import { AssertionError } from "@std/assert/assertion-error";
 /**
  * An error related to spying on a function or instance method.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { MockError, spy } from "@std/testing/mock";
  * import { assertThrows } from "@std/assert";
@@ -484,7 +486,9 @@ function unregisterMock(spy: Spy<any, any[], any>) {
  * Creates a session that tracks all mocks created before it's restored.
  * If a callback is provided, it restores all mocks created within it.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { mockSession, restore, stub } from "@std/testing/mock";
  * import { assertEquals, assertNotEquals } from "@std/assert";
@@ -508,7 +512,9 @@ export function mockSession(): number;
  * Creates a session that tracks all mocks created before it's restored.
  * If a callback is provided, it restores all mocks created within it.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { mockSession, restore, stub } from "@std/testing/mock";
  * import { assertEquals, assertNotEquals } from "@std/assert";
@@ -563,7 +569,9 @@ export function mockSession<
 /**
  * Creates an async session that tracks all mocks created before the promise resolves.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { mockSessionAsync, restore, stub } from "@std/testing/mock";
  * import { assertEquals, assertNotEquals } from "@std/assert";
@@ -606,7 +614,9 @@ export function mockSessionAsync<
  * Restores all mocks registered in the current session that have not already been restored.
  * If an id is provided, it will restore all mocks registered in the session associed with that id that have not already been restored.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { mockSession, restore, stub } from "@std/testing/mock";
  * import { assertEquals, assertNotEquals } from "@std/assert";
@@ -808,7 +818,9 @@ export type SpyLike<
 
 /** Creates a spy function.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   assertSpyCall,
@@ -845,7 +857,9 @@ export function spy<
 /**
  * Create a spy function with the given implementation.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   assertSpyCall,
@@ -879,7 +893,9 @@ export function spy<
 /**
  * Create a spy constructor.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   assertSpyCall,
@@ -917,7 +933,9 @@ export function spy<
 /**
  * Wraps a instance method with a Spy.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   assertSpyCall,
@@ -1002,7 +1020,9 @@ export interface Stub<
 /**
  * Replaces an instance method with a Stub with empty implementation.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { stub, assertSpyCalls } from "@std/testing/mock";
  *
@@ -1038,7 +1058,9 @@ export function stub<
 /**
  * Replaces an instance method with a Stub with the given implementation.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { stub } from "@std/testing/mock";
  * import { assertEquals } from "@std/assert";
@@ -1167,7 +1189,9 @@ export function stub<
 /**
  * Asserts that a spy is called as much as expected and no more.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSpyCalls, spy } from "@std/testing/mock";
  *
@@ -1249,7 +1273,9 @@ function getSpyCall<
 /**
  * Asserts that a spy is called as expected.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSpyCall, spy } from "@std/testing/mock";
  *
@@ -1346,7 +1372,9 @@ export function assertSpyCall<
 /**
  * Asserts that an async spy is called as expected.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSpyCallAsync, spy } from "@std/testing/mock";
  *
@@ -1444,7 +1472,9 @@ export async function assertSpyCallAsync<
 /**
  * Asserts that a spy is called with a specific arg as expected.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSpyCallArg, spy } from "@std/testing/mock";
  *
@@ -1493,7 +1523,9 @@ export function assertSpyCallArg<
  * If a start is provided without an end index, the expected will be compared against all args from the start index to the end.
  * The end index is not included in the range of args that are compared.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSpyCallArgs, spy } from "@std/testing/mock";
  *
@@ -1532,7 +1564,9 @@ export function assertSpyCallArgs<
  * If a start is provided without an end index, the expected will be compared against all args from the start index to the end.
  * The end index is not included in the range of args that are compared.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSpyCallArgs, spy } from "@std/testing/mock";
  *
@@ -1570,7 +1604,9 @@ export function assertSpyCallArgs<
  * If a start is provided without an end index, the expected will be compared against all args from the start index to the end.
  * The end index is not included in the range of args that are compared.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSpyCallArgs, spy } from "@std/testing/mock";
  *
@@ -1637,7 +1673,9 @@ export function assertSpyCallArgs<
 /**
  * Creates a function that returns the instance the method was called on.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { returnsThis } from "@std/testing/mock";
  * import { assertEquals } from "@std/assert";
@@ -1665,7 +1703,9 @@ export function returnsThis<
 /**
  * Creates a function that returns one of its arguments.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { returnsArg } from "@std/testing/mock";
  * import { assertEquals } from "@std/assert";
@@ -1694,7 +1734,9 @@ export function returnsArg<
 /**
  * Creates a function that returns its arguments or a subset of them. If end is specified, it will return arguments up to but not including the end.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { returnsArgs } from "@std/testing/mock";
  * import { assertEquals } from "@std/assert";
@@ -1725,7 +1767,9 @@ export function returnsArgs<
 /**
  * Creates a function that returns the iterable values. Any iterable values that are errors will be thrown.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { returnsNext } from "@std/testing/mock";
  * import { assertEquals, assertThrows } from "@std/assert";
@@ -1771,7 +1815,9 @@ export function returnsNext<
 /**
  * Creates a function that resolves the awaited iterable values. Any awaited iterable values that are errors will be thrown.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { resolvesNext } from "@std/testing/mock";
  * import { assertEquals, assertRejects } from "@std/assert";

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -201,7 +201,9 @@ function getErrorMessage(message: string, options: SnapshotOptions) {
 /**
  * Default serializer for `assertSnapshot`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { serialize } from "@std/testing/snapshot";
  * import { assertEquals } from "@std/assert";
@@ -526,7 +528,9 @@ class AssertSnapshotContext {
  *
  * Type parameter can be specified to ensure values under comparison have the same type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSnapshot } from "@std/testing/snapshot";
  *
@@ -550,7 +554,9 @@ export async function assertSnapshot<T>(
  *
  * Type parameter can be specified to ensure values under comparison have the same type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertSnapshot } from "@std/testing/snapshot";
  *
@@ -645,7 +651,9 @@ export async function assertSnapshot(
  *
  * The specified option becomes the default for returned {@linkcode assertSnapshot}
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { createAssertSnapshot } from "@std/testing/snapshot";
  *

--- a/testing/time.ts
+++ b/testing/time.ts
@@ -46,7 +46,9 @@ export type { DelayOptions };
 /**
  * An error related to faking time.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { FakeTime, TimeError } from "@std/testing/time";
  * import { assertThrows } from "@std/assert";
@@ -245,7 +247,9 @@ let dueTree: RedBlackTree<DueNode>;
  * Note: there is no setter for the `start` property, as it cannot be changed
  * after initialization.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import {
  *   assertSpyCalls,
@@ -327,7 +331,9 @@ export class FakeTime {
   /**
    * Restores real time.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals, assertNotEquals } from "@std/assert";
@@ -356,7 +362,9 @@ export class FakeTime {
   /**
    * Restores real time.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals, assertNotEquals } from "@std/assert"
@@ -380,7 +388,9 @@ export class FakeTime {
   /**
    * Restores real time temporarily until callback returns and resolves.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals, assertNotEquals } from "@std/assert"
@@ -426,7 +436,9 @@ export class FakeTime {
   /**
    * The number of milliseconds elapsed since the epoch (January 1, 1970 00:00:00 UTC) for the fake time.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals } from "@std/assert";
@@ -449,7 +461,9 @@ export class FakeTime {
    * Set the current time. It will call any functions waiting to be called between the current and new fake time.
    * If the timer callback throws, time will stop advancing forward beyond that timer.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals } from "@std/assert";
@@ -496,7 +510,9 @@ export class FakeTime {
   /**
    * The initial number of milliseconds elapsed since the epoch (January 1, 1970 00:00:00 UTC) for the fake time.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals } from "@std/assert";
@@ -515,7 +531,9 @@ export class FakeTime {
   /**
    * Resolves after the given number of milliseconds using real time.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals } from "@std/assert";
@@ -560,7 +578,9 @@ export class FakeTime {
   /**
    * Runs all pending microtasks.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assert } from "@std/assert";
@@ -584,7 +604,9 @@ export class FakeTime {
    * Adds the specified number of milliseconds to the fake time.
    * This will call any functions waiting to be called between the current and new fake time.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import {
    *   assertSpyCalls,
@@ -625,7 +647,9 @@ export class FakeTime {
    * Runs all pending microtasks then adds the specified number of milliseconds to the fake time.
    * This will call any functions waiting to be called between the current and new fake time.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assert, assertEquals } from "@std/assert";
@@ -653,7 +677,9 @@ export class FakeTime {
    * Advances time to when the next scheduled timer is due.
    * If there are no pending timers, time will not be changed.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assert, assertEquals } from "@std/assert";
@@ -682,7 +708,9 @@ export class FakeTime {
    * Runs all pending microtasks then advances time to when the next scheduled timer is due.
    * If there are no pending timers, time will not be changed.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assert, assertEquals } from "@std/assert";
@@ -714,7 +742,9 @@ export class FakeTime {
    * If the timers create additional timers, they will be run too. If there is an interval,
    * time will keep advancing forward until the interval is cleared.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals } from "@std/assert";
@@ -745,7 +775,9 @@ export class FakeTime {
    * time will keep advancing forward until the interval is cleared.
    * Runs all pending microtasks before each timer.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals } from "@std/assert";
@@ -774,7 +806,9 @@ export class FakeTime {
   /**
    * Restores time related global functions to their original state.
    *
-   * @example Usage
+   * @example
+   * <caption>Usage</caption>
+
    * ```ts
    * import { FakeTime } from "@std/testing/time";
    * import { assertEquals, assertNotEquals } from "@std/assert";

--- a/testing/types.ts
+++ b/testing/types.ts
@@ -22,7 +22,9 @@
 /**
  * Asserts at compile time that the provided type argument's type resolves to the expected boolean literal type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts ignore
  * import { assertType, IsExact, IsNullable } from "@std/testing/types";
  *
@@ -46,7 +48,9 @@ export function assertType<T extends boolean>(
 /**
  * Asserts at compile time that the provided type argument's type resolves to true.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { AssertTrue, Has, IsNullable } from "@std/testing/types";
  *
@@ -62,7 +66,9 @@ export type AssertTrue<T extends true> = never;
 /**
  * Asserts at compile time that the provided type argument's type resolves to false.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { AssertFalse, IsNever } from "@std/testing/types";
  *
@@ -78,7 +84,9 @@ export type AssertFalse<T extends false> = never;
 /**
  * Asserts at compile time that the provided type argument's type resolves to the expected boolean literal type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { Assert, Has } from "@std/testing/types";
  *
@@ -95,7 +103,9 @@ export type Assert<T extends boolean, Expected extends T> = never;
 /**
  * Checks if type `T` has the specified type `U`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertType, Has } from "@std/testing/types";
  *
@@ -118,7 +128,9 @@ export type Has<T, U> = IsAny<T> extends true ? true
 /**
  * Checks if type `T` does not have the specified type `U`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertType, NotHas } from "@std/testing/types";
  *
@@ -138,7 +150,9 @@ export type NotHas<T, U> = Has<T, U> extends false ? true : false;
 /**
  * Checks if type `T` is possibly null or undefined.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertType, IsNullable } from "@std/testing/types";
  *
@@ -159,7 +173,9 @@ export type IsNullable<T> = Extract<T, null | undefined> extends never ? false
 /**
  * Checks if type `T` exactly matches type `U`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertType, IsExact } from "@std/testing/types";
  *
@@ -202,7 +218,9 @@ export type DeepPrepareIsExactProp<Prop, Parent, VisitedTypes> = Prop extends
 /**
  * Checks if type `T` is the `any` type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertType, IsAny } from "@std/testing/types";
  *
@@ -218,7 +236,9 @@ export type IsAny<T> = 0 extends (1 & T) ? true : false;
 /**
  * Checks if type `T` is the `never` type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertType, IsNever } from "@std/testing/types";
  *
@@ -233,7 +253,9 @@ export type IsNever<T> = [T] extends [never] ? true : false;
 /**
  * Checks if type `T` is the `unknown` type.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { assertType, IsUnknown } from "@std/testing/types";
  *

--- a/text/closest_string.ts
+++ b/text/closest_string.ts
@@ -27,7 +27,9 @@ export interface ClosestStringOptions {
  * By default, calculates the distance between words using the
  * {@link https://en.wikipedia.org/wiki/Levenshtein_distance | Levenshtein distance}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { closestString } from "@std/text/closest-string";
  * import { assertEquals } from "@std/assert";

--- a/text/levenshtein_distance.ts
+++ b/text/levenshtein_distance.ts
@@ -11,7 +11,9 @@
  * > of the two strings. It's recommended to limit the length and validate input
  * > if arbitrarily accepting input.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { levenshteinDistance } from "@std/text/levenshtein-distance";
  * import { assertEquals } from "@std/assert";

--- a/text/to_camel_case.ts
+++ b/text/to_camel_case.ts
@@ -6,7 +6,9 @@ import { capitalizeWord, splitToWords } from "./_util.ts";
 /**
  * Converts a string into camelCase.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toCamelCase } from "@std/text/to-camel-case";
  * import { assertEquals } from "@std/assert";

--- a/text/to_constant_case.ts
+++ b/text/to_constant_case.ts
@@ -11,7 +11,9 @@ import { splitToWords } from "./_util.ts";
  *
  * @experimental
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toConstantCase } from "@std/text/to-constant-case";
  * import { assertEquals } from "@std/assert/equals";

--- a/text/to_kebab_case.ts
+++ b/text/to_kebab_case.ts
@@ -6,7 +6,9 @@ import { splitToWords } from "./_util.ts";
 /**
  * Converts a string into kebab-case.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toKebabCase } from "@std/text/to-kebab-case";
  * import { assertEquals } from "@std/assert";

--- a/text/to_pascal_case.ts
+++ b/text/to_pascal_case.ts
@@ -6,7 +6,9 @@ import { capitalizeWord, splitToWords } from "./_util.ts";
 /**
  * Converts a string into PascalCase.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toPascalCase } from "@std/text/to-pascal-case";
  * import { assertEquals } from "@std/assert";

--- a/text/to_snake_case.ts
+++ b/text/to_snake_case.ts
@@ -6,7 +6,9 @@ import { splitToWords } from "./_util.ts";
 /**
  * Converts a string into snake_case.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { toSnakeCase } from "@std/text/to-snake-case";
  * import { assertEquals } from "@std/assert";

--- a/text/word_similarity_sort.ts
+++ b/text/word_similarity_sort.ts
@@ -14,7 +14,8 @@ export interface WordSimilaritySortOptions extends CompareSimilarityOptions {}
  * By default, calculates the distance between words using the
  * {@link https://en.wikipedia.org/wiki/Levenshtein_distance | Levenshtein distance}.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
  *
  * ```ts
  * import { wordSimilaritySort } from "@std/text/word-similarity-sort";
@@ -26,7 +27,8 @@ export interface WordSimilaritySortOptions extends CompareSimilarityOptions {}
  * assertEquals(suggestions, ["help", "size", "blah", "length"]);
  * ```
  *
- * @example Case-sensitive sorting
+ * @example
+ * <caption>Case-sensitive sorting</caption>
  *
  * ```ts
  * import { wordSimilaritySort } from "@std/text/word-similarity-sort";

--- a/toml/parse.ts
+++ b/toml/parse.ts
@@ -6,7 +6,9 @@ import { parserFactory, toml } from "./_parser.ts";
 /**
  * Parses a {@link https://toml.io | TOML} string into an object.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/toml/parse";
  * import { assertEquals } from "@std/assert";

--- a/toml/stringify.ts
+++ b/toml/stringify.ts
@@ -265,7 +265,9 @@ class Dumper {
 /**
  * Converts an object to a {@link https://toml.io | TOML} string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { stringify } from "@std/toml/stringify";
  * import { assertEquals } from "@std/assert";

--- a/ulid/decode_time.ts
+++ b/ulid/decode_time.ts
@@ -15,7 +15,9 @@ import {
  * Extracts the number of milliseconds since the Unix epoch that had passed when
  * the ULID was generated. If the ULID is malformed, an error will be thrown.
  *
- * @example Decode the time from a ULID
+ * @example
+ * <caption>Decode the time from a ULID</caption>
+
  * ```ts
  * import { decodeTime, ulid } from "@std/ulid";
  * import { assertEquals } from "@std/assert";

--- a/ulid/monotonic_ulid.ts
+++ b/ulid/monotonic_ulid.ts
@@ -18,7 +18,9 @@ const defaultMonotonicUlid = monotonicFactory();
  * still be generated, but it will not be guaranteed to be monotonic with
  * previous ULIDs for that same seed time.
  *
- * @example Generate a monotonic ULID
+ * @example
+ * <caption>Generate a monotonic ULID</caption>
+
  * ```ts no-assert
  * import { monotonicUlid } from "@std/ulid";
  *
@@ -27,7 +29,9 @@ const defaultMonotonicUlid = monotonicFactory();
  * monotonicUlid(); // 01HYFKHHX8H4BRY8BYHAV1BZ2T
  * ```
  *
- * @example Generate a monotonic ULID with a seed time
+ * @example
+ * <caption>Generate a monotonic ULID with a seed time</caption>
+
  * ```ts no-assert
  * import { monotonicUlid } from "@std/ulid";
  *

--- a/ulid/ulid.ts
+++ b/ulid/ulid.ts
@@ -13,7 +13,9 @@ import { encodeRandom, encodeTime } from "./_util.ts";
  * that the ULIDs will be strictly increasing, even if the seed time is the
  * same. For that, use the {@linkcode monotonicUlid} function.
  *
- * @example Generate a ULID
+ * @example
+ * <caption>Generate a ULID</caption>
+
  * ```ts no-assert
  * import { ulid } from "@std/ulid";
  *
@@ -22,7 +24,9 @@ import { encodeRandom, encodeTime } from "./_util.ts";
  * ulid(); // 01HYFKMDZQ7JD17CRKDXQSZ3Z4
  * ```
  *
- * @example Generate a ULID with a seed time
+ * @example
+ * <caption>Generate a ULID with a seed time</caption>
+
  * ```ts no-assert
  * import { ulid } from "@std/ulid";
  *

--- a/url/basename.ts
+++ b/url/basename.ts
@@ -15,7 +15,9 @@ import { strip } from "./_strip.ts";
  * @param suffix An optional suffix to remove from the base name.
  * @returns The base name of the URL.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { basename } from "@std/url/basename";
  * import { assertEquals } from "@std/assert";

--- a/url/dirname.ts
+++ b/url/dirname.ts
@@ -13,7 +13,9 @@ import { strip } from "./_strip.ts";
  * @param url URL to extract the directory from.
  * @returns The directory path URL of the URL.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { dirname } from "@std/url/dirname";
  * import { assertEquals } from "@std/assert";

--- a/url/extname.ts
+++ b/url/extname.ts
@@ -13,7 +13,9 @@ import { strip } from "./_strip.ts";
  * @param url The URL from which to extract the extension.
  * @returns The extension of the URL.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { extname } from "@std/url/extname";
  * import { assertEquals } from "@std/assert";

--- a/url/join.ts
+++ b/url/join.ts
@@ -11,7 +11,8 @@ import { join as posixJoin } from "@std/path/posix/join";
  * @param paths Array of path segments to be joined to the base URL.
  * @returns A complete URL containing the base URL joined with the paths.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
  *
  * ```ts
  * import { join } from "@std/url/join";

--- a/url/normalize.ts
+++ b/url/normalize.ts
@@ -10,7 +10,8 @@ import { normalize as posixNormalize } from "@std/path/posix/normalize";
  * @param url URL to be normalized.
  * @returns Normalized URL.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
  *
  * ```ts
  * import { normalize } from "@std/url/normalize";

--- a/uuid/common.ts
+++ b/uuid/common.ts
@@ -11,7 +11,9 @@ import { NIL_UUID } from "./constants.ts";
  *
  * @returns `true` if the UUID is the nil UUID, otherwise `false`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { isNil } from "@std/uuid";
  * import { assert, assertFalse } from "@std/assert";
@@ -31,7 +33,9 @@ export function isNil(id: string): boolean {
  *
  * @returns `true` if the string is a valid UUID, otherwise `false`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { validate } from "@std/uuid";
  * import { assert, assertFalse } from "@std/assert";
@@ -54,7 +58,9 @@ export function validate(uuid: string): boolean {
  *
  * @returns The RFC version of the UUID.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { version } from "@std/uuid";
  * import { assertEquals } from "@std/assert";

--- a/uuid/constants.ts
+++ b/uuid/constants.ts
@@ -4,7 +4,9 @@
 /**
  * Name string is a fully-qualified domain name.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { NAMESPACE_DNS } from "@std/uuid/constants";
  * import { generate } from "@std/uuid/v5";
@@ -16,7 +18,9 @@ export const NAMESPACE_DNS = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
 /**
  * Name string is a URL.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { NAMESPACE_URL } from "@std/uuid/constants";
  * import { generate } from "@std/uuid/v3";
@@ -28,7 +32,9 @@ export const NAMESPACE_URL = "6ba7b811-9dad-11d1-80b4-00c04fd430c8";
 /**
  * Name string is an ISO OID.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { NAMESPACE_OID } from "@std/uuid/constants";
  * import { generate } from "@std/uuid/v5";
@@ -40,7 +46,9 @@ export const NAMESPACE_OID = "6ba7b812-9dad-11d1-80b4-00c04fd430c8";
 /**
  * Name string is an X.500 DN (in DER or a text output format).
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { NAMESPACE_X500 } from "@std/uuid/constants";
  * import { generate } from "@std/uuid/v3";

--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -38,7 +38,9 @@ import { generate as generateV5, validate as validateV5 } from "./v5.ts";
  * Generator and validator for
  * {@link https://www.rfc-editor.org/rfc/rfc9562.html#section-5.1 | UUIDv1}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { v1 } from "@std/uuid";
  * import { assert } from "@std/assert";
@@ -56,7 +58,9 @@ export const v1 = {
  * Generator and validator for
  * {@link https://www.rfc-editor.org/rfc/rfc9562.html#section-5.3 | UUIDv3}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { v3, NAMESPACE_DNS } from "@std/uuid";
  * import { assert } from "@std/assert";
@@ -75,7 +79,9 @@ export const v3 = {
  * Validator for
  * {@link https://www.rfc-editor.org/rfc/rfc9562.html#section-5.4 | UUIDv4}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { v4 } from "@std/uuid";
  * import { assert } from "@std/assert";
@@ -92,7 +98,9 @@ export const v4 = {
  * Generator and validator for
  * {@link https://www.rfc-editor.org/rfc/rfc9562.html#section-5.5 | UUIDv5}.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { v5, NAMESPACE_DNS } from "@std/uuid";
  * import { assert } from "@std/assert";

--- a/uuid/v1.ts
+++ b/uuid/v1.ts
@@ -14,7 +14,9 @@ const UUID_RE =
  *
  * @returns `true` if the string is a valid UUIDv1, otherwise `false`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { validate } from "@std/uuid/v1";
  * import { assert, assertFalse } from "@std/assert";
@@ -80,7 +82,9 @@ export interface GenerateOptions {
  *
  * @returns Returns a UUIDv1 string or an array of 16 bytes.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { generate, validate } from "@std/uuid/v1";
  * import { assert } from "@std/assert";

--- a/uuid/v3.ts
+++ b/uuid/v3.ts
@@ -17,7 +17,9 @@ const UUID_RE =
  *
  * @returns `true` if the string is a valid UUIDv3, otherwise `false`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { validate } from "@std/uuid/v3";
  * import { assert, assertFalse } from "@std/assert";
@@ -41,7 +43,9 @@ export function validate(id: string): boolean {
  *
  * @throws {TypeError} If the namespace is not a valid UUID.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { NAMESPACE_URL } from "@std/uuid/constants";
  * import { generate, validate } from "@std/uuid/v3";

--- a/uuid/v4.ts
+++ b/uuid/v4.ts
@@ -12,7 +12,9 @@ const UUID_RE =
  *
  * @returns `true` if the UUID is valid UUIDv4, otherwise `false`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { validate } from "@std/uuid/v4";
  * import { assert, assertFalse } from "@std/assert";

--- a/uuid/v5.ts
+++ b/uuid/v5.ts
@@ -16,7 +16,9 @@ const UUID_RE =
  *
  * @returns `true` if the string is a valid UUIDv5, otherwise `false`.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { validate } from "@std/uuid/v5";
  * import { assert, assertFalse } from "@std/assert";
@@ -40,7 +42,9 @@ export function validate(id: string): boolean {
  *
  * @throws {TypeError} If the namespace is not a valid UUID.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { NAMESPACE_URL } from "@std/uuid/constants";
  * import { generate, validate } from "@std/uuid/v5";

--- a/webgpu/create_capture.ts
+++ b/webgpu/create_capture.ts
@@ -19,7 +19,9 @@ export interface CreateCapture {
 /**
  * Creates a texture and buffer to use as a capture.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { createCapture } from "@std/webgpu/create-capture";
  * import { getRowPadding } from "@std/webgpu/row-padding";

--- a/webgpu/describe_texture_format.ts
+++ b/webgpu/describe_texture_format.ts
@@ -30,7 +30,9 @@ const allFlags = GPUTextureUsage.COPY_SRC | GPUTextureUsage.COPY_DST |
 /**
  * Get various information about a specific {@linkcode GPUTextureFormat}.
  *
- * @example Basic usage
+ * @example
+ * <caption>Basic usage</caption>
+
  * ```ts
  * import { describeTextureFormat } from "@std/webgpu/describe-texture-format";
  * import { assertEquals } from "@std/assert";

--- a/webgpu/row_padding.ts
+++ b/webgpu/row_padding.ts
@@ -21,7 +21,9 @@ export const BYTES_PER_PIXEL = 4;
  *
  * Ref: https://en.wikipedia.org/wiki/Data_structure_alignment#Computing_padding
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { getRowPadding } from "@std/webgpu/row-padding";
  * import { assertEquals } from "@std/assert";
@@ -54,7 +56,9 @@ export function getRowPadding(width: number): Padding {
  * Creates a new buffer while removing any unnecessary empty bytes.
  * Useful for when wanting to save an image as a specific format.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { resliceBufferWithPadding } from "@std/webgpu/row-padding";
  * import { assertEquals } from "@std/assert";

--- a/webgpu/texture_with_data.ts
+++ b/webgpu/texture_with_data.ts
@@ -82,7 +82,9 @@ function textureMipLevelSize(
 /**
  * Create a {@linkcode GPUTexture} with data.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts no-eval
  * import { createTextureWithData } from "@std/webgpu/texture-with-data";
  *

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -36,7 +36,9 @@ export interface ParseOptions {
  *
  * Note: This does not support functions. Untrusted data is safe to parse.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parse } from "@std/yaml/parse";
  * import { assertEquals } from "@std/assert";
@@ -65,7 +67,9 @@ export function parse(
  * Same as {@linkcode parse}, but understands multi-document YAML sources, and
  * returns multiple parsed YAML document objects.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { parseAll } from "@std/yaml/parse";
  * import { assertEquals } from "@std/assert";

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -90,7 +90,9 @@ export type StringifyOptions = {
 /**
  * Converts a JavaScript object or value to a YAML document string.
  *
- * @example Usage
+ * @example
+ * <caption>Usage</caption>
+
  * ```ts
  * import { stringify } from "@std/yaml/stringify";
  * import { assertEquals } from "@std/assert";


### PR DESCRIPTION
The titles as written before would mess up the formatting in VSCode. This puts them in `<caption>` tags as sort of suggested in https://jsdoc.app/tags-example (the way it's written there also doesn't work, though). It also needs an empty line after in the case the caption spans multiple lines.