### PR TITLE
refactor(io): use `writeAll()` within `copy()`

### DIFF
--- a/io/copy.ts
+++ b/io/copy.ts
@@ -2,6 +2,7 @@
 // This module is browser compatible.
 
 import { DEFAULT_BUFFER_SIZE } from "./_constants.ts";
+import { writeAll } from "./write_all.ts";
 import type { Reader, Writer } from "./types.ts";
 
 /**
@@ -22,6 +23,7 @@ import type { Reader, Writer } from "./types.ts";
  * @param src The source to copy from
  * @param dst The destination to copy to
  * @param options Can be used to tune size of the buffer. Default size is 32kB
+ * @returns Number of bytes copied
  */
 export async function copy(
   src: Reader,
@@ -31,20 +33,12 @@ export async function copy(
   },
 ): Promise<number> {
   let n = 0;
-  const bufSize = options?.bufSize ?? DEFAULT_BUFFER_SIZE;
-  const b = new Uint8Array(bufSize);
-  let gotEOF = false;
-  while (gotEOF === false) {
+  const b = new Uint8Array(options?.bufSize ?? DEFAULT_BUFFER_SIZE);
+  while (true) {
     const result = await src.read(b);
-    if (result === null) {
-      gotEOF = true;
-    } else {
-      let nwritten = 0;
-      while (nwritten < result) {
-        nwritten += await dst.write(b.subarray(nwritten, result));
-      }
-      n += nwritten;
-    }
+    if (result === null) break;
+    await writeAll(dst, b.subarray(0, result));
+    n += result;
   }
   return n;
 }

--- a/io/copy_test.ts
+++ b/io/copy_test.ts
@@ -1,21 +1,37 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { copy } from "./copy.ts";
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertStrictEquals } from "@std/assert";
 
 const SRC_PATH = "./io/testdata/copy-src.txt";
 const DST_PATH = "./io/testdata/copy-dst.txt";
 
-Deno.test("copy()", async () => {
+Deno.test("copy()", async (t) => {
   try {
     using srcFile = await Deno.open(SRC_PATH);
     using dstFile = await Deno.open(DST_PATH, {
       create: true,
       write: true,
     });
-    await copy(srcFile, dstFile);
-    const srcOutput = await Deno.readFile(SRC_PATH);
-    const dstOutput = await Deno.readFile(DST_PATH);
-    assertEquals(srcOutput, dstOutput);
+
+    const actualByteCount = await copy(srcFile, dstFile);
+
+    await t.step(
+      "number of copied bytes equals source size",
+      async () => {
+        const fileInfo = await srcFile.stat();
+        const expectedByteCount = fileInfo.size;
+        assertStrictEquals(actualByteCount, expectedByteCount);
+      },
+    );
+
+    await t.step(
+      "source and destination bytes are equal",
+      async () => {
+        const srcOutput = await Deno.readFile(SRC_PATH);
+        const dstOutput = await Deno.readFile(DST_PATH);
+        assertEquals(srcOutput, dstOutput);
+      },
+    );
   } finally {
     await Deno.remove(DST_PATH);
   }


### PR DESCRIPTION
- deduplicate logic by importing `writeAll`
- add JSDoc description of returned value
- add test step for returned value