### PR TITLE
refactor(semver): throw `TypeError` if release is invalid in `increment()`

### DIFF
--- a/semver/increment.ts
+++ b/semver/increment.ts
@@ -191,6 +191,6 @@ export function increment(
       };
     }
     default:
-      throw new Error(`invalid increment argument: ${release}`);
+      throw new TypeError(`Invalid increment argument: ${release}`);
   }
 }

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -1,6 +1,6 @@
 // Copyright Isaac Z. Schlueter and Contributors. All rights reserved. ISC license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import type { ReleaseType, SemVer } from "./types.ts";
 import { increment } from "./increment.ts";
 import { format } from "./format.ts";
@@ -972,4 +972,10 @@ Deno.test("increment()", async (t) => {
       },
     });
   }
+});
+
+Deno.test("increment() throws on invalid input", () => {
+  assertThrows(() =>
+    increment({ major: 1, minor: 2, patch: 3 }, "invalid" as ReleaseType)
+  );
 });

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -42,7 +42,7 @@ export function parse(version: string): SemVer {
   version = version.trim();
 
   const groups = version.match(FULL_REGEXP)?.groups;
-  if (!groups) throw new TypeError(`Invalid Version: ${version}`);
+  if (!groups) throw new TypeError(`Invalid version: ${version}`);
 
   const major = parseNumber(groups.major!, "Invalid major version");
   const minor = parseNumber(groups.minor!, "Invalid minor version");


### PR DESCRIPTION
Provides more context to the error.