### PR TITLE
docs(semver): clarify compare docs

### DIFF
--- a/semver/compare.ts
+++ b/semver/compare.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Compare two SemVers.
  *
- * Returns `0` if `s0 === s1`, or `1` if `s0` is greater, or `-1` if `s1` is
+ * Returns `0` if `s0` equals `s1`, or `1` if `s0` is greater, or `-1` if `s1` is
  * greater.
  *
  * Sorts in ascending order if passed to {@linkcode Array.sort}.


### PR DESCRIPTION
This PR clarifies the description of `compare` docs. The expression `s0 === s1` is misleading as the equality of semvers can't be checked with `===` operator.