### PR TITLE
refactor(yaml): Make `version` property required

### DIFF
--- a/yaml/_loader_state.ts
+++ b/yaml/_loader_state.ts
@@ -149,7 +149,7 @@ export class LoaderState {
   implicitTypes: Type<"scalar">[];
   typeMap: TypeMap;
 
-  version?: string | null;
+  version: string | null;
   checkLineBreaks = false;
   tagMap: ArrayObject = Object.create(null);
   anchorMap: ArrayObject = Object.create(null);
@@ -173,6 +173,7 @@ export class LoaderState {
     this.implicitTypes = this.schema.compiledImplicit;
     this.typeMap = this.schema.compiledTypeMap;
     this.length = input.length;
+    this.version = null;
 
     this.readIndent();
   }
@@ -357,7 +358,7 @@ function yamlDirectiveHandler(state: LoaderState, ...args: string[]) {
     return state.throwError("unacceptable YAML version of the document");
   }
 
-  state.version = args[0];
+  state.version = args[0] ?? null;
   state.checkLineBreaks = minor < 2;
   if (minor !== 1 && minor !== 2) {
     return state.dispatchWarning("unsupported YAML version of the document");


### PR DESCRIPTION
**Changes**
This PR makes the `version` property in `DumperState` required.

**Reasoning**
The version is checked against `null`, so `undefined` should not be possible.