### PR TITLE
BREAKING(semver): remove the handling of non-standard SemVers in format function

### DIFF
--- a/semver/_constants.ts
+++ b/semver/_constants.ts
@@ -3,36 +3,12 @@
 import type { Comparator, SemVer } from "./types.ts";
 
 /**
- * MAX is a sentinel value used by some range calculations.
- * It is equivalent to `∞.∞.∞`.
- */
-export const MAX: SemVer = {
-  major: Number.POSITIVE_INFINITY,
-  minor: Number.POSITIVE_INFINITY,
-  patch: Number.POSITIVE_INFINITY,
-  prerelease: [],
-  build: [],
-};
-
-/**
  * The minimum valid SemVer object. Equivalent to `0.0.0`.
  */
 export const MIN: SemVer = {
   major: 0,
   minor: 0,
   patch: 0,
-  prerelease: [],
-  build: [],
-};
-
-/**
- * A sentinel value used to denote an invalid SemVer object
- * which may be the result of impossible ranges or comparator operations.
- */
-export const INVALID: SemVer = {
-  major: Number.NEGATIVE_INFINITY,
-  minor: Number.POSITIVE_INFINITY,
-  patch: Number.POSITIVE_INFINITY,
   prerelease: [],
   build: [],
 };

--- a/semver/format.ts
+++ b/semver/format.ts
@@ -1,16 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 import type { SemVer } from "./types.ts";
-import { isWildcardComparator } from "./_shared.ts";
 
 function formatNumber(value: number) {
-  if (value === Number.POSITIVE_INFINITY) {
-    return "∞";
-  } else if (value === Number.NEGATIVE_INFINITY) {
-    return "⧞";
-  } else {
-    return value.toFixed(0);
-  }
+  return value.toFixed(0);
 }
 
 /**
@@ -37,10 +30,6 @@ function formatNumber(value: number) {
  * @returns The string representation of a semantic version.
  */
 export function format(semver: SemVer): string {
-  if (isWildcardComparator(semver)) {
-    return "*";
-  }
-
   const major = formatNumber(semver.major);
   const minor = formatNumber(semver.minor);
   const patch = formatNumber(semver.patch);

--- a/semver/format.ts
+++ b/semver/format.ts
@@ -9,10 +9,6 @@ function formatNumber(value: number) {
 /**
  * Format a SemVer object into a string.
  *
- * If any number is {@linkcode NaN}, then `NaN` will be printed.
- *
- * If any number is positive or negative infinity then '∞' or '⧞' will be printed instead.
- *
  * @example Usage
  * ```ts
  * import { format } from "@std/semver/format";

--- a/semver/format_range.ts
+++ b/semver/format_range.ts
@@ -2,10 +2,13 @@
 // This module is browser compatible.
 import { format } from "./format.ts";
 import type { Comparator, Range } from "./types.ts";
+import { isWildcardComparator } from "./_shared.ts";
 
 function formatComparator(comparator: Comparator): string {
   const { operator } = comparator;
-  return `${operator === undefined ? "" : operator}${format(comparator)}`;
+  return `${operator === undefined ? "" : operator}${
+    isWildcardComparator(comparator) ? "*" : format(comparator)
+  }`;
 }
 
 /**

--- a/semver/format_test.ts
+++ b/semver/format_test.ts
@@ -3,8 +3,6 @@
 import { assertEquals } from "@std/assert";
 import { format } from "./format.ts";
 import { parse } from "./parse.ts";
-import { INVALID, MAX, MIN } from "./_constants.ts";
-import type { SemVer } from "./types.ts";
 
 Deno.test("format()", async (t) => {
   const versions: [string, string][] = [
@@ -22,21 +20,6 @@ Deno.test("format()", async (t) => {
       fn: () => {
         const v = parse(version)!;
         const actual = format(v);
-        assertEquals(actual, expected);
-      },
-    });
-  }
-
-  const constantSemVers: [SemVer, string][] = [
-    [MAX, "∞.∞.∞"],
-    [MIN, "0.0.0"],
-    [INVALID, "⧞.∞.∞"],
-  ];
-  for (const [version, expected] of constantSemVers) {
-    await t.step({
-      name: format(version),
-      fn: () => {
-        const actual = format(version);
         assertEquals(actual, expected);
       },
     });

--- a/semver/format_test.ts
+++ b/semver/format_test.ts
@@ -6,6 +6,7 @@ import { parse } from "./parse.ts";
 
 Deno.test("format()", async (t) => {
   const versions: [string, string][] = [
+    ["0.0.0", "0.0.0"],
     ["1.2.3", "1.2.3"],
     ["1.2.3-pre", "1.2.3-pre"],
     ["1.2.3-pre.0", "1.2.3-pre.0"],

--- a/semver/is_semver.ts
+++ b/semver/is_semver.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
-import { ANY, INVALID } from "./_constants.ts";
+import { ANY } from "./_constants.ts";
 import type { SemVer } from "./types.ts";
 import { isValidNumber, isValidString } from "./_shared.ts";
 
@@ -39,7 +39,6 @@ export function isSemVer(value: unknown): value is SemVer {
   if (value === null || value === undefined) return false;
   if (Array.isArray(value)) return false;
   if (typeof value !== "object") return false;
-  if (value === INVALID) return true;
   if (value === ANY) return true;
 
   const {

--- a/semver/is_semver_test.ts
+++ b/semver/is_semver_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert } from "@std/assert";
-import { MAX, MIN } from "./_constants.ts";
+import { MIN } from "./_constants.ts";
 import { isSemVer } from "./is_semver.ts";
 
 Deno.test({
@@ -61,7 +61,6 @@ Deno.test({
       [{ major: 0, minor: 0, patch: 0, build: [], prerelease: ["abc"] }],
       [{ major: 0, minor: 0, patch: 0, build: [], prerelease: ["abc", 0] }],
       [MIN],
-      [MAX],
     ];
     for (const [v] of versions) {
       await t.step(


### PR DESCRIPTION
# What's changed

`format` currently handles NaN semvers (`{ major: NaN, minor: NaN, patch: NaN }`) or Infinity semvers (such as `{ major: Infinity, minor: Infinity, patch: Infinity }`) in a special way.

This change stops those special handlings.

# Motivation

The infinity SemVers or NaN SemVers don't represent valid semantic versions, and they are not part of the semver spec. It's not reasonable to handle them in a special way, but rather we should consider them invalid versions.

# Migration

Do not use these non-standard semvers as sentinel values. Instead use comparison functions such as `compare`, `greaterThan`, `lessThan`, `greaterThanRange`, `lessThanRange`, etc for checking semver conditions.