### PR TITLE
refactor(datetime): remove custom Rules

### DIFF
--- a/datetime/_date_time_formatter.ts
+++ b/datetime/_date_time_formatter.ts
@@ -1,81 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-type Token = {
-  type: string;
-  value: string | number;
-  index: number;
-  [key: string]: unknown;
-};
-
-interface ReceiverResult {
-  [name: string]: string | number | unknown;
-}
-type CallbackResult = {
-  type: string;
-  value: string | number;
-  [key: string]: unknown;
-};
-type CallbackFunction = (value: unknown) => CallbackResult;
-
-type TestResult = { value: unknown; length: number } | undefined;
-type TestFunction = (
-  string: string,
-) => TestResult | undefined;
-
-interface Rule {
-  test: TestFunction;
-  fn: CallbackFunction;
-}
-
-export class Tokenizer {
-  rules: Rule[];
-
-  constructor(rules: Rule[] = []) {
-    this.rules = rules;
-  }
-
-  addRule(test: TestFunction, fn: CallbackFunction): Tokenizer {
-    this.rules.push({ test, fn });
-    return this;
-  }
-
-  tokenize(
-    string: string,
-    receiver = (token: Token): ReceiverResult => token,
-  ): ReceiverResult[] {
-    function* generator(rules: Rule[]): IterableIterator<ReceiverResult> {
-      let index = 0;
-      for (const rule of rules) {
-        const result = rule.test(string);
-        if (result) {
-          const { value, length } = result;
-          index += length;
-          string = string.slice(length);
-          const token = { ...rule.fn(value), index };
-          yield receiver(token);
-          yield* generator(rules);
-        }
-      }
-    }
-    const tokenGenerator = generator(this.rules);
-
-    const tokens: ReceiverResult[] = [];
-
-    for (const token of tokenGenerator) {
-      tokens.push(token);
-    }
-
-    if (string.length) {
-      throw new Error(
-        `parser error: string not fully parsed! ${string.slice(0, 25)}`,
-      );
-    }
-
-    return tokens;
-  }
-}
-
 function digits(value: string | number, count = 2): string {
   return String(value).padStart(count, "0");
 }
@@ -106,124 +31,6 @@ interface Options {
   timeZone?: TimeZone;
 }
 
-function createLiteralTestFunction(value: string): TestFunction {
-  return (string: string): TestResult => {
-    return string.startsWith(value)
-      ? { value, length: value.length }
-      : undefined;
-  };
-}
-
-function createMatchTestFunction(match: RegExp): TestFunction {
-  return (string: string): TestResult => {
-    const result = match.exec(string);
-    if (result) return { value: result, length: result[0].length };
-  };
-}
-
-// according to unicode symbols (http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)
-const DATE_TIME_FORMATTER_DEFAULT_RULES = [
-  {
-    test: createLiteralTestFunction("yyyy"),
-    fn: (): CallbackResult => ({ type: "year", value: "numeric" }),
-  },
-  {
-    test: createLiteralTestFunction("yy"),
-    fn: (): CallbackResult => ({ type: "year", value: "2-digit" }),
-  },
-  {
-    test: createLiteralTestFunction("MM"),
-    fn: (): CallbackResult => ({ type: "month", value: "2-digit" }),
-  },
-  {
-    test: createLiteralTestFunction("M"),
-    fn: (): CallbackResult => ({ type: "month", value: "numeric" }),
-  },
-  {
-    test: createLiteralTestFunction("dd"),
-    fn: (): CallbackResult => ({ type: "day", value: "2-digit" }),
-  },
-  {
-    test: createLiteralTestFunction("d"),
-    fn: (): CallbackResult => ({ type: "day", value: "numeric" }),
-  },
-  {
-    test: createLiteralTestFunction("HH"),
-    fn: (): CallbackResult => ({ type: "hour", value: "2-digit" }),
-  },
-  {
-    test: createLiteralTestFunction("H"),
-    fn: (): CallbackResult => ({ type: "hour", value: "numeric" }),
-  },
-  {
-    test: createLiteralTestFunction("hh"),
-    fn: (): CallbackResult => ({
-      type: "hour",
-      value: "2-digit",
-      hour12: true,
-    }),
-  },
-  {
-    test: createLiteralTestFunction("h"),
-    fn: (): CallbackResult => ({
-      type: "hour",
-      value: "numeric",
-      hour12: true,
-    }),
-  },
-  {
-    test: createLiteralTestFunction("mm"),
-    fn: (): CallbackResult => ({ type: "minute", value: "2-digit" }),
-  },
-  {
-    test: createLiteralTestFunction("m"),
-    fn: (): CallbackResult => ({ type: "minute", value: "numeric" }),
-  },
-  {
-    test: createLiteralTestFunction("ss"),
-    fn: (): CallbackResult => ({ type: "second", value: "2-digit" }),
-  },
-  {
-    test: createLiteralTestFunction("s"),
-    fn: (): CallbackResult => ({ type: "second", value: "numeric" }),
-  },
-  {
-    test: createLiteralTestFunction("SSS"),
-    fn: (): CallbackResult => ({ type: "fractionalSecond", value: 3 }),
-  },
-  {
-    test: createLiteralTestFunction("SS"),
-    fn: (): CallbackResult => ({ type: "fractionalSecond", value: 2 }),
-  },
-  {
-    test: createLiteralTestFunction("S"),
-    fn: (): CallbackResult => ({ type: "fractionalSecond", value: 1 }),
-  },
-  {
-    test: createLiteralTestFunction("a"),
-    fn: (value: unknown): CallbackResult => ({
-      type: "dayPeriod",
-      value: value as string,
-    }),
-  },
-  // quoted literal
-  {
-    test: createMatchTestFunction(/^(')(?<value>\\.|[^\']*)\1/),
-    fn: (match: unknown): CallbackResult => ({
-      type: "literal",
-      value: (match as RegExpExecArray).groups!.value as string,
-    }),
-  },
-  // literal
-  {
-    test: createMatchTestFunction(/^.+?\s*/),
-    fn: (match: unknown): CallbackResult => ({
-      type: "literal",
-      value: (match as RegExpExecArray)[0],
-    }),
-  },
-] as const;
-
 type FormatPart = {
   type: DateTimeFormatPartTypes;
   value: string | number;
@@ -231,25 +38,119 @@ type FormatPart = {
 };
 type Format = FormatPart[];
 
+const QUOTED_LITERAL_REGEXP = /^(')(?<value>\\.|[^\']*)\1/;
+const LITERAL_REGEXP = /^(?<value>.+?\s*)/;
+const SYMBOL_REGEXP = /^(?<symbol>([a-zA-Z])\2*)/;
+
+// according to unicode symbols (http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)
+function formatToParts(format: string) {
+  const tokens = [];
+  let index = 0;
+  while (index < format.length) {
+    const substring = format.slice(index);
+    const symbol = SYMBOL_REGEXP.exec(substring)?.groups?.symbol;
+    switch (symbol) {
+      case "yyyy":
+        tokens.push({ type: "year", value: "numeric" });
+        index += symbol.length;
+        continue;
+      case "yy":
+        tokens.push({ type: "year", value: "2-digit" });
+        index += symbol.length;
+        continue;
+      case "MM":
+        tokens.push({ type: "month", value: "2-digit" });
+        index += symbol.length;
+        continue;
+      case "M":
+        tokens.push({ type: "month", value: "numeric" });
+        index += symbol.length;
+        continue;
+      case "dd":
+        tokens.push({ type: "day", value: "2-digit" });
+        index += symbol.length;
+        continue;
+      case "d":
+        tokens.push({ type: "day", value: "numeric" });
+        index += symbol.length;
+        continue;
+      case "HH":
+        tokens.push({ type: "hour", value: "2-digit" });
+        index += symbol.length;
+        continue;
+      case "H":
+        tokens.push({ type: "hour", value: "numeric" });
+        index += symbol.length;
+        continue;
+      case "hh":
+        tokens.push({ type: "hour", value: "2-digit", hour12: true });
+        index += symbol.length;
+        continue;
+      case "h":
+        tokens.push({ type: "hour", value: "numeric", hour12: true });
+        index += symbol.length;
+        continue;
+      case "mm":
+        tokens.push({ type: "minute", value: "2-digit" });
+        index += symbol.length;
+        continue;
+      case "m":
+        tokens.push({ type: "minute", value: "numeric" });
+        index += symbol.length;
+        continue;
+      case "ss":
+        tokens.push({ type: "second", value: "2-digit" });
+        index += symbol.length;
+        continue;
+      case "s":
+        tokens.push({ type: "second", value: "numeric" });
+        index += symbol.length;
+        continue;
+      case "SSS":
+        tokens.push({ type: "fractionalSecond", value: 3 });
+        index += symbol.length;
+        continue;
+      case "SS":
+        tokens.push({ type: "fractionalSecond", value: 2 });
+        index += symbol.length;
+        continue;
+      case "S":
+        tokens.push({ type: "fractionalSecond", value: 1 });
+        index += symbol.length;
+        continue;
+      case "a":
+        tokens.push({ type: "dayPeriod" });
+        index += symbol.length;
+        continue;
+    }
+
+    const quotedLiteralMatch = QUOTED_LITERAL_REGEXP.exec(substring);
+    if (quotedLiteralMatch) {
+      const value = quotedLiteralMatch.groups!.value;
+      tokens.push({ type: "literal", value });
+      index += quotedLiteralMatch[0].length;
+      continue;
+    }
+
+    const literalGroups = LITERAL_REGEXP.exec(substring)?.groups;
+    if (literalGroups) {
+      const value = literalGroups.value as string;
+      tokens.push({ type: "literal", value });
+      index += value.length;
+      continue;
+    }
+
+    throw new Error(`format "${substring}" is not supported.`);
+  }
+
+  return tokens;
+}
+
 export class DateTimeFormatter {
   #format: Format;
 
-  constructor(
-    formatString: string,
-    rules: Rule[] = [...DATE_TIME_FORMATTER_DEFAULT_RULES],
-  ) {
-    const tokenizer = new Tokenizer(rules);
-    this.#format = tokenizer.tokenize(
-      formatString,
-      ({ type, value, hour12 }) => {
-        const result = {
-          type,
-          value,
-        } as unknown as ReceiverResult;
-        if (hour12) result.hour12 = hour12 as boolean;
-        return result;
-      },
-    ) as Format;
+  constructor(formatString: string) {
+    this.#format = formatToParts(formatString) as Format;
   }
 
   format(date: Date, options: Options = {}): string {

--- a/datetime/_date_time_formatter_test.ts
+++ b/datetime/_date_time_formatter_test.ts
@@ -1,119 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertThrows } from "@std/assert";
-import { assertSpyCall, spy } from "@std/testing/mock";
 import { FakeTime } from "@std/testing/time";
-import { DateTimeFormatter, Tokenizer } from "./_date_time_formatter.ts";
-
-function createRule(
-  { format, type, value, options = {} }: {
-    format: string;
-    type: string;
-    value: string;
-    options?: { hour12?: boolean };
-  },
-) {
-  return {
-    test: (value: string) =>
-      value.startsWith(format) ? { value, length: value.length } : undefined,
-    fn: () => ({ type, value, ...options }),
-  };
-}
-
-Deno.test("tokenizer.tokenize()", () => {
-  const rules = [{
-    test: (value: string) =>
-      value.startsWith("foobar")
-        ? ({ value, length: value.length })
-        : undefined,
-    fn: () => ({ type: "baz", value: "foobar" }),
-  }];
-  const tokenizer = new Tokenizer(rules);
-  assertEquals(tokenizer.tokenize("foobar"), [{
-    index: 6,
-    type: "baz",
-    value: "foobar",
-  }]);
-});
-
-Deno.test("tokenizer.tokenize() works with receiver", () => {
-  const rules = [{
-    test: (value: string) =>
-      value.startsWith("foobar")
-        ? ({ value, length: value.length })
-        : undefined,
-    fn: () => ({ type: "baz", value: "foobar" }),
-  }];
-  const tokenizer = new Tokenizer(rules);
-  const receiver = spy((_) => ({}));
-  assertEquals(tokenizer.tokenize("foobar", receiver), [{}]);
-  assertSpyCall(receiver, 0, {
-    args: [{ index: 6, type: "baz", value: "foobar" }],
-    returned: {},
-  });
-});
-
-Deno.test("tokenizer.tokenize() works with multiple rules", () => {
-  const rules = [
-    {
-      test: (value: string) =>
-        value.includes("baz") ? ({ value, length: value.length }) : undefined,
-      fn: () => ({ type: "baz", value: "foobar" }),
-    },
-    {
-      test: (value: string) =>
-        value.includes("qux") ? ({ value, length: value.length }) : undefined,
-      fn: () => ({ type: "qux", value: "qux" }),
-    },
-  ];
-  const tokenizer = new Tokenizer(rules);
-  const tokens = tokenizer.tokenize("foobarqux");
-  assertEquals(tokens, [
-    { index: 9, type: "qux", value: "qux" },
-  ]);
-});
-
-Deno.test("tokenizer.tokenize() throws without rules", () => {
-  const tokenizer = new Tokenizer();
-  assertThrows(
-    () => tokenizer.tokenize("foobar"),
-    Error,
-    "parser error: string not fully parsed!",
-  );
-});
-
-Deno.test("tokenizer.tokenize() throws when none of the rules match", () => {
-  const rules = [{
-    test: (value: string) =>
-      value.startsWith("foobar")
-        ? ({ value, length: value.length })
-        : undefined,
-    fn: () => ({ type: "baz", value: "foobar" }),
-  }];
-  const tokenizer = new Tokenizer(rules);
-  assertThrows(
-    () => tokenizer.tokenize("bazqux"),
-    Error,
-    "parser error: string not fully parsed!",
-  );
-});
-
-Deno.test("tokenizer.addRule()", () => {
-  const test = spy((value: string) =>
-    value === "foobar" ? ({ value, length: value.length }) : undefined
-  );
-  const fn = spy((_) => ({ type: "foo", value: "bar" }));
-  const tokenizer = new Tokenizer().addRule(test, fn);
-  const tokens = tokenizer.tokenize("foobar");
-  assertEquals(tokens, [{ index: 6, type: "foo", value: "bar" }]);
-  assertSpyCall(test, 0, {
-    args: ["foobar"],
-    returned: { value: "foobar", length: 6 },
-  });
-  assertSpyCall(fn, 0, {
-    args: ["foobar"],
-    returned: { type: "foo", value: "bar" },
-  });
-});
+import { DateTimeFormatter } from "./_date_time_formatter.ts";
 
 Deno.test("dateTimeFormatter.format()", () => {
   const cases = [
@@ -142,28 +30,6 @@ Deno.test("dateTimeFormatter.format() with empty format string returns empty str
   );
 });
 
-Deno.test("dateTimeFormatter.format() throws when a rule returns an unknown value", () => {
-  const cases = [
-    ["yyyy", "year"],
-    ["MM", "month"],
-    ["dd", "day"],
-    ["HH", "hour"],
-    ["mm", "minute"],
-    ["ss", "second"],
-    ["foo", "bar"],
-  ] as const;
-  for (const [format, type] of cases) {
-    const formatter = new DateTimeFormatter(format, [
-      createRule({ format, type, value: "unknown" }),
-    ]);
-    assertThrows(
-      () => formatter.format(new Date(2020, 0, 1)),
-      Error,
-      "FormatterError",
-    );
-  }
-});
-
 Deno.test("dateTimeFormatter.parse()", () => {
   const format = "yyyy-MM-dd";
   const formatter = new DateTimeFormatter(format);
@@ -180,68 +46,6 @@ Deno.test("dateTimeFormatter.parseToParts()", () => {
     { type: "literal", value: "-" },
     { type: "day", value: "01" },
   ]);
-});
-
-Deno.test("dateTimeFormatter.parseToParts() works with custom rules", () => {
-  const cases = [
-    ["yyyy", "year", "numeric", "2020"],
-    ["yy", "year", "2-digit", "20"],
-    ["MM", "month", "2-digit", "03"],
-    ["M", "month", "numeric", "3"],
-    ["M", "month", "long", "March"],
-    ["M", "month", "short", "Mar"],
-    ["M", "month", "narrow", "M"],
-    ["dd", "day", "2-digit", "03"],
-    ["d", "day", "numeric", "3"],
-    ["HH", "hour", "2-digit", "13"],
-    ["H", "hour", "numeric", "13"],
-    ["hh", "hour", "2-digit", "13", { hour12: true }],
-    ["h", "hour", "numeric", "13", { hour12: true }],
-    ["mm", "minute", "2-digit", "03"],
-    ["m", "minute", "numeric", "3"],
-    ["ss", "second", "2-digit", "03"],
-    ["s", "second", "numeric", "3"],
-    ["T", "timeZoneName", "T", "T"],
-  ] as const;
-  for (const [format, type, value, input, options = {}] of cases) {
-    const formatter = new DateTimeFormatter(format, [
-      createRule({ format, type, value, options }),
-    ]);
-    assertEquals(formatter.parseToParts(input), [{ type, value: input }]);
-  }
-});
-
-Deno.test("dateTimeFormatter.parseToParts() throws on invalid input", () => {
-  const format = "foo";
-  const formatter = new DateTimeFormatter(format, [
-    createRule({ format: "foo", type: "bar", value: "baz" }),
-  ]);
-  assertThrows(
-    () => formatter.parseToParts("foo"),
-    Error,
-    "bar baz",
-  );
-});
-
-Deno.test("dateTimeFormatter.parseToParts() throws when a rule returns an unknown value", () => {
-  const cases = [
-    ["yyyy", "year", "2020"],
-    ["MM", "month", "03"],
-    ["dd", "day", "03"],
-    ["HH", "hour", "03"],
-    ["mm", "minute", "03"],
-    ["ss", "second", "03"],
-  ] as const;
-  for (const [format, type, input] of cases) {
-    const formatter = new DateTimeFormatter(format, [
-      createRule({ format, type, value: "unknown" }),
-    ]);
-    assertThrows(
-      () => formatter.parseToParts(input),
-      Error,
-      'ParserError: value "unknown" is not supported',
-    );
-  }
 });
 
 Deno.test("dateTimeFormatter.parseToParts() throws on an empty string", () => {


### PR DESCRIPTION
**Changes**
This change removes the ability to add custom rules to `DateTimeFormatter `.
- removes custom rules for private `DateTimeFormatter` class
- removes `Tokenizer` class