### PR TITLE
chore: fix workspace publish workflow

### DIFF
--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -21,8 +21,7 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@v1
         with:
-          # TODO(kt3k): Set canary when LICENSE issue resolved. See std#5555
-          deno-version: 1.45.3
+          deno-version: canary
 
       - name: Format
         run: deno fmt --check


### PR DESCRIPTION
Publishing is now blocked by the change of hostname handling on onListen handler of `Deno.serve`. This PR tries to fix it by upgrading Deno CLI to canary.