### PR TITLE
BREAKING(semver): do not accept undefined input in `tryParse`

### DIFF
--- a/semver/try_parse.ts
+++ b/semver/try_parse.ts
@@ -21,10 +21,7 @@ import { parse } from "./parse.ts";
  * @param version The version string to parse
  * @returns A valid SemVer or `undefined`
  */
-export function tryParse(version?: string): SemVer | undefined {
-  if (version === undefined) {
-    return undefined;
-  }
+export function tryParse(version: string): SemVer | undefined {
   try {
     return parse(version);
   } catch {


### PR DESCRIPTION
# What's changed

The argument of `tryParse` becomes `string` instead of `string | undefined`.

# Motivation

`canParse` and `parse` only accepts `string`. This change aligns `tryParse` to these similar APis.

# Migration guide

```diff
-tryParse(version);
+typeof version === "string" ? tryParse(version) : undefined;
```