### PR TITLE
fix(dotenv): show warning when there is invalid key in `.env` file

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -4,6 +4,8 @@
  * Parses and loads environment variables from a `.env` file into the current
  * process, or stringify data into a `.env` file format.
  *
+ * Note: The key needs to match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/.
+ *
  * ```ts no-eval
  * // Automatically load environment variables from a `.env` file
  * import "@std/dotenv/load";
@@ -83,6 +85,8 @@ export function loadSync(
  *
  * Inspired by the node modules {@linkcode https://github.com/motdotla/dotenv | dotenv}
  * and {@linkcode https://github.com/motdotla/dotenv-expand | dotenv-expand}.
+ *
+ * Note: The key needs to match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/.
  *
  * ## Basic usage
  * ```sh

--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -10,7 +10,9 @@ type LineParseResult = {
 type CharactersMap = { [key: string]: string };
 
 const RE_KEY_VALUE =
-  /^\s*(?:export\s+)?(?<key>[a-zA-Z_]+[a-zA-Z0-9_]*?)\s*=[\ \t]*('\n?(?<notInterpolated>(.|\n)*?)\n?'|"\n?(?<interpolated>(.|\n)*?)\n?"|(?<unquoted>[^\n#]*)) *#*.*$/gm;
+  /^\s*(?:export\s+)?(?<key>[^\s=#]+?)\s*=[\ \t]*('\n?(?<notInterpolated>(.|\n)*?)\n?'|"\n?(?<interpolated>(.|\n)*?)\n?"|(?<unquoted>[^\n#]*)) *#*.*$/gm;
+
+const RE_VALID_KEY = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 
 const RE_EXPAND_VALUE =
   /(\${(?<inBrackets>.+?)(\:-(?<inBracketsDefault>.+))?}|(?<!\\)\$(?<notInBrackets>\w+)(\:-(?<notInBracketsDefault>.+))?)/g;
@@ -78,6 +80,13 @@ export function parse(text: string): Record<string, string> {
   while ((match = RE_KEY_VALUE.exec(text)) !== null) {
     const { key, interpolated, notInterpolated, unquoted } = match
       ?.groups as LineParseResult;
+
+    if (!RE_VALID_KEY.test(key)) {
+      console.warn(
+        `Ignored the key "${key}" as it is not a valid identifier: The key need to match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/.`,
+      );
+      continue;
+    }
 
     if (unquoted) {
       keysForExpandCheck.push(key);

--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -59,6 +59,8 @@ function expand(str: string, variablesMap: { [key: string]: string }): string {
 /**
  * Parse `.env` file output in an object.
  *
+ * Note: The key needs to match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/.
+ *
  * @example Usage
  * ```ts
  * import { parse } from "@std/dotenv/parse";

--- a/dotenv/parse_test.ts
+++ b/dotenv/parse_test.ts
@@ -3,11 +3,14 @@
 import { assertEquals } from "@std/assert";
 import { parse } from "./parse.ts";
 import * as path from "@std/path";
+import { assertSpyCall, spy } from "@std/testing/mock";
 
 const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("parse()", () => {
+  using consoleWarnSpy = spy(console, "warn");
+
   const testDotenv = Deno.readTextFileSync(
     path.join(testdataDir, "./.env.test"),
   );
@@ -140,6 +143,12 @@ Deno.test("parse()", () => {
     "export is ignored",
     "export at the start of the key is ignored",
   );
+
+  assertSpyCall(consoleWarnSpy, 0, {
+    args: [
+      'Ignored the key "1INVALID" as it is not a valid identifier: The key need to match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/.',
+    ],
+  });
 });
 
 Deno.test("parse() ignores comments", () => {


### PR DESCRIPTION
Currently `parse` of `dotenv` silently ignores the invalid key entries in `.env` file. This PR adds the warning like `Ignored the key "1INVALID" as it is not a valid identifier: The key need to match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/.` when `.env` file has invalid key entry.

closes #5619