### PR TITLE
BREAKING(ini): move `reviver` to 2nd argument in `parse()`

### DIFF
--- a/ini/parse.ts
+++ b/ini/parse.ts
@@ -2,17 +2,7 @@
 // This module is browser compatible.
 
 import { IniMap, type ReviverFunction } from "./_ini_map.ts";
-export type { ParseOptions, ReviverFunction };
-
-/** Options for {@linkcode parse}. */
-interface ParseOptions {
-  /**
-   * Provide custom parsing of the value in a key/value pair. Similar to the
-   * {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#reviver | reviver}
-   * function in {@linkcode JSON.parse}.
-   */
-  reviver?: ReviverFunction;
-}
+export type { ReviverFunction };
 
 /**
  * Parse an INI config string into an object.
@@ -48,22 +38,22 @@ interface ParseOptions {
  * import { parse } from "@std/ini/parse";
  * import { assertEquals } from "@std/assert";
  *
+ * function reviver(key: string, value: string, section?: string): Date | number | string {
+ *   if (section === "section Foo") {
+ *     if (key === "date") {
+ *       return new Date(value);
+ *     } else if (key === "amount") {
+ *       return +value;
+ *     }
+ *   }
+ *   return value;
+ * }
+ *
  * const parsed = parse(`
  * [section Foo]
  * date = 2012-10-10
  * amount = 12345
- * `, {
- *   reviver(key, value, section) {
- *     if (section === "section Foo") {
- *       if (key === "date") {
- *         return new Date(value);
- *       } else if (key === "amount") {
- *         return +value;
- *       }
- *     }
- *     return value;
- *   }
- * });
+ * `, reviver);
  *
  * assertEquals(parsed, {
  *   "section Foo": {
@@ -74,12 +64,12 @@ interface ParseOptions {
  * ```
  *
  * @param text The text to parse
- * @param options The options to use
+ * @param reviver Function for replacing INI values with JavaScript values.
  * @return The parsed object
  */
 export function parse(
   text: string,
-  options?: ParseOptions,
+  reviver: ReviverFunction = (_key, value) => value,
 ): Record<string, unknown | Record<string, unknown>> {
-  return IniMap.from(text, options).toObject();
+  return IniMap.from(text, { reviver }).toObject();
 }


### PR DESCRIPTION
### What's changed

This PR replaces [`ParseOptions`](https://jsr.io/@std/ini@1.0.0-rc.2/doc/~/ParseOptions) with `reviver` (the function previously defined as [`ParseOptions.reviver`](https://jsr.io/@std/ini@1.0.0-rc.2/doc/~/ParseOptions.reviver)). As a result, the `ParseOptions` interface has been removed as it's no longer used anywhere.

### Motivation

This change was made to simplify working with [`parse()`](https://jsr.io/@std/ini@1.0.0-rc.2/doc/parse/~/parse), as having a whole `options` object was extraneous, given it only included one property.

### Migration guide

To migrate, move the `reviver` function from `options.reviver` to the 2nd argument of `parse()`.

```diff
import { parse } from "@std/ini/parse";
import { assertEquals } from "@std/assert";

function reviver(
  key: string,
  value: string,
  section?: string,
): number | Date | string {
  if (section === "section Foo") {
    if (key === "date") {
      return new Date(value);
    } else if (key === "amount") {
      return +value;
    }
  }
  return value;
}

const iniText = `
[section Foo]
date = 2012-10-10
amount = 12345
`;

- const parsed = parse(iniText, { reviver });
+ const parsed = parse(iniText, reviver);

assertEquals(parsed, {
  "section Foo": {
    date: new Date("2012-10-10"),
    amount: 12345,
  },
});
```