### PR TITLE
BREAKING(ini): reduce options for `stringify`, make `FormattingOptions` type private

### DIFF
--- a/ini/stringify.ts
+++ b/ini/stringify.ts
@@ -12,7 +12,7 @@ export interface StringifyOptions {
    */
   lineBreak?: "\n" | "\r\n" | "\r";
   /**
-   * Use a plain assignment char or pad with spaces. Ignored on parse.
+   * Use a plain assignment char or pad with spaces.
    *
    * @default {false}
    */

--- a/ini/stringify.ts
+++ b/ini/stringify.ts
@@ -1,14 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import {
-  type FormattingOptions,
-  IniMap,
-  type ReplacerFunction,
-} from "./_ini_map.ts";
+import { IniMap, type ReplacerFunction } from "./_ini_map.ts";
 
 /** Options for {@linkcode stringify}. */
-export interface StringifyOptions extends FormattingOptions {
+export interface StringifyOptions {
   /**
    * Provide custom string conversion for the value in a key/value pair.
    * Similar to the
@@ -18,7 +14,7 @@ export interface StringifyOptions extends FormattingOptions {
   replacer?: ReplacerFunction;
 }
 
-export type { FormattingOptions, ReplacerFunction };
+export type { ReplacerFunction };
 
 /**
  * Compile an object into an INI config string. Provide formatting options to modify the output.
@@ -83,5 +79,5 @@ export function stringify(
   object: any,
   options?: StringifyOptions,
 ): string {
-  return IniMap.from(object, options).toString(options?.replacer);
+  return IniMap.from(object).toString(options?.replacer);
 }

--- a/ini/stringify.ts
+++ b/ini/stringify.ts
@@ -6,6 +6,18 @@ import { IniMap, type ReplacerFunction } from "./_ini_map.ts";
 /** Options for {@linkcode stringify}. */
 export interface StringifyOptions {
   /**
+   * Character(s) used to break lines in the config file. Ignored on parse.
+   *
+   * @default {"\n"}
+   */
+  lineBreak?: "\n" | "\r\n" | "\r";
+  /**
+   * Use a plain assignment char or pad with spaces. Ignored on parse.
+   *
+   * @default {false}
+   */
+  pretty?: boolean;
+  /**
    * Provide custom string conversion for the value in a key/value pair.
    * Similar to the
    * {@linkcode https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/stringify#replacer | replacer}
@@ -79,5 +91,5 @@ export function stringify(
   object: any,
   options?: StringifyOptions,
 ): string {
-  return IniMap.from(object).toString(options?.replacer);
+  return IniMap.from(object, options).toString(options?.replacer);
 }

--- a/ini/stringify.ts
+++ b/ini/stringify.ts
@@ -6,7 +6,7 @@ import { IniMap, type ReplacerFunction } from "./_ini_map.ts";
 /** Options for {@linkcode stringify}. */
 export interface StringifyOptions {
   /**
-   * Character(s) used to break lines in the config file. Ignored on parse.
+   * Character(s) used to break lines in the config file.
    *
    * @default {"\n"}
    */

--- a/ini/stringify_test.ts
+++ b/ini/stringify_test.ts
@@ -18,10 +18,6 @@ Deno.test({
   fn() {
     assertValidStringify({ a: "b" }, `a=b`);
     assertValidStringify({ a: "b" }, `a = b`, { pretty: true });
-    assertValidStringify({ a: "b" }, `a : b`, {
-      assignment: ":",
-      pretty: true,
-    });
     assertValidStringify(
       { a: "b", section: { c: "d" }, e: "f" },
       `a=b\ne=f\n[section]\nc=d`,


### PR DESCRIPTION
This PR removes `commentChar`, `assignment`, and `deduplicate` options from `stringfiy` options.

- `deduplicate` is no longer relevant as we dropped the support of `IniMap`, which was only meaningful with `IniMap`
- `commentChar` is no longer relevant as stringify doesn't support comments in output.
- Dropped `assignment` option as `=` seems the only common character for assignment in `INI`.

This PR also make `FormattingOptions` private as it's no longer reasonable to keep it public.

related #5562