### PR TITLE
perf(uuid): make `uuidToBytes()` up to 2.5x faster

### DIFF
--- a/uuid/_common.ts
+++ b/uuid/_common.ts
@@ -45,9 +45,35 @@ export function bytesToUuid(bytes: number[] | Uint8Array): string {
  * @param uuid Value that gets converted.
  */
 export function uuidToBytes(uuid: string): Uint8Array {
-  const bytes = uuid
-    .replaceAll("-", "")
-    .match(/.{1,2}/g)!
-    .map((byte) => parseInt(byte, 16));
-  return new Uint8Array(bytes);
+  const bytes = new Uint8Array(16);
+  let i = 0;
+
+  for (const str of uuid.split("-")) {
+    const hex = parseInt(str, 16);
+    switch (str.length) {
+      case 4: {
+        bytes[i++] = (hex >>> 8) & 0xff;
+        bytes[i++] = hex & 0xff;
+        break;
+      }
+      case 8: {
+        bytes[i++] = (hex >>> 24) & 0xff;
+        bytes[i++] = (hex >>> 16) & 0xff;
+        bytes[i++] = (hex >>> 8) & 0xff;
+        bytes[i++] = hex & 0xff;
+        break;
+      }
+      case 12: {
+        bytes[i++] = (hex / 0x10000000000) & 0xff;
+        bytes[i++] = (hex / 0x100000000) & 0xff;
+        bytes[i++] = (hex >>> 24) & 0xff;
+        bytes[i++] = (hex >>> 16) & 0xff;
+        bytes[i++] = (hex >>> 8) & 0xff;
+        bytes[i++] = hex & 0xff;
+        break;
+      }
+    }
+  }
+
+  return bytes;
 }


### PR DESCRIPTION
<details>
<summary>Code</summary>

```ts
function uuidToBytes_new(uuid: string): Uint8Array {
  const bytes = new Uint8Array(16);
  let i = 0;

  for (const str of uuid.split("-")) {
    const hex = parseInt(str, 16);
    switch (str.length) {
      case 4: {
        bytes[i++] = (hex >>> 8) & 0xff;
        bytes[i++] = hex & 0xff;
        break;
      }
      case 8: {
        bytes[i++] = (hex >>> 24) & 0xff;
        bytes[i++] = (hex >>> 16) & 0xff;
        bytes[i++] = (hex >>> 8) & 0xff;
        bytes[i++] = hex & 0xff;
        break;
      }
      case 12: {
        bytes[i++] = (hex / 0x10000000000) & 0xff;
        bytes[i++] = (hex / 0x100000000) & 0xff;
        bytes[i++] = (hex >>> 24) & 0xff;
        bytes[i++] = (hex >>> 16) & 0xff;
        bytes[i++] = (hex >>> 8) & 0xff;
        bytes[i++] = hex & 0xff;
        break;
      }
    }
  }

  return bytes;
}

function uuidToBytes_old(uuid: string): Uint8Array {
  const bytes = uuid
    .replaceAll("-", "")
    .match(/.{1,2}/g)!
    .map((byte) => parseInt(byte, 16));
  return new Uint8Array(bytes);
}

for (let i = 0; i < 4; ++i) {
  const uuids: string[] = [];
  const size = 10 ** (i + 1);

  for (let j = 0; j < size; ++j) {
    uuids.push(crypto.randomUUID());
  }

  Deno.bench("new", { group: `${size} uuids` }, () => {
    for (const u of uuids) {
      uuidToBytes_new(u);
    }
  });

  Deno.bench("old", { group: `${size} uuids` }, () => {
    for (const u of uuids) {
      uuidToBytes_old(u);
    }
  });
}
```
</details>

<details>
<summary>Benchmark results</summary>

```
cpu: Intel(R) Core(TM) i3-6006U CPU @ 2.00GHz
runtime: deno 1.45.5 (x86_64-pc-windows-msvc)

file:///D:/coding/project/javascript/deno/console/mod.ts
benchmark      time (avg)        iter/s             (min … max)       p75       p99      p995
--------------------------------------------------------------- -----------------------------

group 10 uuids
new            23.24 µs/iter      43,023.7      (19.3 µs … 744 µs) 21 µs 77.2 µs 91.2 µs
old             58.3 µs/iter      17,151.5    (51.4 µs … 766.8 µs) 54.3 µs 134.1 µs 229.5 µs

summary
  new
   2.51x faster than old

group 100 uuids
new            240.3 µs/iter       4,161.5    (207.4 µs … 1.26 ms) 233.4 µs 603.8 µs 674.8 µs
old           570.83 µs/iter       1,751.8    (516.8 µs … 1.32 ms) 561.7 µs 983.1 µs 1.07 ms

summary
  new
   2.38x faster than old

group 1000 uuids
new             2.46 ms/iter         407.0     (2.14 ms … 4.61 ms) 2.48 ms 3.69 ms 4.02 ms
old             5.68 ms/iter         176.2     (5.25 ms … 6.94 ms) 5.9 ms 6.94 ms 6.94 ms

summary
  new
   2.31x faster than old

group 10000 uuids
new             24.3 ms/iter          41.2   (22.96 ms … 26.59 ms) 25.16 ms 26.59 ms 26.59 ms
old            62.02 ms/iter          16.1   (53.65 ms … 81.79 ms) 63.98 ms 81.79 ms 81.79 ms

summary
  new
   2.55x faster than old
```

</details>