### PR TITLE
fix(archive): make `block` and `reader` properties in `Untar` private

### DIFF
--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -355,7 +355,7 @@ export class Untar {
 
     const meta = this.#getMetadata(header);
 
-    this.#entry = new TarEntry(meta, this.reader);
+    this.#entry = new TarEntry(meta, this.#reader);
 
     return this.#entry;
   }

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -224,15 +224,15 @@ export class TarEntry implements Reader {
  */
 export class Untar {
   /** Internal reader. */
-  reader: Reader;
+  #reader: Reader;
   /** Internal block. */
-  block: Uint8Array;
+  #block: Uint8Array;
   #entry: TarEntry | undefined;
 
   /** Constructs a new instance. */
   constructor(reader: Reader) {
-    this.reader = reader;
-    this.block = new Uint8Array(HEADER_LENGTH);
+    this.#reader = reader;
+    this.#block = new Uint8Array(HEADER_LENGTH);
   }
 
   #checksum(header: Uint8Array): number {
@@ -248,12 +248,12 @@ export class Untar {
   }
 
   async #getAndValidateHeader(): Promise<TarHeader | null> {
-    await readBlock(this.reader, this.block);
-    const header = parseHeader(this.block);
+    await readBlock(this.#reader, this.#block);
+    const header = parseHeader(this.#block);
 
     // calculate the checksum
     const decoder = new TextDecoder();
-    const checksum = this.#checksum(this.block);
+    const checksum = this.#checksum(this.#block);
 
     if (parseInt(decoder.decode(header.checksum), 8) !== checksum) {
       if (checksum === initialChecksum) {
@@ -327,7 +327,7 @@ export class Untar {
 
     const meta = this.#getMetadata(header);
 
-    this.#entry = new TarEntry(meta, header, this.reader);
+    this.#entry = new TarEntry(meta, header, this.#reader);
 
     return this.#entry;
   }


### PR DESCRIPTION
These properties are not documented or tested anywhere. It seems they were included in the public API by mistake.