### PR TITLE
feat(front-matter/unstable): add pass-through `ParseOptions` argument for YAML parser

### DIFF
--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { extractAndParse, type Parser } from "./_shared.ts";
-import { parse, ParseOptions } from "@std/yaml/parse";
+import { parse, type ParseOptions } from "@std/yaml/parse";
 import type { Extract } from "./types.ts";
 import { EXTRACT_YAML_REGEXP } from "./_formats.ts";
 

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -31,9 +31,39 @@ export type { Extract };
  *
  * @typeParam T The type of the parsed front matter.
  * @param text The text to extract YAML front matter from.
+ * @returns The extracted YAML front matter and body content.
+ */
+export function extract<T>(text: string): Extract<T>;
+/**
+ * Extracts and parses {@link https://yaml.org | YAML} from the metadata of
+ * front matter content.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Extract YAML front matter
+ * ```ts
+ * import { extract } from "@std/front-matter/yaml";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const output = `---yaml
+ * date: 2022-01-01
+ * ---
+ * Hello, world!`;
+ * const result = extract(output, { schema: "json" });
+ *
+ * assertEquals(result, {
+ *   frontMatter: "date: 2022-01-01",
+ *   body: "Hello, world!",
+ *   attrs: { date: "2022-01-01" },
+ * });
+ * ```
+ *
+ * @typeParam T The type of the parsed front matter.
+ * @param text The text to extract YAML front matter from.
  * @param options The options to pass to `@std/yaml/parse`.
  * @returns The extracted YAML front matter and body content.
  */
+export function extract<T>(text: string, options?: ParseOptions): Extract<T>;
 export function extract<T>(text: string, options?: ParseOptions): Extract<T> {
   return extractAndParse(
     text,

--- a/front_matter/yaml.ts
+++ b/front_matter/yaml.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { extractAndParse, type Parser } from "./_shared.ts";
-import { parse } from "@std/yaml/parse";
+import { parse, ParseOptions } from "@std/yaml/parse";
 import type { Extract } from "./types.ts";
 import { EXTRACT_YAML_REGEXP } from "./_formats.ts";
 
@@ -31,8 +31,13 @@ export type { Extract };
  *
  * @typeParam T The type of the parsed front matter.
  * @param text The text to extract YAML front matter from.
+ * @param options The options to pass to `@std/yaml/parse`.
  * @returns The extracted YAML front matter and body content.
  */
-export function extract<T>(text: string): Extract<T> {
-  return extractAndParse(text, EXTRACT_YAML_REGEXP, parse as Parser);
+export function extract<T>(text: string, options?: ParseOptions): Extract<T> {
+  return extractAndParse(
+    text,
+    EXTRACT_YAML_REGEXP,
+    ((s) => parse(s, options)) as Parser,
+  );
 }

--- a/front_matter/yaml_test.ts
+++ b/front_matter/yaml_test.ts
@@ -36,3 +36,12 @@ Deno.test("extractYaml() allows whitespaces after the header", () => {
   assertEquals(extract("---yaml  \nfoo: 0\n--- \n").attrs, { foo: 0 });
   assertEquals(extract("= yaml =  \nfoo: 0\n---\n").attrs, { foo: 0 });
 });
+
+Deno.test("extractYaml() parses with schema options", () => {
+  assertEquals(
+    extract("---\ndate: 2024-08-20\n---\n", { schema: "json" }).attrs,
+    {
+      date: "2024-08-20",
+    },
+  );
+});


### PR DESCRIPTION
This adds an `options` argument to `front_matter/yaml/extract` to pass options to the underlying YAML parser, such as schema selection, pursuant to #5677.

Closes #5677