### PR TITLE
docs(csv): more examples for `parse` and `CsvParseStream`

### DIFF
--- a/csv/_io.ts
+++ b/csv/_io.ts
@@ -228,11 +228,13 @@ export function createQuoteErrorMessage(
 export function convertRowToObject(
   row: string[],
   headers: readonly string[],
-  index: number,
+  zeroBasedLine: number,
 ) {
   if (row.length !== headers.length) {
     throw new Error(
-      `Error number of fields line: ${index}\nNumber of fields found: ${headers.length}\nExpected number of fields: ${row.length}`,
+      `record on line ${
+        zeroBasedLine + 1
+      } has ${row.length} fields, but the header has ${headers.length} fields`,
     );
   }
   const out: Record<string, unknown> = {};

--- a/csv/_io.ts
+++ b/csv/_io.ts
@@ -45,7 +45,8 @@ export interface ReadOptions {
    * If negative, no check is made and records may have a variable number of
    * fields.
    *
-   * If the wrong number of fields is in a row, a `ParseError` is thrown.
+   * If the wrong number of fields is in a row, a {@linkcode https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError | SyntaxError}
+   * is thrown.
    */
   fieldsPerRecord?: number;
 }

--- a/csv/mod.ts
+++ b/csv/mod.ts
@@ -56,7 +56,9 @@
  *
  * results in
  *
+ * ```ts no-assert
  * [`the "word" is true`, `a "quoted-field"`]
+ * ```
  *
  * Newlines and commas may be included in a quoted-field
  *

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -261,7 +261,7 @@ export interface ParseOptions {
    * are ignored. With leading whitespace the comment character becomes part of
    * the field, even you provide `trimLeadingSpace: true`.
    *
-   * @default {"#"}
+   * By default, no character is considered to be a start of a comment.
    */
   comment?: string;
   /** Flag to trim the leading space of the value.

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -306,8 +306,7 @@ export interface ParseOptions {
 }
 
 /**
- * Csv parse helper to manipulate data.
- * Provides an auto/custom mapper for columns.
+ * Parses CSV string into an array of arrays of strings.
  *
  * @example Usage
  * ```ts
@@ -324,8 +323,10 @@ export interface ParseOptions {
  */
 export function parse(input: string): string[][];
 /**
- * Csv parse helper to manipulate data.
- * Provides an auto/custom mapper for columns.
+ * Parses CSV string into an array of objects or an array of arrays of strings.
+ *
+ * If `column` or `skipFirstRow` option is provided, it returns an array of
+ * objects, otherwise it returns an array of arrays of string.
  *
  * @example Usage
  * ```ts

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -505,9 +505,9 @@ export function parse<const T extends ParseOptions>(
       headers = options.columns;
     }
 
-    const firstLineIndex = options.skipFirstRow ? 1 : 0;
+    const zeroBasedFirstLineIndex = options.skipFirstRow ? 1 : 0;
     return r.map((row, i) => {
-      return convertRowToObject(row, headers, firstLineIndex + i);
+      return convertRowToObject(row, headers, zeroBasedFirstLineIndex + i);
     }) as ParseResult<ParseOptions, T>;
   }
   return r as ParseResult<ParseOptions, T>;

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -246,7 +246,7 @@ class Parser {
       if (lineResult.length > 0) {
         if (_nbFields && _nbFields !== lineResult.length) {
           throw new SyntaxError(
-            `record on line ${lineIndex}: wrong number of fields`,
+            `record on line ${lineIndex}: expected ${_nbFields} fields but got ${lineResult.length}`,
           );
         }
         result.push(lineResult);
@@ -444,6 +444,33 @@ export function parse(input: string): string[][];
  * const result = parse(string, { comment: "#" });
  *
  * assertEquals(result, [["a", "b", "c"], ["d", "e", "f"]]);
+ * ```
+ *
+ * @example fieldsPerRecord: 0 (infer the number of fields from the first row)
+ *  ```ts
+ * import { parse } from "@std/csv/parse";
+ * import { assertThrows } from "@std/assert/throws";
+ *
+ * // Note that the second row has more fields than the first row
+ * const string = "a,b\nc,d,e";
+ * assertThrows(
+ *   () => parse(string, { fieldsPerRecord: 0 }),
+ *   SyntaxError,
+ *   "record on line 2: expected 2 fields but got 3",
+ * );
+ * ```
+ *
+ * @example fieldsPerRecord: 2 (enforce the number of fields for each row)
+ *  ```ts
+ * import { parse } from "@std/csv/parse";
+ * import { assertThrows } from "@std/assert/throws";
+ *
+ * const string = "a,b\nc,d,e";
+ * assertThrows(
+ *   () => parse(string, { fieldsPerRecord: 2 }),
+ *   SyntaxError,
+ *   "record on line 2: expected 2 fields but got 3",
+ * );
  * ```
  *
  * @typeParam T The options' type for parsing.

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -311,7 +311,7 @@ export interface ParseOptions {
  * @example Usage
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  *
  * const string = "a,b,c\n#d,e,f";
  *
@@ -321,7 +321,7 @@ export interface ParseOptions {
  * @example Quoted fields
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  *
  * const string = `"a ""word""","comma,","newline\n"\nfoo,bar,baz`;
  * const result = parse(string);
@@ -345,7 +345,7 @@ export function parse(input: string): string[][];
  * @example skipFirstRow: false
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  * import { assertType, IsExact } from "@std/testing/types"
  *
  * const string = "a,b,c\nd,e,f";
@@ -358,7 +358,7 @@ export function parse(input: string): string[][];
  * @example skipFirstRow: true
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  * import { assertType, IsExact } from "@std/testing/types"
  *
  * const string = "a,b,c\nd,e,f";
@@ -371,7 +371,7 @@ export function parse(input: string): string[][];
  * @example specify columns
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  * import { assertType, IsExact } from "@std/testing/types"
  *
  * const string = "a,b,c\nd,e,f";
@@ -384,7 +384,7 @@ export function parse(input: string): string[][];
  * @example specify columns with skipFirstRow
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  * import { assertType, IsExact } from "@std/testing/types"
  *
  * const string = "a,b,c\nd,e,f";
@@ -397,7 +397,7 @@ export function parse(input: string): string[][];
  * @example TSV (tab-separated values)
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  *
  * const string = "a\tb\tc\nd\te\tf";
  * const result = parse(string, { separator: "\t" });
@@ -408,7 +408,7 @@ export function parse(input: string): string[][];
  * @example trimLeadingSpace: true
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  *
  * const string = " a,  b,    c\n";
  * const result = parse(string, { trimLeadingSpace: true });
@@ -419,7 +419,7 @@ export function parse(input: string): string[][];
  * @example lazyQuotes: true
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  *
  * const string = `a "word","1"2",a","b`;
  * const result = parse(string, { lazyQuotes: true });
@@ -430,7 +430,7 @@ export function parse(input: string): string[][];
  * @example comment
  * ```ts
  * import { parse } from "@std/csv/parse";
- * import { assertEquals } from "@std/assert";
+ * import { assertEquals } from "@std/assert/equals";
  *
  * const string = "a,b,c\n# THIS IS A COMMENT LINE\nd,e,f";
  * const result = parse(string, { comment: "#" });

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -287,8 +287,8 @@ export interface ParseOptions {
    * If negative, no check is made and records may have a variable number of
    * fields.
    *
-   * If the wrong number of fields is in a row, a {@linkcode SyntaxError} is
-   * thrown.
+   * If the wrong number of fields is in a row, a {@linkcode https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError | SyntaxError}
+   * is thrown.
    */
   fieldsPerRecord?: number;
   /**

--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -472,20 +472,21 @@ export class CsvParseStream<
    * The instance's {@linkcode ReadableStream}.
    *
    * @example Usage
-   * ```ts no-assert
+   * ```ts
    * import { CsvParseStream } from "@std/csv/parse-stream";
+   * import { assertEquals } from "@std/assert/equals";
    *
    * const source = ReadableStream.from([
-   *   "name,age",
-   *   "Alice,34",
-   *   "Bob,24",
-   *   "Charlie,45",
+   *   "name,age\n",
+   *   "Alice,34\n",
+   *   "Bob,24\n",
    * ]);
-   * const parseStream = new CsvParseStream();
+   * const parseStream = new CsvParseStream({ skipFirstRow: true });
    * const parts = source.pipeTo(parseStream.writable);
-   * for await (const part of parseStream.readable) {
-   *   console.log(part);
-   * }
+   * assertEquals(await Array.fromAsync(parseStream.readable), [
+   *   { name: "Alice", age: "34" },
+   *   { name: "Bob", age: "24" },
+   * ]);
    * ```
    *
    * @returns The instance's {@linkcode ReadableStream}.
@@ -498,20 +499,21 @@ export class CsvParseStream<
    * The instance's {@linkcode WritableStream}.
    *
    * @example Usage
-   * ```ts no-assert
+   * ```ts
    * import { CsvParseStream } from "@std/csv/parse-stream";
+   * import { assertEquals } from "@std/assert/equals";
    *
    * const source = ReadableStream.from([
-   *   "name,age",
-   *   "Alice,34",
-   *   "Bob,24",
-   *   "Charlie,45",
+   *   "name,age\n",
+   *   "Alice,34\n",
+   *   "Bob,24\n",
    * ]);
-   * const parseStream = new CsvParseStream();
+   * const parseStream = new CsvParseStream({ skipFirstRow: true });
    * const parts = source.pipeTo(parseStream.writable);
-   * for await (const part of parseStream.readable) {
-   *   console.log(part);
-   * }
+   * assertEquals(await Array.fromAsync(parseStream.readable), [
+   *   { name: "Alice", age: "34" },
+   *   { name: "Bob", age: "24" },
+   * ]);
    * ```
    *
    * @returns The instance's {@linkcode WritableStream}.

--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -49,8 +49,8 @@ export interface CsvParseStreamOptions {
    * If negative, no check is made and records may have a variable number of
    * fields.
    *
-   * If the wrong number of fields is in a row, a {@linkcode ParseError} is
-   * thrown.
+   * If the wrong number of fields is in a row, a {@linkcode https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/SyntaxError | SyntaxError}
+   * is thrown.
    */
   fieldsPerRecord?: number;
   /**

--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -23,7 +23,7 @@ export interface CsvParseStreamOptions {
    * are ignored. With leading whitespace the comment character becomes part of
    * the field, even you provide `trimLeadingSpace: true`.
    *
-   * @default {"#"}
+   * By default, no character is considered to be a start of a comment.
    */
   comment?: string;
   /** Flag to trim the leading space of the value.

--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -295,6 +295,7 @@ export type RowType<T> = T extends undefined ? string[]
  * ```ts
  * import { CsvParseStream } from "@std/csv/parse-stream";
  * import { assertEquals } from "@std/assert/equals";
+ * import { assertRejects } from "@std/assert/rejects";
  *
  * const source = ReadableStream.from([
  *   "Alice,34\n",
@@ -303,14 +304,35 @@ export type RowType<T> = T extends undefined ? string[]
  * const stream = source.pipeThrough(new CsvParseStream({
  *   fieldsPerRecord: 0,
  * }));
- * for await (const row of stream) {
- * }
- * const result = await Array.fromAsync(stream);
+ * const reader = stream.getReader();
+ * assertEquals(await reader.read(), { done: false, value: ["Alice", "34"] });
+ * await assertRejects(
+ *   () => reader.read(),
+ *   SyntaxError,
+ *   "record on line 2: expected 2 fields but got 3",
+ * );
+ * ```
  *
- * assertEquals(result, [
- *   ["Alice", "34"],
- *   ["Bob", "24"],
+ * @example fieldsPerRecord: 2 (enforce the number of fields for each row)
+ * ```ts
+ * import { CsvParseStream } from "@std/csv/parse-stream";
+ * import { assertEquals } from "@std/assert/equals";
+ * import { assertRejects } from "@std/assert/rejects";
+ *
+ * const source = ReadableStream.from([
+ *   "Alice,34\n",
+ *   "Bob,24,CA\n",
  * ]);
+ * const stream = source.pipeThrough(new CsvParseStream({
+ *   fieldsPerRecord: 2,
+ * }));
+ * const reader = stream.getReader();
+ * assertEquals(await reader.read(), { done: false, value: ["Alice", "34"] });
+ * await assertRejects(
+ *   () => reader.read(),
+ *   SyntaxError,
+ *   "record on line 2: expected 2 fields but got 3",
+ * );
  * ```
  *
  * @typeParam T The type of options for the stream.

--- a/csv/parse_stream_test.ts
+++ b/csv/parse_stream_test.ts
@@ -350,14 +350,23 @@ x,,,
         columns: ["foo", "bar", "baz"],
       },
       {
-        name: "mismatching number of headers and fields",
+        name: "mismatching number of headers and fields 1",
         input: "a,b,c\nd,e",
         skipFirstRow: true,
         columns: ["foo", "bar", "baz"],
         error: {
           klass: Error,
-          msg:
-            "Error number of fields line: 1\nNumber of fields found: 3\nExpected number of fields: 2",
+          msg: "record on line 2 has 2 fields, but the header has 3 fields",
+        },
+      },
+      {
+        name: "mismatching number of headers and fields 2",
+        input: "a,b,c\nd,e,,g",
+        skipFirstRow: true,
+        columns: ["foo", "bar", "baz"],
+        error: {
+          klass: Error,
+          msg: "record on line 2 has 4 fields, but the header has 3 fields",
         },
       },
       {

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -310,6 +310,17 @@ Deno.test({
       },
     });
     await t.step({
+      name: "NegativeFieldsPerRecord",
+      fn() {
+        const input = `a,b,c\nd,e`;
+        const output = [
+          ["a", "b", "c"],
+          ["d", "e"],
+        ];
+        assertEquals(parse(input, { fieldsPerRecord: -1 }), output);
+      },
+    });
+    await t.step({
       name: "FieldCount",
       fn() {
         const input = "a,b,c\nd,e";

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -23,6 +23,7 @@ Deno.test({
         );
       },
     });
+
     await t.step({
       name: "CRLF",
       fn() {
@@ -93,6 +94,42 @@ Deno.test({
         assertEquals(
           parse(input),
           [["two\nline", "one line", "three\nline\nfield"]],
+        );
+      },
+    });
+
+    await t.step({
+      name: "BlankField",
+      fn() {
+        const input = "a,b,c\nd,,f";
+        assertEquals(
+          parse(input),
+          [["a", "b", "c"], ["d", "", "f"]],
+        );
+      },
+    });
+
+    await t.step({
+      name: "BlankField2",
+      fn() {
+        const input = "a,b,c\nd,,f";
+        assertEquals(
+          parse(input, { skipFirstRow: true }),
+          [{ a: "d", b: "", c: "f" }],
+        );
+      },
+    });
+
+    await t.step({
+      name: "BlankField3",
+      fn() {
+        const input = "a,b,c\nd,,f";
+        assertEquals(
+          parse(input, { columns: ["one", "two", "three"] }),
+          [
+            { one: "a", two: "b", three: "c" },
+            { one: "d", two: "", three: "f" },
+          ],
         );
       },
     });
@@ -783,7 +820,7 @@ c"d,e`;
       },
     });
     await t.step({
-      name: "mismatching number of headers and fields",
+      name: "mismatching number of headers and fields 1",
       fn() {
         const input = "a,b,c\nd,e";
         assertThrows(
@@ -793,7 +830,22 @@ c"d,e`;
               columns: ["foo", "bar", "baz"],
             }),
           Error,
-          "Error number of fields line: 1\nNumber of fields found: 3\nExpected number of fields: 2",
+          "record on line 2 has 2 fields, but the header has 3 fields",
+        );
+      },
+    });
+    await t.step({
+      name: "mismatching number of headers and fields 2",
+      fn() {
+        const input = "a,b,c\nd,e,,g";
+        assertThrows(
+          () =>
+            parse(input, {
+              skipFirstRow: true,
+              columns: ["foo", "bar", "baz"],
+            }),
+          Error,
+          "record on line 2 has 4 fields, but the header has 3 fields",
         );
       },
     });

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -257,7 +257,7 @@ Deno.test({
         assertThrows(
           () => parse(input, { fieldsPerRecord: 0 }),
           SyntaxError,
-          "record on line 2: wrong number of fields",
+          "record on line 2: expected 3 fields but got 2",
         );
       },
     });
@@ -268,7 +268,7 @@ Deno.test({
         assertThrows(
           () => parse(input, { fieldsPerRecord: 2 }),
           SyntaxError,
-          "record on line 1: wrong number of fields",
+          "record on line 1: expected 2 fields but got 3",
         );
       },
     });


### PR DESCRIPTION
This commit adds more examples to `parse` function and `CsvParseStream` class to cover all the provided options.

Also fixes a few other things:

- Replace stale description `ParseError` with the correct `SyntaxError`.
- Fix the default value of `comment` property. The old comment says the default value is `#`, but this was wrong.
- Get negative value in `fieldsPerRecord` option working in `parse` as documented