### PR TITLE
fix(csv): remove `undefined` from possible value type of parse result

### DIFF
--- a/csv/_io.ts
+++ b/csv/_io.ts
@@ -250,14 +250,13 @@ export type ParseResult<ParseOptions, T> =
   T extends ParseOptions & { columns: readonly (infer C extends string)[] }
     ? RecordWithColumn<C>[]
     // If `skipFirstRow` option is specified, the return type is Record type.
-    : T extends ParseOptions & { skipFirstRow: true }
-      ? Record<string, string | undefined>[]
+    : T extends ParseOptions & { skipFirstRow: true } ? Record<string, string>[]
     // If `columns` and `skipFirstRow` option is _not_ specified, the return type is string[][].
     : T extends
       ParseOptions & { columns?: undefined; skipFirstRow?: false | undefined }
       ? string[][]
     // else, the return type is Record type or string[][].
-    : Record<string, string | undefined>[] | string[][];
+    : Record<string, string>[] | string[][];
 
 /**
  * Record type with column type.
@@ -269,5 +268,5 @@ export type ParseResult<ParseOptions, T> =
  * ```
  */
 export type RecordWithColumn<C extends string> = string extends C
-  ? Record<string, string | undefined>
+  ? Record<string, string>
   : Record<C, string>;

--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -388,7 +388,7 @@ export function parse(input: string): string[][];
  * const result = parse(string, { skipFirstRow: true });
  *
  * assertEquals(result, [{ a: "d", b: "e", c: "f" }]);
- * assertType<IsExact<typeof result, Record<string, string | undefined>[]>>(true);
+ * assertType<IsExact<typeof result, Record<string, string>[]>>(true);
  * ```
  *
  * @example Specify columns with `columns` option

--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -148,7 +148,7 @@ export type RowType<T> = T extends undefined ? string[]
  *   { name: "Alice", age: "34" },
  *   { name: "Bob", age: "24" },
  * ]);
- * assertType<IsExact<typeof result, Record<string, string | undefined>[]>>(true);
+ * assertType<IsExact<typeof result, Record<string, string>[]>>(true);
  * ```
  *
  * @example Specify columns with `columns` option

--- a/csv/parse_stream_test.ts
+++ b/csv/parse_stream_test.ts
@@ -491,13 +491,13 @@ Deno.test({
       // `skipFirstRow` may be `true` or `false`.
       // `columns` may be `undefined` or `string[]`.
       // If you don't know exactly what the value of the option is,
-      // the return type is ReadableStream<string[] | Record<string, string | undefined>>
+      // the return type is ReadableStream<string[] | Record<string, string>>
       const options: CsvParseStreamOptions = {};
       const { readable } = new CsvParseStream(options);
       type _ = AssertTrue<
         IsExact<
           typeof readable,
-          ReadableStream<string[] | Record<string, string | undefined>>
+          ReadableStream<string[] | Record<string, string>>
         >
       >;
     }
@@ -520,7 +520,7 @@ Deno.test({
       type _ = AssertTrue<
         IsExact<
           typeof readable,
-          ReadableStream<Record<string, string | undefined>>
+          ReadableStream<Record<string, string>>
         >
       >;
     }
@@ -541,7 +541,7 @@ Deno.test({
       type _ = AssertTrue<
         IsExact<
           typeof readable,
-          ReadableStream<Record<string, string | undefined>>
+          ReadableStream<Record<string, string>>
         >
       >;
     }
@@ -562,7 +562,7 @@ Deno.test({
       type _ = AssertTrue<
         IsExact<
           typeof readable,
-          ReadableStream<Record<string, string | undefined>>
+          ReadableStream<Record<string, string>>
         >
       >;
     }

--- a/csv/parse_test.ts
+++ b/csv/parse_test.ts
@@ -943,13 +943,13 @@ Deno.test({
       // `skipFirstRow` may be `true` or `false`.
       // `columns` may be `undefined` or `string[]`.
       // If you don't know exactly what the value of the option is,
-      // the return type is string[][] | Record<string, string|undefined>[]
+      // the return type is string[][] | Record<string, string>[]
       const options: ParseOptions = {};
       const parsed = parse("a\nb", options);
       type _ = AssertTrue<
         IsExact<
           typeof parsed,
-          string[][] | Record<string, string | undefined>[]
+          string[][] | Record<string, string>[]
         >
       >;
     }
@@ -970,7 +970,7 @@ Deno.test({
     {
       const parsed = parse("a\nb", { skipFirstRow: true });
       type _ = AssertTrue<
-        IsExact<typeof parsed, Record<string, string | undefined>[]>
+        IsExact<typeof parsed, Record<string, string>[]>
       >;
     }
 
@@ -988,7 +988,7 @@ Deno.test({
     {
       const parsed = parse("a\nb", { columns: ["aaa"] as string[] });
       type _ = AssertTrue<
-        IsExact<typeof parsed, Record<string, string | undefined>[]>
+        IsExact<typeof parsed, Record<string, string>[]>
       >;
     }
 
@@ -1000,7 +1000,7 @@ Deno.test({
     {
       const parsed = parse("a\nb", { skipFirstRow: true, columns: undefined });
       type _ = AssertTrue<
-        IsExact<typeof parsed, Record<string, string | undefined>[]>
+        IsExact<typeof parsed, Record<string, string>[]>
       >;
     }
     {


### PR DESCRIPTION
As we discussed in https://github.com/denoland/std/pull/5605#discussion_r1701028684, it seems like we never get `undefined` as a parse result of fields. If there is a mismatch in the number of fields across rows, the parse just throws an error.
To better reflect this in typing, this commit removes `undefined` from the record value type.