### PR TITLE
fix(semver): do not throw in `canParse`

### DIFF
--- a/semver/can_parse.ts
+++ b/semver/can_parse.ts
@@ -21,10 +21,7 @@ export function canParse(version: string): boolean {
   try {
     parse(version);
     return true;
-  } catch (err) {
-    if (!(err instanceof TypeError)) {
-      throw err;
-    }
+  } catch {
     return false;
   }
 }


### PR DESCRIPTION
This addressed the concern raised in https://github.com/denoland/std/pull/5220#pullrequestreview-2208098580