### PR TITLE
fix(http): handle wrong request method correctly

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -173,7 +173,7 @@ export async function serveFile(
   filePath: string,
   options?: ServeFileOptions,
 ): Promise<Response> {
-  if (req.method !== "GET" && req.method !== "HEAD") {
+  if (req.method !== "GET") {
     return createStandardResponse(STATUS_CODE.MethodNotAllowed);
   }
 
@@ -639,7 +639,7 @@ export async function serveDir(
   req: Request,
   opts: ServeDirOptions = {},
 ): Promise<Response> {
-  if (req.method !== "GET" && req.method !== "HEAD") {
+  if (req.method !== "GET") {
     return createStandardResponse(STATUS_CODE.MethodNotAllowed);
   }
 

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -173,6 +173,10 @@ export async function serveFile(
   filePath: string,
   options?: ServeFileOptions,
 ): Promise<Response> {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    return createStandardResponse(STATUS_CODE.MethodNotAllowed);
+  }
+
   let { etagAlgorithm: algorithm, fileInfo } = options ?? {};
 
   try {
@@ -635,6 +639,10 @@ export async function serveDir(
   req: Request,
   opts: ServeDirOptions = {},
 ): Promise<Response> {
+  if (req.method !== "GET" && req.method !== "HEAD") {
+    return createStandardResponse(STATUS_CODE.MethodNotAllowed);
+  }
+
   let response: Response;
   try {
     response = await createServeDirResponse(req, opts);

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -267,6 +267,15 @@ Deno.test("serveDir() handles not found files", async () => {
   assertEquals(res.status, 404);
 });
 
+Deno.test("serveDir() handles incorrect method", async () => {
+  const req = new Request("http://localhost/", { method: "POST" });
+  const res = await serveDir(req, serveDirOptions);
+  await res.body?.cancel();
+
+  assertEquals(res.status, 405);
+  assertEquals(res.statusText, "Method Not Allowed");
+});
+
 Deno.test("serveDir() traverses path correctly", async () => {
   const req = new Request("http://localhost/../../../../../../../..");
   const res = await serveDir(req, serveDirOptions);
@@ -737,6 +746,17 @@ Deno.test("serveFile() handles file not found", async () => {
 
   assertEquals(res.status, 404);
   assertEquals(res.statusText, "Not Found");
+});
+
+Deno.test("serveFile() handles method not allowed", async () => {
+  const req = new Request("http://localhost/testdata/test_file.txt", {
+    method: "POST",
+  });
+  const res = await serveFile(req, TEST_FILE_PATH);
+  await res.body?.cancel();
+
+  assertEquals(res.status, 405);
+  assertEquals(res.statusText, "Method Not Allowed");
 });
 
 Deno.test("serveFile() serves HTTP 404 when the path is a directory", async () => {


### PR DESCRIPTION
Previously, the `file-server` module handled all requests with non-`GET` and non-`HEAD` methods the same as `GET` and `HEAD` methods, when they shouldn't have. Now, such methods cause a HTTP 405 status to be served.