### PR TITLE
refactor(yaml): remove `result` property

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -478,7 +478,6 @@ export class DumperState {
   implicitTypes: Type<"scalar">[];
   explicitTypes: Type<KindType>[];
   tag: string | null = null;
-  result = "";
   duplicates: unknown[] = [];
   usedDuplicates: Set<unknown> = new Set();
   styleMap: ArrayObject<StyleVariant>;


### PR DESCRIPTION
**Changes**
This PR removes the `result` property of the `DumperState`.

**Reasoning**
It is not used anywhere.