### PR TITLE
fix(semver): correctly remove spaces between operators and versions in `parseRange()`

### DIFF
--- a/semver/greater_than_range_test.ts
+++ b/semver/greater_than_range_test.ts
@@ -133,7 +133,7 @@ Deno.test("greaterThanRange() checks if the semver is greater than the range", a
     ["~>1", "1.2.3"],
     ["~> 1", "1.2.3"],
     ["~1.0", "1.0.2"], // >=1.0.0 <1.1.0
-    // ["~ 1.0", "1.0.2"], TODO(kt3k): Enable this. The parsing of `~ 1.0` seems broken now.
+    ["~ 1.0", "1.0.2"],
     [">=1", "1.0.0"],
     [">= 1", "1.0.0"],
     ["<1.2", "1.1.1"],

--- a/semver/less_than_range_test.ts
+++ b/semver/less_than_range_test.ts
@@ -37,7 +37,7 @@ Deno.test("lessThanRange() checks if the SemVer is less than the range", async (
     ["~>1", "0.2.4"],
     ["~> 1", "0.2.3"],
     ["~1.0", "0.1.2"], // >=1.0.0 <1.1.0
-    // ["~ 1.0", "0.1.0"], TODO(kt3k): Enable this. The parsing of `~ 1.0` seems broken now.
+    ["~ 1.0", "0.1.0"],
     [">1.2", "1.2.0"],
     ["> 1.2", "1.2.1"],
     ["~v0.5.4-pre", "0.5.4-alpha"],

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -406,7 +406,7 @@ function parseOperatorRanges(string: string): Comparator[] {
 export function parseRange(range: string): Range {
   return range
     // remove spaces between operators and versions
-    .replaceAll(/(?<=<|>|=) +/g, "")
+    .replaceAll(/(?<=<|>|=|~) +/g, "")
     .split(/\s*\|\|\s*/)
     .map((string) => parseHyphenRange(string) || parseOperatorRanges(string));
 }


### PR DESCRIPTION
Missed in #4375