### PR TITLE
docs(assert): Add additional example in assertObjectMatch docs

### DIFF
--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -12,6 +12,8 @@ import { assertEquals } from "./equals.ts";
  *
  * assertObjectMatch({ foo: "bar" }, { foo: "bar" }); // Doesn't throw
  * assertObjectMatch({ foo: "bar" }, { foo: "baz" }); // Throws
+ * assertObjectMatch({ foo: 1, bar: 2 }, { foo: 1 }); // Doesn't throw
+ * assertObjectMatch({ foo: 1 }, { foo: 1, bar: 2 }); // Throws
  * ```
  *
  * @example Usage with nested objects


### PR DESCRIPTION
As title describes, add an example in usage of `assertObjectMatch` to show that the `expected` object can be a subset of the `actual` object but the inverse will result in an assertion failure.

Discussed in #5682