### PR TITLE
chore: support `expect-error` directive in code snippets evaluator

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -148,6 +148,17 @@ delimiter. E.g.
  */
 ````
 
+You can also write code snippets that are expected to fail either at compile
+time or at runtime by adding `expect-error`. E.g.
+
+````ts
+/**
+ * ```ts expect-error
+ * (code snippet to fail)
+ * ```
+ */
+````
+
 ### Notices for unstable APIs
 
 Each unstable API must have the

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -149,12 +149,24 @@ delimiter. E.g.
 ````
 
 You can also write code snippets that are expected to fail either at compile
-time or at runtime by adding `expect-error`. E.g.
+time or at runtime by adding `expect-error`. However, if the fenced code is
+supposed to not pass type checking, you may also want to specify `ignore`
+directive, because we run `deno test --doc` command in CI, which does type
+checking against fenced code snippets except for those with `ignore` directive.
+So concrete examples are:
 
 ````ts
 /**
+ * ```ts expect-error ignore
+ * // Does not pass type checking
+ * const x: string = 1;
+ * ```
+ *
  * ```ts expect-error
- * (code snippet to fail)
+ * import { assert } from "@std/assert/assert";
+ *
+ * // Fails at runtime
+ * assert(false);
  * ```
  */
 ````

--- a/testing/types.ts
+++ b/testing/types.ts
@@ -4,7 +4,7 @@
 /**
  * Testing utilities for types.
  *
- * ```ts ignore
+ * ```ts expect-error
  * import { assertType, IsExact, IsNullable } from "@std/testing/types";
  *
  * const result = "some result" as string | number;
@@ -23,7 +23,7 @@
  * Asserts at compile time that the provided type argument's type resolves to the expected boolean literal type.
  *
  * @example Usage
- * ```ts ignore
+ * ```ts expect-error
  * import { assertType, IsExact, IsNullable } from "@std/testing/types";
  *
  * const result = "some result" as string | number;

--- a/testing/types.ts
+++ b/testing/types.ts
@@ -4,7 +4,7 @@
 /**
  * Testing utilities for types.
  *
- * ```ts expect-error
+ * ```ts expect-error ignore
  * import { assertType, IsExact, IsNullable } from "@std/testing/types";
  *
  * const result = "some result" as string | number;
@@ -23,7 +23,7 @@
  * Asserts at compile time that the provided type argument's type resolves to the expected boolean literal type.
  *
  * @example Usage
- * ```ts expect-error
+ * ```ts expect-error ignore
  * import { assertType, IsExact, IsNullable } from "@std/testing/types";
  *
  * const result = "some result" as string | number;


### PR DESCRIPTION
This commit adds support for `expect-error` directive in code snippets evaluator, which allows example snippets to have ones that are expected to fail either at compile time or runtime.

This is inspired by Rust where we can add doc tests that are supposed to panic, or to fail to compile, e.g.

```rust
/// ```should_panic
/// assert!(false);
/// ```
///
/// ```compile_fail
/// let x = 5;
/// x += 2;
/// ```
```