### PR TITLE
fix(semver): throw on invalid input in `parseRange()`

### DIFF
--- a/semver/_constants.ts
+++ b/semver/_constants.ts
@@ -57,14 +57,6 @@ export const ALL: Comparator = {
   ...ANY,
 };
 
-/**
- * A comparator which will not span any semantic versions
- */
-export const NONE: Comparator = {
-  operator: "<",
-  ...MIN,
-};
-
 export const OPERATORS = [
   undefined,
   "=",

--- a/semver/is_range.ts
+++ b/semver/is_range.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 import type { Comparator, Range } from "./types.ts";
 import { OPERATORS } from "./_constants.ts";
-import { ALL, NONE } from "./_constants.ts";
+import { ALL } from "./_constants.ts";
 import { isSemVer } from "./is_semver.ts";
 
 function isComparator(value: unknown): value is Comparator {
@@ -10,7 +10,7 @@ function isComparator(value: unknown): value is Comparator {
     value === null || value === undefined || Array.isArray(value) ||
     typeof value !== "object"
   ) return false;
-  if (value === NONE || value === ALL) return true;
+  if (value === ALL) return true;
   const { operator } = value as Comparator;
   return (
     (operator === undefined ||

--- a/semver/max_satisfying_test.ts
+++ b/semver/max_satisfying_test.ts
@@ -4,7 +4,6 @@ import { assertEquals } from "@std/assert";
 import { parse } from "./parse.ts";
 import { parseRange } from "./parse_range.ts";
 import { maxSatisfying } from "./max_satisfying.ts";
-import { MAX, MIN } from "./_constants.ts";
 
 Deno.test({
   name: "maxSatisfying()",
@@ -25,9 +24,4 @@ Deno.test({
       });
     }
   },
-});
-
-Deno.test("minSatisfying() handles bad ranges", function () {
-  const r = parseRange("some frogs and sneks-v2.5.6");
-  assertEquals(maxSatisfying([MIN, MAX], r), undefined);
 });

--- a/semver/min_satisfying_test.ts
+++ b/semver/min_satisfying_test.ts
@@ -4,7 +4,6 @@ import { assertEquals } from "@std/assert";
 import { parse } from "./parse.ts";
 import { parseRange } from "./parse_range.ts";
 import { minSatisfying } from "./min_satisfying.ts";
-import { MAX, MIN } from "./_constants.ts";
 
 Deno.test("minSatisfying()", async (t) => {
   const versions: [string[], string, string][] = [
@@ -22,9 +21,4 @@ Deno.test("minSatisfying()", async (t) => {
       assertEquals(actual, expected);
     });
   }
-});
-
-Deno.test("minSatisfying() handles bad ranges", function () {
-  const r = parseRange("some frogs and sneks-v2.5.6");
-  assertEquals(minSatisfying([MIN, MAX], r), undefined);
 });

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -406,7 +406,7 @@ function parseOperatorRanges(string: string): (Comparator | null)[] {
 export function parseRange(range: string): Range {
   const result = range
     // remove spaces between operators and versions
-    .replaceAll(/(?<=<|>|=|~)(\s+)/g, "")
+    .replaceAll(/(?<=<|>|=|~|^)(\s+)/g, "")
     .split(/\s*\|\|\s*/)
     .map((string) => parseHyphenRange(string) || parseOperatorRanges(string));
   if (result.some((r) => r.includes(null))) {

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -406,7 +406,7 @@ function parseOperatorRanges(string: string): (Comparator | null)[] {
 export function parseRange(range: string): Range {
   const result = range
     // remove spaces between operators and versions
-    .replaceAll(/(?<=<|>|=|~|^)(\s+)/g, "")
+    .replaceAll(/(?<=<|>|=|~|\^)(\s+)/g, "")
     .split(/\s*\|\|\s*/)
     .map((string) => parseHyphenRange(string) || parseOperatorRanges(string));
   if (result.some((r) => r.includes(null))) {

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -406,7 +406,7 @@ function parseOperatorRanges(string: string): (Comparator | null)[] {
 export function parseRange(range: string): Range {
   const result = range
     // remove spaces between operators and versions
-    .replaceAll(/(?<=<|>|=|~) +/g, "")
+    .replaceAll(/(?<=<|>|=|~)(\s+)/g, "")
     .split(/\s*\|\|\s*/)
     .map((string) => parseHyphenRange(string) || parseOperatorRanges(string));
   if (result.some((r) => r.includes(null))) {

--- a/semver/parse_range_test.ts
+++ b/semver/parse_range_test.ts
@@ -579,6 +579,12 @@ Deno.test("parseRange() parses ranges with caret", () => {
         { operator: "<", major: 2, minor: 0, patch: 0 },
       ],
     ]],
+    ["^ 1.2.3", [
+      [
+        { operator: ">=", major: 1, minor: 2, patch: 3, prerelease: [] },
+        { operator: "<", major: 2, minor: 0, patch: 0 },
+      ],
+    ]],
     ["^0.2.3", [
       [
         { operator: ">=", major: 0, minor: 2, patch: 3, prerelease: [] },

--- a/semver/parse_range_test.ts
+++ b/semver/parse_range_test.ts
@@ -1,6 +1,6 @@
 // Copyright Isaac Z. Schlueter and Contributors. All rights reserved. ISC license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { parseRange } from "./parse_range.ts";
 import type { Range } from "./types.ts";
 
@@ -351,18 +351,6 @@ Deno.test("parseRange() parse ranges of different kinds", () => {
         { operator: "<", major: 0, minor: 0, patch: 2 },
       ],
     ]],
-    ["blerg", [
-      [
-        {
-          operator: "<",
-          major: 0,
-          minor: 0,
-          patch: 0,
-          prerelease: [],
-          build: [],
-        },
-      ],
-    ]],
     ["^1.2.3", [
       [
         { operator: ">=", major: 1, minor: 2, patch: 3, prerelease: [] },
@@ -663,4 +651,8 @@ Deno.test("parseRange() parses ranges with caret", () => {
     const range = parseRange(r);
     assertEquals(range, expected);
   }
+});
+
+Deno.test("parseRange() throws on invalid range", () => {
+  assertThrows(() => parseRange("blerg"), TypeError, "Invalid range: blerg");
 });

--- a/semver/satisfies_test.ts
+++ b/semver/satisfies_test.ts
@@ -269,7 +269,6 @@ Deno.test({
       ["<=1.2.3", "1.2.3-beta"],
 
       // invalid ranges never satisfied!
-      ["blerg", "1.2.3"],
       ["^1.2.3", "2.0.0-pre"],
 
       ["1.0.0 - 2.0.0", "0.0.0"],


### PR DESCRIPTION
Closes #4845