### PR TITLE
BREAKING(datetime): replace `utc` with `timeZone` option

### DIFF
--- a/datetime/format.ts
+++ b/datetime/format.ts
@@ -6,11 +6,11 @@ import { DateTimeFormatter } from "./_date_time_formatter.ts";
 /** Options for {@linkcode format}. */
 export interface FormatOptions {
   /**
-   * Whether returns the formatted date in UTC instead of local time.
+   * The timezone the formatted date should be in.
    *
-   * @default {false}
+   * @default {undefined}
    */
-  utc?: boolean;
+  timeZone?: "UTC";
 }
 
 /**
@@ -69,7 +69,7 @@ export interface FormatOptions {
  *
  * const date = new Date(2019, 0, 20, 16, 34, 23, 123);
  *
- * assertEquals(format(date, "yyyy-MM-dd HH:mm:ss", { utc: true }), "2019-01-20 05:34:23");
+ * assertEquals(format(date, "yyyy-MM-dd HH:mm:ss", { timeZone: "UTC" }), "2019-01-20 05:34:23");
  * ```
  */
 export function format(
@@ -78,8 +78,5 @@ export function format(
   options: FormatOptions = {},
 ): string {
   const formatter = new DateTimeFormatter(formatString);
-  return formatter.format(
-    date,
-    options.utc ? { timeZone: "UTC" } : undefined,
-  );
+  return formatter.format(date, options);
 }

--- a/datetime/format_test.ts
+++ b/datetime/format_test.ts
@@ -108,7 +108,7 @@ Deno.test({
       format(
         new Date("2019-01-01T13:00:00.000+09:00"),
         "yyyy-MM-dd HH:mm:ss.SSS",
-        { utc: true },
+        { timeZone: "UTC" },
       ),
     );
 
@@ -117,7 +117,7 @@ Deno.test({
       format(
         new Date("2019-01-01T13:00:00.000-05:00"),
         "yyyy-MM-dd HH:mm:ss.SSS",
-        { utc: true },
+        { timeZone: "UTC" },
       ),
     );
   },


### PR DESCRIPTION
**Changes**
This PR changes the `utc` boolean option to `timeZone` with explicit `"UTC"` value option.

**Reasoning**
This makes the option extendable if needed and aligns the api to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toLocaleTimeString#using_options