### PR TITLE
fix(archive): make `data` property private in `Tar`

### DIFF
--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -257,11 +257,11 @@ export interface TarDataWithSource extends TarData {
  */
 export class Tar {
   /** Tar data. */
-  data: TarDataWithSource[];
+  #data: TarDataWithSource[];
 
   /** Constructs a new instance. */
   constructor() {
-    this.data = [];
+    this.#data = [];
   }
 
   /**
@@ -385,7 +385,7 @@ export class Tar {
       });
 
     tarData.checksum = pad(checksum, 6) + "\u0000 ";
-    this.data.push(tarData);
+    this.#data.push(tarData);
   }
 
   /**
@@ -393,7 +393,7 @@ export class Tar {
    */
   getReader(): Reader {
     const readers: Reader[] = [];
-    this.data.forEach((tarData) => {
+    this.#data.forEach((tarData) => {
       let { reader } = tarData;
       const { filePath } = tarData;
       const headerArr = formatHeader(tarData);


### PR DESCRIPTION
This property is not documented or tested anywhere. It seems it was included in the public API by mistake.