### PR TITLE
test(async): fix `abortable.AsyncIterable() calls return before throwing` test

### DIFF
--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -137,9 +137,13 @@ Deno.test("abortable.AsyncIterable() calls return before throwing", async () => 
   const iterable: AsyncIterable<string> = {
     [Symbol.asyncIterator]: () => ({
       next: () =>
-        new Promise((resolve) =>
-          setTimeout(() => resolve({ value: "Hello", done: false }), 1)
-        ),
+        new Promise((resolve) => {
+          const timeoutId = setTimeout(
+            () => resolve({ value: "Hello", done: false }),
+            1,
+          );
+          clearTimeout(timeoutId);
+        }),
       return: () => {
         returnCalled = true;
         return Promise.resolve({ value: undefined, done: true });

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -134,15 +134,15 @@ Deno.test("abortable.AsyncIterable() handles already aborted signal", async () =
 Deno.test("abortable.AsyncIterable() calls return before throwing", async () => {
   const c = new AbortController();
   let returnCalled = false;
+  let timeoutId: number;
   const iterable: AsyncIterable<string> = {
     [Symbol.asyncIterator]: () => ({
       next: () =>
         new Promise((resolve) => {
-          const timeoutId = setTimeout(
+          timeoutId = setTimeout(
             () => resolve({ value: "Hello", done: false }),
             1,
           );
-          clearTimeout(timeoutId);
         }),
       return: () => {
         returnCalled = true;
@@ -164,4 +164,5 @@ Deno.test("abortable.AsyncIterable() calls return before throwing", async () => 
   assertEquals(returnCalled, true);
   assertEquals(error.name, "AbortError");
   assertEquals(items, []);
+  clearTimeout(timeoutId!);
 });


### PR DESCRIPTION
Fixes https://github.com/denoland/std/actions/runs/10189680039/job/28188160624