### PR TITLE
refactor(log): make `BaseHandler` abstract

### DIFF
--- a/log/base_handler.ts
+++ b/log/base_handler.ts
@@ -16,7 +16,7 @@ export interface BaseHandlerOptions {
   formatter?: FormatterFunction;
 }
 
-export class BaseHandler {
+export abstract class BaseHandler {
   #levelName: LevelName;
   #level: LogLevel;
   formatter: FormatterFunction;
@@ -59,7 +59,7 @@ export class BaseHandler {
     return this.formatter(logRecord);
   }
 
-  log(_msg: string) {}
+  abstract log(msg: string): void;
   setup() {}
   destroy() {}
 

--- a/log/console_handler.ts
+++ b/log/console_handler.ts
@@ -52,7 +52,7 @@ export class ConsoleHandler extends BaseHandler {
     return msg;
   }
 
-  override log(msg: string) {
+  log(msg: string) {
     console.log(msg);
   }
 }

--- a/log/file_handler.ts
+++ b/log/file_handler.ts
@@ -90,7 +90,7 @@ export class FileHandler extends BaseHandler {
     }
   }
 
-  override log(msg: string) {
+  log(msg: string) {
     const bytes = this[encoderSymbol].encode(msg + "\n");
     if (bytes.byteLength > this[bufSymbol].byteLength - this[pointerSymbol]) {
       this.flush();


### PR DESCRIPTION
Ref: https://github.com/denoland/std/pull/5702
**Changes**
This PR makes the `BaseHandler` and `log()` method abstract.
It removes the obsolete `override` for `log()` in `FileHandler` and `ConsoleHandler`.