### PR TITLE
refactor(yaml): redefine `include` as optional `Schema`

### DIFF
--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -57,9 +57,7 @@ function compileList<K extends KindType, D = any>(
 ): Type<K, D>[] {
   const exclude: number[] = [];
 
-  for (const includedSchema of schema.include) {
-    result = compileList(includedSchema, name, result);
-  }
+  if (schema.include) result = compileList(schema.include, name, result);
 
   for (const currentType of schema[name]) {
     for (const [previousIndex, previousType] of result.entries()) {
@@ -100,7 +98,7 @@ function compileMap(...typesList: Type<KindType>[][]): TypeMap {
 export class Schema {
   implicit: Type<"scalar">[];
   explicit: Type<KindType>[];
-  include: Schema[];
+  include?: Schema;
 
   compiledImplicit: Type<"scalar">[];
   compiledExplicit: Type<KindType>[];
@@ -109,11 +107,11 @@ export class Schema {
   constructor(definition: {
     implicit?: Type<"scalar">[];
     explicit?: Type<KindType>[];
-    include?: Schema[];
+    include?: Schema;
   }) {
     this.explicit = definition.explicit || [];
     this.implicit = definition.implicit || [];
-    this.include = definition.include || [];
+    this.include = definition.include;
     this.compiledImplicit = compileList(this, "implicit", []);
     this.compiledExplicit = compileList(this, "explicit", []);
     this.compiledTypeMap = compileMap(
@@ -139,7 +137,7 @@ const FAILSAFE_SCHEMA = new Schema({
  */
 const JSON_SCHEMA = new Schema({
   implicit: [nil, bool, int, float],
-  include: [FAILSAFE_SCHEMA],
+  include: FAILSAFE_SCHEMA,
 });
 
 /**
@@ -148,7 +146,7 @@ const JSON_SCHEMA = new Schema({
  * @see {@link http://www.yaml.org/spec/1.2/spec.html#id2804923}
  */
 const CORE_SCHEMA = new Schema({
-  include: [JSON_SCHEMA],
+  include: JSON_SCHEMA,
 });
 
 /**
@@ -157,7 +155,7 @@ const CORE_SCHEMA = new Schema({
 export const DEFAULT_SCHEMA = new Schema({
   explicit: [binary, omap, pairs, set],
   implicit: [timestamp, merge],
-  include: [CORE_SCHEMA],
+  include: CORE_SCHEMA,
 });
 
 /***
@@ -187,7 +185,7 @@ export const DEFAULT_SCHEMA = new Schema({
  */
 const EXTENDED_SCHEMA = new Schema({
   explicit: [regexp, undefinedType],
-  include: [DEFAULT_SCHEMA],
+  include: DEFAULT_SCHEMA,
 });
 
 export const SCHEMA_MAP = new Map([


### PR DESCRIPTION
**Changes**
This PR redefines the `include` property in `Schema` as a single optional `Schema`.

**Reasoning**
Every used Schema only has one included `Schema`.