### PR TITLE
fix(csv,streams): use string arrays in `ReadableStream.from()` in docs and tests

### DIFF
--- a/csv/parse_stream_test.ts
+++ b/csv/parse_stream_test.ts
@@ -437,7 +437,7 @@ x,,,
           options.columns = testCase.columns;
         }
 
-        const readable = ReadableStream.from(testCase.input)
+        const readable = ReadableStream.from([testCase.input])
           .pipeThrough(new CsvParseStream(options));
 
         if (testCase.output) {

--- a/streams/mod.ts
+++ b/streams/mod.ts
@@ -9,7 +9,7 @@
  * import { toText } from "@std/streams";
  * import { assertEquals } from "@std/assert";
  *
- * const stream = ReadableStream.from("Hello, world!");
+ * const stream = ReadableStream.from(["Hello, world!"]);
  * const text = await toText(stream);
  *
  * assertEquals(text, "Hello, world!");

--- a/streams/text_line_stream_test.ts
+++ b/streams/text_line_stream_test.ts
@@ -25,7 +25,7 @@ Deno.test("TextLineStream parses simple input", async () => {
     "654321\r",
   ]);
 
-  const stream2 = ReadableStream.from("rewq0987\r\n\r\n654321\n")
+  const stream2 = ReadableStream.from(["rewq0987\r\n\r\n654321\n"])
     .pipeThrough(new TextLineStream());
 
   assertEquals(await Array.fromAsync(stream2), [
@@ -60,7 +60,7 @@ Deno.test("TextLineStream parses with `allowCR` enabled", async () => {
     "654321",
   ]);
 
-  const stream2 = ReadableStream.from("rewq0987\r\n\r\n654321\n")
+  const stream2 = ReadableStream.from(["rewq0987\r\n\r\n654321\n"])
     .pipeThrough(new TextLineStream());
 
   assertEquals(await Array.fromAsync(stream2), [
@@ -72,7 +72,7 @@ Deno.test("TextLineStream parses with `allowCR` enabled", async () => {
 
 Deno.test("TextLineStream parses large chunks", async () => {
   const totalLines = 20_000;
-  const stream = ReadableStream.from("\n".repeat(totalLines))
+  const stream = ReadableStream.from(["\n".repeat(totalLines)])
     .pipeThrough(new TextLineStream());
   const lines = await Array.fromAsync(stream);
 


### PR DESCRIPTION
Due to https://github.com/denoland/deno/pull/24623