### PR TITLE
chore(async): add browser-compat declarations

### DIFF
--- a/async/deadline.ts
+++ b/async/deadline.ts
@@ -1,9 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-// TODO(iuioiua): Add web-compatible declaration once TypeScript 5.5 is released
-// and in the Deno runtime. See https://github.com/microsoft/TypeScript/pull/58211
-//
-// Note: this code is still compatible with recent
-// web browsers. See https://caniuse.com/?search=AbortSignal.any
+// This module is browser compatible.
+
 import { abortable } from "./abortable.ts";
 
 /** Options for {@linkcode deadline}. */

--- a/async/mod.ts
+++ b/async/mod.ts
@@ -1,9 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-// TODO(iuioiua): Add web-compatible declaration once TypeScript 5.5 is released
-// and in the Deno runtime. See https://github.com/microsoft/TypeScript/pull/58211
-//
-// Note: this code is still compatible with recent
-// web browsers. See https://caniuse.com/?search=AbortSignal.any
+// This module is browser compatible.
 
 /**
  * Provide helpers with asynchronous tasks like {@linkcode delay | delays},


### PR DESCRIPTION
The latest stable Deno (1.45) uses TypeScript 5.5.