### PR TITLE
chore: allow manual dispatch of workspace_publish

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -21,7 +21,8 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@v1
         with:
-          deno-version: canary
+          # TODO(kt3k): Set canary when LICENSE issue resolved. See std#5555
+          deno-version: 1.45.3
 
       - name: Format
         run: deno fmt --check

--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -3,6 +3,7 @@ name: workspace publish
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 jobs:
   publish:


### PR DESCRIPTION
We need to manually dispatch `workspace_publish` workflow to retry it with latest stable CLI.

ref: https://github.com/denoland/std/issues/5555