### PR TITLE
docs(testing): mention default serializer

### DIFF
--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -189,7 +189,7 @@ export type SnapshotOptions<T = unknown> = {
    */
   path?: string;
   /**
-   * Function to use when serializing the snapshot.
+   * Function to use when serializing the snapshot. The default is {@linkcode serialize}.
    */
   serializer?: (actual: T) => string;
 };


### PR DESCRIPTION
This PR adds the mentioning of the default serializer of snapshot testing.

related #5218 