### PR TITLE
chore: fix formatting of markdown file

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,7 +4,6 @@ about: Suggest an idea for this project
 title: ''
 labels: ''
 assignees: ''
-
 ---
 
 **Is your feature request related to a problem? Please describe.**


### PR DESCRIPTION
This change has been made by `deno fmt` canary. We need to land this to make the main CI green.