### PR TITLE
test(async): improve test speed of `async/pool_test.ts`

### DIFF
--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -13,13 +13,13 @@ Deno.test("pooledMap()", async () => {
   const results = pooledMap(
     2,
     [1, 2, 3],
-    (i) => new Promise<number>((r) => setTimeout(() => r(i), 10)),
+    (i) => new Promise<number>((r) => setTimeout(() => r(i), 100)),
   );
   const array = await Array.fromAsync(results);
   assertEquals(array, [1, 2, 3]);
   const diff = new Date().getTime() - start.getTime();
-  assert(diff >= 20);
-  assert(diff < 30);
+  assert(diff >= 200);
+  assert(diff < 300);
 });
 
 Deno.test("pooledMap() handles errors", async () => {

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -13,13 +13,13 @@ Deno.test("pooledMap()", async () => {
   const results = pooledMap(
     2,
     [1, 2, 3],
-    (i) => new Promise<number>((r) => setTimeout(() => r(i), 1000)),
+    (i) => new Promise<number>((r) => setTimeout(() => r(i), 10)),
   );
   const array = await Array.fromAsync(results);
   assertEquals(array, [1, 2, 3]);
   const diff = new Date().getTime() - start.getTime();
-  assert(diff >= 2000);
-  assert(diff < 3000);
+  assert(diff >= 20);
+  assert(diff < 30);
 });
 
 Deno.test("pooledMap() handles errors", async () => {
@@ -47,19 +47,10 @@ Deno.test("pooledMap() handles errors", async () => {
 });
 
 Deno.test("pooledMap() returns ordered items", async () => {
-  function getRandomInt(min: number, max: number): number {
-    min = Math.ceil(min);
-    max = Math.floor(max);
-    return Math.floor(Math.random() * (max - min) + min); //The maximum is exclusive and the minimum is inclusive
-  }
-
   const results = pooledMap(
     2,
     [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-    (i) =>
-      new Promise<number>((r) =>
-        setTimeout(() => r(i), getRandomInt(5, 20) * 100)
-      ),
+    (i) => new Promise<number>((r) => setTimeout(() => r(i), 100 / i)),
   );
 
   const returned = await Array.fromAsync(results);


### PR DESCRIPTION
It seems that these tests didn't need to be so slow.

On M2 laptop:
- Before: ~8s
- After: ~0.7s