### PR TITLE
refactor(yaml): remove `schema` property

### DIFF
--- a/yaml/_loader_state.ts
+++ b/yaml/_loader_state.ts
@@ -137,7 +137,6 @@ function codepointToChar(codepoint: number): string {
 }
 
 export class LoaderState {
-  schema: Schema;
   input: string;
   length: number;
   lineIndent = 0;
@@ -166,12 +165,11 @@ export class LoaderState {
       allowDuplicateKeys = false,
     }: LoaderStateOptions,
   ) {
-    this.schema = schema;
     this.input = input;
     this.onWarning = onWarning;
     this.allowDuplicateKeys = allowDuplicateKeys;
-    this.implicitTypes = this.schema.compiledImplicit;
-    this.typeMap = this.schema.compiledTypeMap;
+    this.implicitTypes = schema.compiledImplicit;
+    this.typeMap = schema.compiledTypeMap;
     this.length = input.length;
 
     this.readIndent();


### PR DESCRIPTION
**Changes**
This PR removes the `schema` property in `DumperState`.

**Reasoning**
`schema` is only used in the constructor to extract values which are stored in properties themselves.