### PR TITLE
fix(streams/unstable): fix type error in `to_lines.ts`

### DIFF
--- a/streams/to_lines.ts
+++ b/streams/to_lines.ts
@@ -33,7 +33,7 @@ import { TextLineStream } from "./text_line_stream.ts";
  */
 export function toLines(
   readable: ReadableStream<Uint8Array>,
-  options?: StreamPipeOptions,
+  options?: PipeOptions,
 ): ReadableStream<string> {
   return readable
     .pipeThrough(new TextDecoderStream())


### PR DESCRIPTION
This PR changes the type of the `options` argument of `toLines()` from `StreamPipeOptions` to `PipeOptions` to resolve type error.