### PR TITLE
refactor(semver): unify param names

### DIFF
--- a/semver/can_parse.ts
+++ b/semver/can_parse.ts
@@ -14,12 +14,12 @@ import { parse } from "./parse.ts";
  * assertFalse(canParse("invalid"));
  * ```
  *
- * @param version The version string to check
+ * @param value The version string to check
  * @returns `true` if the string can be parsed as SemVer, `false` otherwise
  */
-export function canParse(version: string): boolean {
+export function canParse(value: string): boolean {
   try {
-    parse(version);
+    parse(value);
     return true;
   } catch {
     return false;

--- a/semver/compare.ts
+++ b/semver/compare.ts
@@ -10,7 +10,7 @@ import {
 /**
  * Compare two SemVers.
  *
- * Returns `0` if `s0` equals `s1`, or `1` if `s0` is greater, or `-1` if `s1` is
+ * Returns `0` if `version1` equals `version2`, or `1` if `version1` is greater, or `-1` if `version2` is
  * greater.
  *
  * Sorts in ascending order if passed to {@linkcode Array.sort}.
@@ -20,28 +20,25 @@ import {
  * import { parse, compare } from "@std/semver";
  * import { assertEquals } from "@std/assert";
  *
- * const s0 = parse("1.2.3");
- * const s1 = parse("1.2.4");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.4");
  *
- * assertEquals(compare(s0, s1), -1);
- * assertEquals(compare(s1, s0), 1);
- * assertEquals(compare(s0, s0), 0);
+ * assertEquals(compare(version1, version2), -1);
+ * assertEquals(compare(version2, version1), 1);
+ * assertEquals(compare(version1, version1), 0);
  * ```
  *
- * @param s0 The first SemVer to compare
- * @param s1 The second SemVer to compare
- * @returns `1` if `s0` is greater, `0` if equal, or `-1` if `s1` is greater
+ * @param version1 The first SemVer to compare
+ * @param version2 The second SemVer to compare
+ * @returns `1` if `version1` is greater, `0` if equal, or `-1` if `version2` is greater
  */
-export function compare(
-  s0: SemVer,
-  s1: SemVer,
-): 1 | 0 | -1 {
-  if (s0 === s1) return 0;
+export function compare(version1: SemVer, version2: SemVer): 1 | 0 | -1 {
+  if (version1 === version2) return 0;
   return (
-    compareNumber(s0.major, s1.major) ||
-    compareNumber(s0.minor, s1.minor) ||
-    compareNumber(s0.patch, s1.patch) ||
-    checkIdentifier(s0.prerelease, s1.prerelease) ||
-    compareIdentifier(s0.prerelease, s1.prerelease)
+    compareNumber(version1.major, version2.major) ||
+    compareNumber(version1.minor, version2.minor) ||
+    compareNumber(version1.patch, version2.patch) ||
+    checkIdentifier(version1.prerelease, version2.prerelease) ||
+    compareIdentifier(version1.prerelease, version2.prerelease)
   );
 }

--- a/semver/difference.ts
+++ b/semver/difference.ts
@@ -12,29 +12,39 @@ import { compareIdentifier } from "./_shared.ts";
  * import { parse, difference } from "@std/semver";
  * import { assertEquals } from "@std/assert";
  *
- * const s0 = parse("1.2.3");
- * const s1 = parse("1.2.4");
- * const s2 = parse("1.3.0");
- * const s3 = parse("2.0.0");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.4");
+ * const version3 = parse("1.3.0");
+ * const version4 = parse("2.0.0");
  *
- * assertEquals(difference(s0, s1), "patch");
- * assertEquals(difference(s0, s2), "minor");
- * assertEquals(difference(s0, s3), "major");
- * assertEquals(difference(s0, s0), undefined);
+ * assertEquals(difference(version1, version2), "patch");
+ * assertEquals(difference(version1, version3), "minor");
+ * assertEquals(difference(version1, version4), "major");
+ * assertEquals(difference(version1, version1), undefined);
  * ```
  *
- * @param s0 The first SemVer to compare
- * @param s1 The second SemVer to compare
+ * @param version1 The first SemVer to compare
+ * @param version2 The second SemVer to compare
  * @returns The release type difference or `undefined` if the versions are the same
  */
-export function difference(s0: SemVer, s1: SemVer): ReleaseType | undefined {
-  const hasPrerelease = s0.prerelease?.length || s1.prerelease?.length;
+export function difference(
+  version1: SemVer,
+  version2: SemVer,
+): ReleaseType | undefined {
+  const hasPrerelease = version1.prerelease?.length ||
+    version2.prerelease?.length;
 
-  if (s0.major !== s1.major) return hasPrerelease ? "premajor" : "major";
-  if (s0.minor !== s1.minor) return hasPrerelease ? "preminor" : "minor";
-  if (s0.patch !== s1.patch) return hasPrerelease ? "prepatch" : "patch";
+  if (version1.major !== version2.major) {
+    return hasPrerelease ? "premajor" : "major";
+  }
+  if (version1.minor !== version2.minor) {
+    return hasPrerelease ? "preminor" : "minor";
+  }
+  if (version1.patch !== version2.patch) {
+    return hasPrerelease ? "prepatch" : "patch";
+  }
 
-  if (compareIdentifier(s0.prerelease, s1.prerelease) !== 0) {
+  if (compareIdentifier(version1.prerelease, version2.prerelease) !== 0) {
     return "prerelease";
   }
 }

--- a/semver/equals.ts
+++ b/semver/equals.ts
@@ -6,24 +6,24 @@ import type { SemVer } from "./types.ts";
 /**
  * Returns `true` if both SemVers are equivalent.
  *
- * This is equal to `compare(s0, s1) === 0`.
+ * This is equal to `compare(version1, version2) === 0`.
  *
  * @example Usage
  * ```ts
  * import { parse, equals } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const s0 = parse("1.2.3");
- * const s1 = parse("1.2.3");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.3");
  *
- * assert(equals(s0, s1));
- * assert(!equals(s0, parse("1.2.4")));
+ * assert(equals(version1, version2));
+ * assert(!equals(version1, parse("1.2.4")));
  * ```
  *
- * @param s0 The first SemVer to compare
- * @param s1 The second SemVer to compare
- * @returns `true` if `s0` is equal to `s1`, `false` otherwise
+ * @param version1 The first SemVer to compare
+ * @param version2 The second SemVer to compare
+ * @returns `true` if `version1` is equal to `version2`, `false` otherwise
  */
-export function equals(s0: SemVer, s1: SemVer): boolean {
-  return compare(s0, s1) === 0;
+export function equals(version1: SemVer, version2: SemVer): boolean {
+  return compare(version1, version2) === 0;
 }

--- a/semver/format.ts
+++ b/semver/format.ts
@@ -22,15 +22,15 @@ function formatNumber(value: number) {
  * assertEquals(format(semver), "1.2.3");
  * ```
  *
- * @param semver The SemVer to format
+ * @param version The SemVer to format
  * @returns The string representation of a semantic version.
  */
-export function format(semver: SemVer): string {
-  const major = formatNumber(semver.major);
-  const minor = formatNumber(semver.minor);
-  const patch = formatNumber(semver.patch);
-  const pre = semver.prerelease?.join(".") ?? "";
-  const build = semver.build?.join(".") ?? "";
+export function format(version: SemVer): string {
+  const major = formatNumber(version.major);
+  const minor = formatNumber(version.minor);
+  const patch = formatNumber(version.patch);
+  const pre = version.prerelease?.join(".") ?? "";
+  const build = version.build?.join(".") ?? "";
 
   const primary = `${major}.${minor}.${patch}`;
   const release = [primary, pre].filter((v) => v).join("-");

--- a/semver/greater_or_equal.ts
+++ b/semver/greater_or_equal.ts
@@ -6,25 +6,25 @@ import { compare } from "./compare.ts";
 /**
  * Greater than or equal to comparison for two SemVers.
  *
- * This is equal to `compare(s0, s1) >= 0`.
+ * This is equal to `compare(version1, version2) >= 0`.
  *
  * @example Usage
  * ```ts
  * import { parse, greaterOrEqual } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const s0 = parse("1.2.3");
- * const s1 = parse("1.2.4");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.4");
  *
- * assert(greaterOrEqual(s1, s0));
- * assert(!greaterOrEqual(s0, s1));
- * assert(greaterOrEqual(s0, s0));
+ * assert(greaterOrEqual(version2, version1));
+ * assert(!greaterOrEqual(version1, version2));
+ * assert(greaterOrEqual(version1, version1));
  * ```
  *
- * @param s0 The first version to compare
- * @param s1 The second version to compare
- * @returns `true` if `s0` is greater than or equal to `s1`, `false` otherwise
+ * @param version1 The first version to compare
+ * @param version2 The second version to compare
+ * @returns `true` if `version1` is greater than or equal to `version2`, `false` otherwise
  */
-export function greaterOrEqual(s0: SemVer, s1: SemVer): boolean {
-  return compare(s0, s1) >= 0;
+export function greaterOrEqual(version1: SemVer, version2: SemVer): boolean {
+  return compare(version1, version2) >= 0;
 }

--- a/semver/greater_than.ts
+++ b/semver/greater_than.ts
@@ -7,25 +7,25 @@ import { compare } from "./compare.ts";
 /**
  * Greater than comparison for two SemVers.
  *
- * This is equal to `compare(s0, s1) > 0`.
+ * This is equal to `compare(version1, version2) > 0`.
  *
  * @example Usage
  * ```ts
  * import { parse, greaterThan } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const s0 = parse("1.2.3");
- * const s1 = parse("1.2.4");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.4");
  *
- * assert(greaterThan(s1, s0));
- * assert(!greaterThan(s0, s1));
- * assert(!greaterThan(s0, s0));
+ * assert(greaterThan(version2, version1));
+ * assert(!greaterThan(version1, version2));
+ * assert(!greaterThan(version1, version1));
  * ```
  *
- * @param s0 The first version to compare
- * @param s1 The second version to compare
- * @returns `true` if `s0` is greater than `s1`, `false` otherwise
+ * @param version1 The first version to compare
+ * @param version2 The second version to compare
+ * @returns `true` if `version1` is greater than `version2`, `false` otherwise
  */
-export function greaterThan(s0: SemVer, s1: SemVer): boolean {
-  return compare(s0, s1) > 0;
+export function greaterThan(version1: SemVer, version2: SemVer): boolean {
+  return compare(version1, version2) > 0;
 }

--- a/semver/greater_than_range.ts
+++ b/semver/greater_than_range.ts
@@ -14,41 +14,41 @@ import { compare } from "./compare.ts";
  * import { parse, parseRange, greaterThanRange } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const v0 = parse("1.2.3");
- * const v1 = parse("1.2.4");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.4");
  * const range = parseRange(">=1.2.3 <1.2.4");
  *
- * assert(!greaterThanRange(v0, range));
- * assert(greaterThanRange(v1, range));
+ * assert(!greaterThanRange(version1, range));
+ * assert(greaterThanRange(version2, range));
  * ```
  *
- * @param semver The version to check.
+ * @param version The version to check.
  * @param range The range to check against.
  * @returns `true` if the semver is greater than the range, `false` otherwise.
  */
-export function greaterThanRange(semver: SemVer, range: Range): boolean {
+export function greaterThanRange(version: SemVer, range: Range): boolean {
   return range.every((comparatorSet) =>
-    greaterThanComparatorSet(semver, comparatorSet)
+    greaterThanComparatorSet(version, comparatorSet)
   );
 }
 
 function greaterThanComparatorSet(
-  semver: SemVer,
+  version: SemVer,
   comparatorSet: Comparator[],
 ): boolean {
   // If the comparator set contains wildcard, then the semver is not greater than the range.
   if (comparatorSet.some(isWildcardComparator)) return false;
   // If the semver satisfies the comparator set, then it's not greater than the range.
-  if (testComparatorSet(semver, comparatorSet)) return false;
+  if (testComparatorSet(version, comparatorSet)) return false;
   // If the semver is less than any of the comparator set, then it's not greater than the range.
   if (
-    comparatorSet.some((comparator) => lessThanComparator(semver, comparator))
+    comparatorSet.some((comparator) => lessThanComparator(version, comparator))
   ) return false;
   return true;
 }
 
-function lessThanComparator(semver: SemVer, comparator: Comparator): boolean {
-  const cmp = compare(semver, comparator);
+function lessThanComparator(version: SemVer, comparator: Comparator): boolean {
+  const cmp = compare(version, comparator);
   switch (comparator.operator) {
     case "=":
     case undefined:

--- a/semver/increment.ts
+++ b/semver/increment.ts
@@ -87,10 +87,10 @@ export interface IncrementOptions {
 export function increment(
   version: SemVer,
   release: ReleaseType,
-  options?: IncrementOptions,
+  options: IncrementOptions = {},
 ): SemVer {
-  const build = options?.build !== undefined
-    ? parseBuild(options?.build)
+  const build = options.build !== undefined
+    ? parseBuild(options.build)
     : version.build;
 
   switch (release) {
@@ -99,7 +99,7 @@ export function increment(
         major: version.major + 1,
         minor: 0,
         patch: 0,
-        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options.prerelease),
         build,
       };
     case "preminor":
@@ -107,7 +107,7 @@ export function increment(
         major: version.major,
         minor: version.minor + 1,
         patch: 0,
-        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options.prerelease),
         build,
       };
     case "prepatch":
@@ -115,7 +115,7 @@ export function increment(
         major: version.major,
         minor: version.minor,
         patch: version.patch + 1,
-        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options.prerelease),
         build,
       };
     case "prerelease": {
@@ -126,7 +126,7 @@ export function increment(
         major: version.major,
         minor: version.minor,
         patch,
-        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options.prerelease),
         build,
       };
     }
@@ -186,7 +186,7 @@ export function increment(
         major: version.major,
         minor: version.minor,
         patch: version.patch,
-        prerelease: bumpPrerelease(version.prerelease, options?.prerelease),
+        prerelease: bumpPrerelease(version.prerelease, options.prerelease),
         build,
       };
     }

--- a/semver/less_or_equal.ts
+++ b/semver/less_or_equal.ts
@@ -6,25 +6,25 @@ import { compare } from "./compare.ts";
 /**
  * Less than or equal to comparison for two SemVers.
  *
- * This is equal to `compare(s0, s1) <= 0`.
+ * This is equal to `compare(version1, version2) <= 0`.
  *
  * @example Usage
  * ```ts
  * import { parse, lessOrEqual } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const s0 = parse("1.2.3");
- * const s1 = parse("1.2.4");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.4");
  *
- * assert(lessOrEqual(s0, s1));
- * assert(!lessOrEqual(s1, s0));
- * assert(lessOrEqual(s0, s0));
+ * assert(lessOrEqual(version1, version2));
+ * assert(!lessOrEqual(version2, version1));
+ * assert(lessOrEqual(version1, version1));
  * ```
  *
- * @param s0 the first version to compare
- * @param s1 the second version to compare
- * @returns `true` if `s0` is less than or equal to `s1`, `false` otherwise
+ * @param version1 the first version to compare
+ * @param version2 the second version to compare
+ * @returns `true` if `version1` is less than or equal to `version2`, `false` otherwise
  */
-export function lessOrEqual(s0: SemVer, s1: SemVer): boolean {
-  return compare(s0, s1) <= 0;
+export function lessOrEqual(version1: SemVer, version2: SemVer): boolean {
+  return compare(version1, version2) <= 0;
 }

--- a/semver/less_than.ts
+++ b/semver/less_than.ts
@@ -6,25 +6,25 @@ import { compare } from "./compare.ts";
 /**
  * Less than comparison for two SemVers.
  *
- * This is equal to `compare(s0, s1) < 0`.
+ * This is equal to `compare(version1, version2) < 0`.
  *
  * @example Usage
  * ```ts
  * import { parse, lessThan } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const s0 = parse("1.2.3");
- * const s1 = parse("1.2.4");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.4");
  *
- * assert(lessThan(s0, s1));
- * assert(!lessThan(s1, s0));
- * assert(!lessThan(s0, s0));
+ * assert(lessThan(version1, version2));
+ * assert(!lessThan(version2, version1));
+ * assert(!lessThan(version1, version1));
  * ```
  *
- * @param s0 the first version to compare
- * @param s1 the second version to compare
- * @returns `true` if `s0` is less than `s1`, `false` otherwise
+ * @param version1 the first version to compare
+ * @param version2 the second version to compare
+ * @returns `true` if `version1` is less than `version2`, `false` otherwise
  */
-export function lessThan(s0: SemVer, s1: SemVer): boolean {
-  return compare(s0, s1) < 0;
+export function lessThan(version1: SemVer, version2: SemVer): boolean {
+  return compare(version1, version2) < 0;
 }

--- a/semver/less_than_range.ts
+++ b/semver/less_than_range.ts
@@ -14,43 +14,43 @@ import { compare } from "./compare.ts";
  * import { parse, parseRange, lessThanRange } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const v0 = parse("1.2.3");
- * const v1 = parse("1.0.0");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.0.0");
  * const range = parseRange(">=1.2.3 <1.2.4");
  *
- * assert(!lessThanRange(v0, range));
- * assert(lessThanRange(v1, range));
+ * assert(!lessThanRange(version1, range));
+ * assert(lessThanRange(version2, range));
  * ```
  *
- * @param semver The version to check.
+ * @param version The version to check.
  * @param range The range to check against.
  * @returns `true` if the SemVer is less than the range, `false` otherwise.
  */
-export function lessThanRange(semver: SemVer, range: Range): boolean {
+export function lessThanRange(version: SemVer, range: Range): boolean {
   return range.every((comparatorSet) =>
-    lessThanComparatorSet(semver, comparatorSet)
+    lessThanComparatorSet(version, comparatorSet)
   );
 }
 
-function lessThanComparatorSet(semver: SemVer, comparatorSet: Comparator[]) {
+function lessThanComparatorSet(version: SemVer, comparatorSet: Comparator[]) {
   // If the comparator set contains wildcard, then the semver is not greater than the range.
   if (comparatorSet.some(isWildcardComparator)) return false;
   // If the SemVer satisfies the comparator set, then it's not less than the range.
-  if (testComparatorSet(semver, comparatorSet)) return false;
+  if (testComparatorSet(version, comparatorSet)) return false;
   // If the SemVer is greater than any of the comparator set, then it's not less than the range.
   if (
     comparatorSet.some((comparator) =>
-      greaterThanComparator(semver, comparator)
+      greaterThanComparator(version, comparator)
     )
   ) return false;
   return true;
 }
 
 function greaterThanComparator(
-  semver: SemVer,
+  version: SemVer,
   comparator: Comparator,
 ): boolean {
-  const cmp = compare(semver, comparator);
+  const cmp = compare(version, comparator);
   switch (comparator.operator) {
     case "=":
     case undefined:

--- a/semver/not_equals.ts
+++ b/semver/not_equals.ts
@@ -6,24 +6,24 @@ import { compare } from "./compare.ts";
 /**
  * Not equal comparison for two SemVers.
  *
- * This is equal to `compare(s0, s1) !== 0`.
+ * This is equal to `compare(version1, version2) !== 0`.
  *
  * @example Usage
  * ```ts
  * import { parse, notEquals } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const s0 = parse("1.2.3");
- * const s1 = parse("1.2.4");
+ * const version1 = parse("1.2.3");
+ * const version2 = parse("1.2.4");
  *
- * assert(notEquals(s0, s1));
- * assert(!notEquals(s0, s0));
+ * assert(notEquals(version1, version2));
+ * assert(!notEquals(version1, version1));
  * ```
  *
- * @param s0 The first version to compare
- * @param s1 The second version to compare
- * @returns `true` if `s0` is not equal to `s1`, `false` otherwise
+ * @param version1 The first version to compare
+ * @param version2 The second version to compare
+ * @returns `true` if `version1` is not equal to `version2`, `false` otherwise
  */
-export function notEquals(s0: SemVer, s1: SemVer): boolean {
-  return compare(s0, s1) !== 0;
+export function notEquals(version1: SemVer, version2: SemVer): boolean {
+  return compare(version1, version2) !== 0;
 }

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -23,26 +23,26 @@ import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
  * ```
  *
  * @throws {TypeError} If the input string is invalid.
- * @param version The version string to parse
+ * @param value The version string to parse
  * @returns A valid SemVer
  */
-export function parse(version: string): SemVer {
-  if (typeof version !== "string") {
+export function parse(value: string): SemVer {
+  if (typeof value !== "string") {
     throw new TypeError(
       `version must be a string`,
     );
   }
 
-  if (version.length > MAX_LENGTH) {
+  if (value.length > MAX_LENGTH) {
     throw new TypeError(
       `version is longer than ${MAX_LENGTH} characters`,
     );
   }
 
-  version = version.trim();
+  value = value.trim();
 
-  const groups = version.match(FULL_REGEXP)?.groups;
-  if (!groups) throw new TypeError(`Invalid version: ${version}`);
+  const groups = value.match(FULL_REGEXP)?.groups;
+  if (!groups) throw new TypeError(`Invalid version: ${value}`);
 
   const major = parseNumber(groups.major!, "Invalid major version");
   const minor = parseNumber(groups.minor!, "Invalid minor version");
@@ -53,11 +53,5 @@ export function parse(version: string): SemVer {
     : [];
   const build = groups.buildmetadata ? parseBuild(groups.buildmetadata) : [];
 
-  return {
-    major,
-    minor,
-    patch,
-    prerelease,
-    build,
-  };
+  return { major, minor, patch, prerelease, build };
 }

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -403,14 +403,14 @@ function parseOperatorRanges(string: string): (Comparator | null)[] {
  * @param range The range set string
  * @returns A valid SemVer range
  */
-export function parseRange(range: string): Range {
-  const result = range
+export function parseRange(value: string): Range {
+  const result = value
     // remove spaces between operators and versions
     .replaceAll(/(?<=<|>|=|~|\^)(\s+)/g, "")
     .split(/\s*\|\|\s*/)
     .map((string) => parseHyphenRange(string) || parseOperatorRanges(string));
   if (result.some((r) => r.includes(null))) {
-    throw new TypeError(`Invalid range: ${range}`);
+    throw new TypeError(`Invalid range: ${value}`);
   }
   return result as Range;
 }

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -400,7 +400,7 @@ function parseOperatorRanges(string: string): (Comparator | null)[] {
  * ```
  *
  * @throws {TypeError} If the input range is invalid.
- * @param range The range set string
+ * @param value The range set string
  * @returns A valid SemVer range
  */
 export function parseRange(value: string): Range {

--- a/semver/range_intersects.ts
+++ b/semver/range_intersects.ts
@@ -6,23 +6,23 @@ import { satisfies } from "./satisfies.ts";
 import type { Comparator, Range } from "./types.ts";
 
 function comparatorIntersects(
-  c0: Comparator,
-  c1: Comparator,
+  comparator1: Comparator,
+  comparator2: Comparator,
 ): boolean {
-  const op0 = c0.operator;
-  const op1 = c1.operator;
+  const op0 = comparator1.operator;
+  const op1 = comparator2.operator;
 
   if (op0 === undefined) {
-    // if c0 is empty comparator, then returns true
-    if (isWildcardComparator(c0)) return true;
-    return satisfies(c0, [[c1]]);
+    // if comparator1 is empty comparator, then returns true
+    if (isWildcardComparator(comparator1)) return true;
+    return satisfies(comparator1, [[comparator2]]);
   }
   if (op1 === undefined) {
-    if (isWildcardComparator(c1)) return true;
-    return satisfies(c1, [[c0]]);
+    if (isWildcardComparator(comparator2)) return true;
+    return satisfies(comparator2, [[comparator1]]);
   }
 
-  const cmp = compare(c0, c1);
+  const cmp = compare(comparator1, comparator2);
 
   const sameDirectionIncreasing = (op0 === ">=" || op0 === ">") &&
     (op1 === ">=" || op1 === ">");
@@ -55,9 +55,9 @@ function rangesSatisfiable(ranges: Range[]): boolean {
 function comparatorsSatisfiable(comparators: Comparator[]): boolean {
   // Comparators are satisfiable if they all intersect with each other
   for (let i = 0; i < comparators.length - 1; i++) {
-    const c0 = comparators[i]!;
-    for (const c1 of comparators.slice(i + 1)) {
-      if (!comparatorIntersects(c0, c1)) {
+    const comparator1 = comparators[i]!;
+    for (const comparator2 of comparators.slice(i + 1)) {
+      if (!comparatorIntersects(comparator1, comparator2)) {
         return false;
       }
     }
@@ -74,28 +74,27 @@ function comparatorsSatisfiable(comparators: Comparator[]): boolean {
  * import { parseRange, rangeIntersects } from "@std/semver";
  * import { assert } from "@std/assert";
  *
- * const r0 = parseRange(">=1.0.0 <2.0.0");
- * const r1 = parseRange(">=1.0.0 <1.2.3");
- * const r2 = parseRange(">=1.2.3 <2.0.0");
+ * const range1 = parseRange(">=1.0.0 <2.0.0");
+ * const range2 = parseRange(">=1.0.0 <1.2.3");
+ * const range3 = parseRange(">=1.2.3 <2.0.0");
  *
- * assert(rangeIntersects(r0, r1));
- * assert(rangeIntersects(r0, r2));
- * assert(!rangeIntersects(r1, r2));
+ * assert(rangeIntersects(range1, range2));
+ * assert(rangeIntersects(range1, range3));
+ * assert(!rangeIntersects(range2, range3));
  * ```
  *
- * @param r0 range 0
- * @param r1 range 1
+ * @param range1 range 0
+ * @param range2 range 1
  * @returns returns true if the given ranges intersect, false otherwise
  */
-export function rangeIntersects(
-  r0: Range,
-  r1: Range,
-): boolean {
-  return rangesSatisfiable([r0, r1]) &&
-    r0.some((r00) => {
-      return r1.some((r11) => {
-        return r00.every((c0) => {
-          return r11.every((c1) => comparatorIntersects(c0, c1));
+export function rangeIntersects(range1: Range, range2: Range): boolean {
+  return rangesSatisfiable([range1, range2]) &&
+    range1.some((range10) => {
+      return range2.some((r11) => {
+        return range10.every((comparator1) => {
+          return r11.every((comparator2) =>
+            comparatorIntersects(comparator1, comparator2)
+          );
         });
       });
     });

--- a/semver/satisfies.ts
+++ b/semver/satisfies.ts
@@ -24,9 +24,6 @@ import { testComparatorSet } from "./_test_comparator_set.ts";
  * @param range The range to check
  * @returns true if the version is in the range
  */
-export function satisfies(
-  version: SemVer,
-  range: Range,
-): boolean {
+export function satisfies(version: SemVer, range: Range): boolean {
   return range.some((set) => testComparatorSet(version, set));
 }

--- a/semver/try_parse.ts
+++ b/semver/try_parse.ts
@@ -18,12 +18,12 @@ import { parse } from "./parse.ts";
  * assertEquals(tryParse(" invalid "), undefined);
  * ```
  *
- * @param version The version string to parse
+ * @param value The version string to parse
  * @returns A valid SemVer or `undefined`
  */
-export function tryParse(version: string): SemVer | undefined {
+export function tryParse(value: string): SemVer | undefined {
   try {
-    return parse(version);
+    return parse(value);
   } catch {
     return undefined;
   }

--- a/semver/try_parse_range.ts
+++ b/semver/try_parse_range.ts
@@ -21,16 +21,14 @@ import { parseRange } from "./parse_range.ts";
  * ]);
  * ```
  *
- * @param range The range string
+ * @param value The range string
  * @returns A Range object if valid otherwise `undefined`
  */
-export function tryParseRange(
-  range: string,
-): Range | undefined {
+export function tryParseRange(value: string): Range | undefined {
   try {
     // Return '*' instead of '' so that truthiness works.
     // This will throw if it's invalid anyway
-    return parseRange(range);
+    return parseRange(value);
   } catch {
     return undefined;
   }


### PR DESCRIPTION
**Changes**
This PR unifies names of public functions.
- `value` if the `argument` is a string to be parsed
- `version` if the argument is a `SemVer`
- `versionN...` if multiple arguments are `SemVer`s
- `Range` if the argument is a `Range`

**Reasoning**
The docs are automatically created and use the jsdoc param names.
It makes the docs more esthetically pleasing and easier to understand.