### PR TITLE
fix(http): better `eTag` return type for `string` and `Uint8Array` inputs

### DIFF
--- a/http/etag.ts
+++ b/http/etag.ts
@@ -95,7 +95,7 @@ async function calcFileInfo(
 }
 
 /**
- * Calculate an ETag for string or Uint8Array entities. This returns a strong tag.
+ * Calculate an ETag for string or `Uint8Array` entities. This returns a strong tag.
  *
  * @example Usage
  * ```ts

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -95,9 +95,7 @@ async function calcFileInfo(
 }
 
 /**
- * Calculate an ETag for an entity. When the entity is a specific set of data
- * it will be fingerprinted as a "strong" tag, otherwise if it is just file
- * information, it will be calculated as a weak tag.
+ * Calculate an ETag for string or Uint8Array entities. This returns a strong tag.
  *
  * @example Usage
  * ```ts
@@ -121,9 +119,7 @@ export async function eTag(
   options?: ETagOptions,
 ): Promise<string>;
 /**
- * Calculate an ETag for an entity. When the entity is a specific set of data
- * it will be fingerprinted as a "strong" tag, otherwise if it is just file
- * information, it will be calculated as a weak tag.
+ * Calculate an ETag for file information entity. This returns a weak tag.
  *
  * @example Usage
  * ```ts

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -117,6 +117,14 @@ async function calcFileInfo(
  * @returns The calculated ETag.
  */
 export async function eTag(
+  entity: string | Uint8Array,
+  options?: ETagOptions,
+): Promise<string>;
+export async function eTag(
+  entity: FileInfo,
+  options?: ETagOptions,
+): Promise<string | undefined>;
+export async function eTag(
   entity: ETagSource,
   options: ETagOptions = {},
 ): Promise<string | undefined> {

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -95,7 +95,11 @@ async function calcFileInfo(
 }
 
 /**
- * Calculate an ETag for string or `Uint8Array` entities. This returns a strong tag.
+ * Calculate an ETag for string or `Uint8Array` entities. This returns a
+ * {@linkcode https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#etag_value | strong tag}
+ * of the form `"<ascii chars>"`, which guarantees the byte-for-byte equality of the resource.
+ *
+ * You can optionally set true to the `weak` option to get a weak tag.
  *
  * @example Usage
  * ```ts
@@ -119,7 +123,10 @@ export async function eTag(
   options?: ETagOptions,
 ): Promise<string>;
 /**
- * Calculate an ETag for file information entity. This returns a weak tag.
+ * Calculate an ETag for file information entity. This returns a
+ * {@linkcode https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/ETag#w | weak tag}
+ * of the form `W\"<ascii chars>"`, which guarantees the equivalence of the resource,
+ * not the byte-for-byte equality.
  *
  * @example Usage
  * ```ts

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -120,6 +120,30 @@ export async function eTag(
   entity: string | Uint8Array,
   options?: ETagOptions,
 ): Promise<string>;
+/**
+ * Calculate an ETag for an entity. When the entity is a specific set of data
+ * it will be fingerprinted as a "strong" tag, otherwise if it is just file
+ * information, it will be calculated as a weak tag.
+ *
+ * @example Usage
+ * ```ts
+ * import { eTag } from "@std/http/etag";
+ * import { assert } from "@std/assert";
+ *
+ * const fileInfo = await Deno.stat("README.md");
+ *
+ * const etag = await eTag(fileInfo);
+ * assert(etag);
+ *
+ * const body = (await Deno.open("README.md")).readable;
+ *
+ * const res = new Response(body, { headers: { etag } });
+ * ```
+ *
+ * @param entity The entity to get the ETag for.
+ * @param options Various additional options.
+ * @returns The calculated ETag.
+ */
 export async function eTag(
   entity: FileInfo,
   options?: ETagOptions,

--- a/http/etag_test.ts
+++ b/http/etag_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals } from "@std/assert";
-import { assertType, IsExact } from "@std/testing/types";
+import { assertType, type IsExact } from "@std/testing/types";
 
 import { eTag, ifMatch, ifNoneMatch } from "./etag.ts";
 

--- a/http/etag_test.ts
+++ b/http/etag_test.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { assert, assertEquals } from "@std/assert";
+import { assertType, IsExact } from "@std/testing/types";
 
 import { eTag, ifMatch, ifNoneMatch } from "./etag.ts";
 
@@ -129,5 +130,19 @@ Deno.test({
         }),
       ),
     );
+  },
+});
+
+Deno.test({
+  name: "eTag() returns string type for string and Uint8Array",
+  async fn() {
+    {
+      const result = await eTag("hello deno");
+      assertType<IsExact<typeof result, string>>(true);
+    }
+    {
+      const result = await eTag(new Uint8Array());
+      assertType<IsExact<typeof result, string>>(true);
+    }
   },
 });


### PR DESCRIPTION
Not completely sure this is a breaking change, but this PR improves the return type of `eTag` function. Now it returns `Promise<string>` if the input is `string` or `Uint8Array`.

related #5217