### PR TITLE
fix(testing): fix false positive in `IsExact`

### DIFF
--- a/testing/types.ts
+++ b/testing/types.ts
@@ -177,12 +177,14 @@ export type IsNullable<T> = Extract<T, null | undefined> extends never ? false
  * @typeParam T The type to check if it exactly matches type `U`.
  * @typeParam U The type to check if it exactly matches type `T`.
  */
-export type IsExact<T, U> = TupleMatches<AnyToBrand<T>, AnyToBrand<U>> extends
-  true
-  ? TupleMatches<DeepPrepareIsExact<T>, DeepPrepareIsExact<U>> extends true
-    ? true
-  : false
-  : false;
+export type IsExact<T, U> =
+  ParametersAndReturnTypeMatches<AnyToBrand<T>, AnyToBrand<U>> extends true
+    ? ParametersAndReturnTypeMatches<
+      DeepPrepareIsExact<T>,
+      DeepPrepareIsExact<U>
+    > extends true ? true
+    : false
+    : false;
 
 /** @internal */
 export type DeepPrepareIsExact<T, VisitedTypes = never> = {
@@ -246,6 +248,16 @@ export type IsNever<T> = [T] extends [never] ? true : false;
 export type IsUnknown<T> = unknown extends T
   ? ([T] extends [null] ? false : true)
   : false;
+
+/**
+ * The internal utility type to match the given types as return types.
+ *
+ * @internal
+ */
+export type ParametersAndReturnTypeMatches<T, U> = Matches<
+  <X>(_: T) => X extends T ? 1 : 2,
+  <X>(_: U) => X extends U ? 1 : 2
+>;
 
 /**
  * The internal utility type to match the given types as tuples.

--- a/testing/types.ts
+++ b/testing/types.ts
@@ -177,14 +177,15 @@ export type IsNullable<T> = Extract<T, null | undefined> extends never ? false
  * @typeParam T The type to check if it exactly matches type `U`.
  * @typeParam U The type to check if it exactly matches type `T`.
  */
-export type IsExact<T, U> =
-  ParametersAndReturnTypeMatches<AnyToBrand<T>, AnyToBrand<U>> extends true
-    ? ParametersAndReturnTypeMatches<
-      DeepPrepareIsExact<T>,
-      DeepPrepareIsExact<U>
-    > extends true ? true
-    : false
-    : false;
+export type IsExact<T, U> = ParametersAndReturnTypeMatches<
+  FlatType<AnyToBrand<T>>,
+  FlatType<AnyToBrand<U>>
+> extends true ? ParametersAndReturnTypeMatches<
+    FlatType<DeepPrepareIsExact<T>>,
+    FlatType<DeepPrepareIsExact<U>>
+  > extends true ? true
+  : false
+  : false;
 
 /** @internal */
 export type DeepPrepareIsExact<T, VisitedTypes = never> = {
@@ -286,3 +287,12 @@ export type AnyToBrand<T> = IsAny<T> extends true ? AnyBrand : T;
  * @internal
  */
 export type AnyBrand = { __conditionalTypeChecksAny__: undefined };
+
+/**
+ * The utility type to flatten record types.
+ *
+ * @internal
+ */
+export type FlatType<T> = T extends Record<PropertyKey, unknown>
+  ? { [K in keyof T]: FlatType<T[K]> }
+  : T;

--- a/testing/types_test.ts
+++ b/testing/types_test.ts
@@ -32,6 +32,10 @@ import {
 
 // IsExact
 {
+  class _Class<T> {
+    declare private _prop: T;
+  }
+
   // matching
   assertType<IsExact<string | number, string | number>>(true);
   assertType<IsExact<string | number | Date, string | number | Date>>(true);
@@ -47,6 +51,7 @@ import {
   assertType<IsExact<{ prop: never }, { prop: never }>>(true);
   assertType<IsExact<{ prop: any }, { prop: any }>>(true);
   assertType<IsExact<{ prop: unknown }, { prop: unknown }>>(true);
+  assertType<IsExact<{ readonly prop: any }, { readonly prop: any }>>(true);
   assertType<IsExact<[], []>>(true);
   assertType<IsExact<readonly [], readonly []>>(true);
   assertType<IsExact<any[], any[]>>(true);
@@ -58,6 +63,32 @@ import {
   assertType<IsExact<[any, ...any[]], [any, ...any[]]>>(true);
   assertType<IsExact<[any, ...any[], any], [any, ...any[], any]>>(true);
   assertType<IsExact<typeof globalThis, typeof globalThis>>(true);
+  assertType<IsExact<() => void, () => void>>(true);
+  assertType<IsExact<() => any, () => any>>(true);
+  assertType<IsExact<() => unknown, () => unknown>>(true);
+  assertType<IsExact<() => never, () => never>>(true);
+  assertType<IsExact<(arg: any) => void, (arg: any) => void>>(true);
+  assertType<IsExact<(arg?: any) => void, (arg?: any) => void>>(true);
+  assertType<IsExact<(...args: any[]) => void, (...args: any[]) => void>>(true);
+  assertType<
+    IsExact<
+      (arg: any, ...args: any[]) => void,
+      (arg: any, ...args: any[]) => void
+    >
+  >(true);
+  assertType<IsExact<_Class<any>, _Class<any>>>(true);
+  assertType<
+    IsExact<
+      _Class<{ x: any; prop?: any }>,
+      _Class<{ x: any; prop?: any }>
+    >
+  >(true);
+  assertType<
+    IsExact<
+      _Class<{ x: any; readonly prop: any }>,
+      _Class<{ x: any; readonly prop: any }>
+    >
+  >(true);
 
   // not matching
   assertType<IsExact<string | number | Date, string | number>>(false);
@@ -102,6 +133,7 @@ import {
     >
   >(false);
   assertType<IsExact<{ prop: string | undefined }, { prop?: string }>>(false); // these are different
+  assertType<IsExact<{ prop: any }, { readonly prop: any }>>(false);
   assertType<IsExact<[], readonly []>>(false);
   assertType<IsExact<any[], []>>(false);
   assertType<IsExact<any[], unknown[]>>(false);
@@ -112,6 +144,43 @@ import {
   assertType<IsExact<[...any[]], [any, ...any[]]>>(false);
   assertType<IsExact<[...any[]], [any, ...any[], any]>>(false);
   assertType<IsExact<[any, ...any[]], [any, ...any[], any]>>(false);
+  assertType<IsExact<() => void, () => undefined>>(false);
+  assertType<IsExact<() => any, () => unknown>>(false);
+  assertType<IsExact<() => any, () => never>>(false);
+  assertType<IsExact<(arg: any) => void, (arg: unknown) => void>>(false);
+  assertType<IsExact<() => void, (arg?: any) => void>>(false);
+  assertType<IsExact<(arg: any) => void, (arg?: any) => void>>(false);
+  assertType<
+    IsExact<
+      (...args: any[]) => void,
+      (...args: unknown[]) => void
+    >
+  >(false);
+  assertType<
+    IsExact<
+      (arg: any, ...args: any[]) => void,
+      (arg: unknown, ...args: any[]) => void
+    >
+  >(false);
+  assertType<
+    IsExact<
+      (arg: any, ...args: any[]) => void,
+      (arg: any, ...args: unknown[]) => void
+    >
+  >(false);
+  assertType<IsExact<_Class<any>, _Class<number>>>(false);
+  assertType<
+    IsExact<
+      _Class<{ x: any; prop?: any }>,
+      _Class<{ x: any; other?: any }>
+    >
+  >(false);
+  assertType<
+    IsExact<
+      _Class<{ x: any; prop: any }>,
+      _Class<{ x: any; readonly prop: any }>
+    >
+  >(false);
 }
 
 // Has

--- a/testing/types_test.ts
+++ b/testing/types_test.ts
@@ -89,6 +89,18 @@ import {
       _Class<{ x: any; readonly prop: any }>
     >
   >(true);
+  assertType<
+    IsExact<
+      { [x: string]: unknown } & { prop: unknown },
+      { [x: string]: unknown; prop: unknown }
+    >
+  >(true);
+  assertType<
+    IsExact<
+      { [x: string]: unknown; prop: unknown },
+      { [x: string]: unknown } & { prop: unknown }
+    >
+  >(true);
 
   // not matching
   assertType<IsExact<string | number | Date, string | number>>(false);
@@ -179,6 +191,18 @@ import {
     IsExact<
       _Class<{ x: any; prop: any }>,
       _Class<{ x: any; readonly prop: any }>
+    >
+  >(false);
+  assertType<
+    IsExact<
+      { [x: string]: unknown; prop: any } & { prop: unknown },
+      { [x: string]: unknown; prop: unknown }
+    >
+  >(false);
+  assertType<
+    IsExact<
+      { [x: string]: unknown; prop: unknown },
+      { [x: string]: unknown; prop: any } & { prop: unknown }
     >
   >(false);
 }

--- a/testing/types_test.ts
+++ b/testing/types_test.ts
@@ -47,6 +47,16 @@ import {
   assertType<IsExact<{ prop: never }, { prop: never }>>(true);
   assertType<IsExact<{ prop: any }, { prop: any }>>(true);
   assertType<IsExact<{ prop: unknown }, { prop: unknown }>>(true);
+  assertType<IsExact<[], []>>(true);
+  assertType<IsExact<readonly [], readonly []>>(true);
+  assertType<IsExact<any[], any[]>>(true);
+  assertType<IsExact<unknown[], unknown[]>>(true);
+  assertType<IsExact<never[], never[]>>(true);
+  assertType<IsExact<[elm?: any], [elm?: any]>>(true);
+  assertType<IsExact<[...any[]], [...any[]]>>(true);
+  assertType<IsExact<[...any[], any], [...any[], any]>>(true);
+  assertType<IsExact<[any, ...any[]], [any, ...any[]]>>(true);
+  assertType<IsExact<[any, ...any[], any], [any, ...any[], any]>>(true);
   assertType<IsExact<typeof globalThis, typeof globalThis>>(true);
 
   // not matching
@@ -92,6 +102,16 @@ import {
     >
   >(false);
   assertType<IsExact<{ prop: string | undefined }, { prop?: string }>>(false); // these are different
+  assertType<IsExact<[], readonly []>>(false);
+  assertType<IsExact<any[], []>>(false);
+  assertType<IsExact<any[], unknown[]>>(false);
+  assertType<IsExact<any[], never[]>>(false);
+  assertType<IsExact<[], [elm?: any]>>(false);
+  assertType<IsExact<[elm: any], [elm?: any]>>(false);
+  assertType<IsExact<[...any[]], [...any[], any]>>(false);
+  assertType<IsExact<[...any[]], [any, ...any[]]>>(false);
+  assertType<IsExact<[...any[]], [any, ...any[], any]>>(false);
+  assertType<IsExact<[any, ...any[]], [any, ...any[], any]>>(false);
 }
 
 // Has


### PR DESCRIPTION
## Problem

`IsExact` has many false positives.

## My fix

- Add test cases for array or tuple types. These work correctly in the original `IsExact` implementation before this PR, but give false positives in [the alternative implementation](https://github.com/type-challenges/type-challenges/blob/e77262dba62e9254451f661cb4fe5517ffd1d933/utils/index.d.ts#L7-L9), so I am added it.
- Add test cases for function or class, and fix false positive.
  - This fix resulted in the following false negative.
- Add test cases for intersection, and fix false negative. In other words, I fixed the problem that "correct equality may still be stricter than some expect."

## Refs

https://github.com/denoland/std/issues/3196#issuecomment-1430099273
It was closed by arguments against including utility types.
However, `IsExact` already exists in `@std` so I fixed the bug.