### PR TITLE
test(cli): stop spinner without error

### DIFF
--- a/cli/spinner_test.ts
+++ b/cli/spinner_test.ts
@@ -79,63 +79,63 @@ Deno.test("Spinner constructor accepts each color", async () => {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_black.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[30m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[30m⠋${COLOR_RESET} `);
   }
 
   {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_red.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[31m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[31m⠋${COLOR_RESET} `);
   }
 
   {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_green.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[32m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[32m⠋${COLOR_RESET} `);
   }
 
   {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_yellow.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[33m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[33m⠋${COLOR_RESET} `);
   }
 
   {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_blue.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[34m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[34m⠋${COLOR_RESET} `);
   }
 
   {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_magenta.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[35m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[35m⠋${COLOR_RESET} `);
   }
 
   {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_cyan.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[36m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[36m⠋${COLOR_RESET} `);
   }
 
   {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_white.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[37m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[37m⠋${COLOR_RESET} `);
   }
 
   {
     const text = await spawnDeno([
       "cli/testdata/spinner_cases/custom_color_gray.ts",
     ]);
-    assertEquals(text, `${LINE_CLEAR}\u001b[90m⠋${COLOR_RESET} `);
+    assertStringIncludes(text, `${LINE_CLEAR}\u001b[90m⠋${COLOR_RESET} `);
   }
 });
 
@@ -179,7 +179,7 @@ Deno.test("Spinner.color can get each color", () => {
 
 Deno.test("Spinner.start() begins the sequence", async () => {
   const text = await spawnDeno(["cli/testdata/spinner_cases/start.ts"]);
-  assertEquals(text, `${LINE_CLEAR}⠋${COLOR_RESET} `);
+  assertStringIncludes(text, `${LINE_CLEAR}⠋${COLOR_RESET} `);
 });
 
 Deno.test("Spinner.stop() terminates the sequence", async () => {

--- a/cli/testdata/spinner_cases/change_message.ts
+++ b/cli/testdata/spinner_cases/change_message.ts
@@ -7,4 +7,4 @@ spinner.start();
 setTimeout(() => (spinner.message = "One dino 🦕"), 125); // 150
 setTimeout(() => (spinner.message = "Two dinos 🦕🦕"), 200); // 225
 
-setTimeout(spinner.stop, 500);
+setTimeout(() => spinner.stop(), 500);

--- a/cli/testdata/spinner_cases/custom_color_black.ts
+++ b/cli/testdata/spinner_cases/custom_color_black.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "black" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_color_blue.ts
+++ b/cli/testdata/spinner_cases/custom_color_blue.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "blue" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_color_cyan.ts
+++ b/cli/testdata/spinner_cases/custom_color_cyan.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "cyan" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_color_gray.ts
+++ b/cli/testdata/spinner_cases/custom_color_gray.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "gray" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_color_green.ts
+++ b/cli/testdata/spinner_cases/custom_color_green.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "green" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_color_magenta.ts
+++ b/cli/testdata/spinner_cases/custom_color_magenta.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "magenta" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_color_red.ts
+++ b/cli/testdata/spinner_cases/custom_color_red.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "red" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_color_white.ts
+++ b/cli/testdata/spinner_cases/custom_color_white.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "white" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_color_yellow.ts
+++ b/cli/testdata/spinner_cases/custom_color_yellow.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ color: "yellow" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_interval_10.ts
+++ b/cli/testdata/spinner_cases/custom_interval_10.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ interval: 10 });
 
 spinner.start();
 
-setTimeout(spinner.stop, 1000);
+setTimeout(() => spinner.stop(), 1000);

--- a/cli/testdata/spinner_cases/custom_interval_750.ts
+++ b/cli/testdata/spinner_cases/custom_interval_750.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ interval: 750 });
 
 spinner.start();
 
-setTimeout(spinner.stop, 1000);
+setTimeout(() => spinner.stop(), 1000);

--- a/cli/testdata/spinner_cases/custom_message.ts
+++ b/cli/testdata/spinner_cases/custom_message.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner({ message: "Spinning with Deno 🦕" });
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);

--- a/cli/testdata/spinner_cases/custom_spinner.ts
+++ b/cli/testdata/spinner_cases/custom_spinner.ts
@@ -6,4 +6,4 @@ const spinner = new Spinner({
 
 spinner.start();
 
-setTimeout(spinner.stop, 1000);
+setTimeout(() => spinner.stop(), 1000);

--- a/cli/testdata/spinner_cases/set_color.ts
+++ b/cli/testdata/spinner_cases/set_color.ts
@@ -7,4 +7,4 @@ spinner.start();
 spinner.color = "black";
 setTimeout(() => spinner.color = "red", 125); // 150
 
-setTimeout(spinner.stop, 350);
+setTimeout(() => spinner.stop(), 350);

--- a/cli/testdata/spinner_cases/start.ts
+++ b/cli/testdata/spinner_cases/start.ts
@@ -4,4 +4,4 @@ const spinner = new Spinner();
 
 spinner.start();
 
-setTimeout(spinner.stop, 100);
+setTimeout(() => spinner.stop(), 100);


### PR DESCRIPTION
Currently most spinner test scripts end the execution with errors (because `setTimeout(spinner.stop, num)` throws instead of correctly stopping the spinner).

This PR fixes them by correctly stopping the spinners.

(This probably fixes https://github.com/denoland/std/issues/5541 )