### PR TITLE
feat(path/unstable): support `URL` input in `dirname()`

### DIFF
--- a/path/dirname.ts
+++ b/path/dirname.ts
@@ -23,6 +23,29 @@ import { dirname as windowsDirname } from "./windows/dirname.ts";
  * @param path Path to extract the directory from.
  * @returns The directory path.
  */
-export function dirname(path: string): string {
-  return isWindows ? windowsDirname(path) : posixDirname(path);
+export function dirname(path: string): string;
+/**
+ * Return the directory path of a file URL.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { dirname } from "@std/path/dirname";
+ * import { assertEquals } from "@std/assert";
+ *
+ * if (Deno.build.os === "windows") {
+ *   assertEquals(dirname(new URL("file:///C:/home/user/Documents/image.png")), "C:\\home\\user\\Documents");
+ * } else {
+ *   assertEquals(dirname(new URL("file:///home/user/Documents/image.png")), "/home/user/Documents");
+ * }
+ * ```
+ *
+ * @param path Path to extract the directory from.
+ * @returns The directory path.
+ */
+export function dirname(path: URL): string;
+export function dirname(path: string | URL): string {
+  // deno-lint-ignore no-explicit-any
+  return isWindows ? windowsDirname(path as any) : posixDirname(path as any);
 }

--- a/path/dirname_test.ts
+++ b/path/dirname_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // Copyright the Browserify authors. MIT License.
 // Ported from https://github.com/browserify/path-browserify/
-import { assertEquals } from "@std/assert";
+import { assertEquals, assertThrows } from "@std/assert";
 import { dirname } from "./dirname.ts";
 import * as posix from "./posix/mod.ts";
 import * as windows from "./windows/mod.ts";
@@ -87,6 +87,16 @@ Deno.test("posix.dirname()", function () {
   assertEquals(posix.dirname("/foo/bar/baz\\"), "/foo/bar");
 });
 
+Deno.test("posix.dirname() works with file URLs", () => {
+  assertEquals(
+    posix.dirname(new URL("file:///home/user/Documents/image.png")),
+    "/home/user/Documents",
+  );
+
+  // throws with non-file URLs
+  assertThrows(() => posix.dirname(new URL("https://deno.land/")));
+});
+
 Deno.test("windows.dirname()", function () {
   for (const [name, expected] of WINDOWS_TESTSUITE) {
     assertEquals(windows.dirname(name), expected);
@@ -100,4 +110,14 @@ Deno.test("windows.dirname()", function () {
   for (const [name, expected] of POSIX_TESTSUITE) {
     assertEquals(windows.dirname(name), expected);
   }
+});
+
+Deno.test("windows.dirname() works with file URLs", () => {
+  assertEquals(
+    windows.dirname(new URL("file:///C:/home/user/Documents/image.png")),
+    "C:\\home\\user\\Documents",
+  );
+
+  // throws with non-file URLs
+  assertThrows(() => windows.dirname(new URL("https://deno.land/")));
 });

--- a/path/dirname_test.ts
+++ b/path/dirname_test.ts
@@ -94,7 +94,11 @@ Deno.test("posix.dirname() works with file URLs", () => {
   );
 
   // throws with non-file URLs
-  assertThrows(() => posix.dirname(new URL("https://deno.land/")));
+  assertThrows(
+    () => posix.dirname(new URL("https://deno.land/")),
+    TypeError,
+    "Must be a file URL.",
+  );
 });
 
 Deno.test("windows.dirname()", function () {
@@ -119,5 +123,9 @@ Deno.test("windows.dirname() works with file URLs", () => {
   );
 
   // throws with non-file URLs
-  assertThrows(() => windows.dirname(new URL("https://deno.land/")));
+  assertThrows(
+    () => windows.dirname(new URL("https://deno.land/")),
+    TypeError,
+    "Must be a file URL.",
+  );
 });

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -44,7 +44,6 @@ export function dirname(path: string): string;
  * import { dirname } from "@std/path/posix/dirname";
  * import { assertEquals } from "@std/assert";
  *
- * assertEquals(dirname(new URL(import.meta.url)), import.meta.dirname);
  * assertEquals(dirname(new URL("file:///home/user/Documents/image.png")), "/home/user/Documents");
  * ```
  *

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -4,6 +4,7 @@
 import { assertArg } from "../_common/dirname.ts";
 import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
 import { isPosixPathSeparator } from "./_util.ts";
+import { fromFileUrl } from "./from_file_url.ts";
 
 /**
  * Return the directory path of a `path`.
@@ -32,7 +33,29 @@ import { isPosixPathSeparator } from "./_util.ts";
  * @param path The path to get the directory from.
  * @returns The directory path.
  */
-export function dirname(path: string): string {
+export function dirname(path: string): string;
+/**
+ * Return the directory path of a file URL.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { dirname } from "@std/path/posix/dirname";
+ * import { assertEquals } from "@std/assert";
+ *
+ * assertEquals(dirname(new URL(import.meta.url)), import.meta.dirname);
+ * assertEquals(dirname(new URL("file:///home/user/Documents/image.png")), "/home/user/Documents");
+ * ```
+ *
+ * @param path The file url to get the directory from.
+ * @returns The directory path.
+ */
+export function dirname(path: URL): string;
+export function dirname(path: string | URL): string {
+  if (path instanceof URL) {
+    path = fromFileUrl(path);
+  }
   assertArg(path);
 
   let end = -1;

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -9,6 +9,7 @@ import {
   isPosixPathSeparator,
   isWindowsDeviceRoot,
 } from "./_util.ts";
+import { fromFileUrl } from "./from_file_url.ts";
 
 /**
  * Return the directory path of a `path`.
@@ -25,7 +26,29 @@ import {
  * @param path The path to get the directory from.
  * @returns The directory path.
  */
-export function dirname(path: string): string {
+export function dirname(path: string): string;
+/**
+ * Return the directory path of a file URL.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { dirname } from "@std/path/windows/dirname";
+ * import { assertEquals } from "@std/assert";
+ *
+ * assertEquals(dirname(new URL(import.meta.url)), import.meta.dirname);
+ * assertEquals(dirname(new URL("file:///C:/foo/bar/baz.ext")), "C:\\foo\\bar");
+ * ```
+ *
+ * @param path The path to get the directory from.
+ * @returns The directory path.
+ */
+export function dirname(path: URL): string;
+export function dirname(path: string | URL): string {
+  if (path instanceof URL) {
+    path = fromFileUrl(path);
+  }
   assertArg(path);
 
   const len = path.length;

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -37,7 +37,6 @@ export function dirname(path: string): string;
  * import { dirname } from "@std/path/windows/dirname";
  * import { assertEquals } from "@std/assert";
  *
- * assertEquals(dirname(new URL(import.meta.url)), import.meta.dirname);
  * assertEquals(dirname(new URL("file:///C:/foo/bar/baz.ext")), "C:\\foo\\bar");
  * ```
  *


### PR DESCRIPTION
part of #5537

This PR adds `dirname(url: URL): string` overload to dirname function.

If a user have a file URL string or object, currently they need to convert it to a path string first to perform path operation on it:

```ts
import { dirname, fromFileUrl } from "@std/path";

dirname(fromFileUrl(new URL(import.meta.url)));
```

This change makes it simpler by automatically interpret the file URL as path

```ts
import { dirname } from "@std/path";

dirname(new URL(import.meta.url));
```