### PR TITLE
chore: update Releases.md

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -83,6 +83,7 @@
 
 #### @std/text 1.0.1 (patch)
 
+- feat(text/unstable): add toConstantCase() (#5110)
 - fix(text): unicode support and word splitting according to case (#5447)
 - perf(text): make `levenshteinDistance()` up to 147x faster (#5527)
 - test(text): add more testcases for `levenshteinDistance` (#5528)


### PR DESCRIPTION
#5110 was missed in the release note in the previous release #5554 because [the upgrade tool](https://github.com/denoland/bump-workspaces) didn't understand `text/unstable` scope yet. (Now it's addressed in https://github.com/denoland/bump-workspaces/pull/30 )

This PR fixes the release note.