### PR TITLE
refactor(yaml): move state functions into `LoaderState` class

### DIFF
--- a/yaml/_loader_state.ts
+++ b/yaml/_loader_state.ts
@@ -210,6 +210,1369 @@ export class LoaderState {
     this.onWarning?.(error);
   }
 
+  yamlDirectiveHandler(...args: string[]) {
+    if (this.version !== null) {
+      return this.throwError("duplication of %YAML directive");
+    }
+
+    if (args.length !== 1) {
+      return this.throwError("YAML directive accepts exactly one argument");
+    }
+
+    const match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]!);
+    if (match === null) {
+      return this.throwError("ill-formed argument of the YAML directive");
+    }
+
+    const major = parseInt(match[1]!, 10);
+    const minor = parseInt(match[2]!, 10);
+    if (major !== 1) {
+      return this.throwError("unacceptable YAML version of the document");
+    }
+
+    this.version = args[0] ?? null;
+    this.checkLineBreaks = minor < 2;
+    if (minor !== 1 && minor !== 2) {
+      return this.dispatchWarning("unsupported YAML version of the document");
+    }
+  }
+  tagDirectiveHandler(...args: string[]) {
+    if (args.length !== 2) {
+      return this.throwError("TAG directive accepts exactly two arguments");
+    }
+
+    const handle = args[0]!;
+    const prefix = args[1]!;
+
+    if (!PATTERN_TAG_HANDLE.test(handle)) {
+      return this.throwError(
+        "ill-formed tag handle (first argument) of the TAG directive",
+      );
+    }
+
+    if (this.tagMap.has(handle)) {
+      return this.throwError(
+        `there is a previously declared suffix for "${handle}" tag handle`,
+      );
+    }
+
+    if (!PATTERN_TAG_URI.test(prefix)) {
+      return this.throwError(
+        "ill-formed tag prefix (second argument) of the TAG directive",
+      );
+    }
+
+    this.tagMap.set(handle, prefix);
+  }
+
+  captureSegment(
+    start: number,
+    end: number,
+    checkJson: boolean,
+  ) {
+    let result: string;
+    if (start < end) {
+      result = this.input.slice(start, end);
+
+      if (checkJson) {
+        for (
+          let position = 0;
+          position < result.length;
+          position++
+        ) {
+          const character = result.charCodeAt(position);
+          if (
+            !(character === 0x09 ||
+              (0x20 <= character && character <= 0x10ffff))
+          ) {
+            return this.throwError("expected valid JSON character");
+          }
+        }
+      } else if (PATTERN_NON_PRINTABLE.test(result)) {
+        return this.throwError("the stream contains non-printable characters");
+      }
+
+      this.result += result;
+    }
+  }
+
+  mergeMappings(
+    destination: ArrayObject,
+    source: ArrayObject,
+    overridableKeys: Set<string>,
+  ) {
+    if (!isObject(source)) {
+      return this.throwError(
+        "cannot merge mappings; the provided source object is unacceptable",
+      );
+    }
+
+    for (const [key, value] of Object.entries(source)) {
+      if (Object.hasOwn(destination, key)) continue;
+      Object.defineProperty(destination, key, {
+        value,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      overridableKeys.add(key);
+    }
+  }
+
+  storeMappingPair(
+    result: ArrayObject | null,
+    overridableKeys: Set<string>,
+    keyTag: string | null,
+    keyNode: Record<PropertyKey, unknown> | unknown[] | string | null,
+    valueNode: unknown,
+    startLine?: number,
+    startPos?: number,
+  ): ArrayObject {
+    // The output is a plain object here, so keys can only be strings.
+    // We need to convert keyNode to a string, but doing so can hang the process
+    // (deeply nested arrays that explode exponentially using aliases).
+    if (Array.isArray(keyNode)) {
+      keyNode = Array.prototype.slice.call(keyNode);
+
+      for (let index = 0; index < keyNode.length; index++) {
+        if (Array.isArray(keyNode[index])) {
+          return this.throwError(
+            "nested arrays are not supported inside keys",
+          );
+        }
+
+        if (
+          typeof keyNode === "object" &&
+          getObjectTypeString(keyNode[index]) === "[object Object]"
+        ) {
+          keyNode[index] = "[object Object]";
+        }
+      }
+    }
+
+    // Avoid code execution in load() via toString property
+    // (still use its own toString for arrays, timestamps,
+    // and whatever user schema extensions happen to have @@toStringTag)
+    if (
+      typeof keyNode === "object" &&
+      getObjectTypeString(keyNode) === "[object Object]"
+    ) {
+      keyNode = "[object Object]";
+    }
+
+    keyNode = String(keyNode);
+
+    if (result === null) {
+      result = {};
+    }
+
+    if (keyTag === "tag:yaml.org,2002:merge") {
+      if (Array.isArray(valueNode)) {
+        for (
+          let index = 0;
+          index < valueNode.length;
+          index++
+        ) {
+          this.mergeMappings(result, valueNode[index], overridableKeys);
+        }
+      } else {
+        this.mergeMappings(
+          result,
+          valueNode as ArrayObject,
+          overridableKeys,
+        );
+      }
+    } else {
+      if (
+        !this.allowDuplicateKeys &&
+        !overridableKeys.has(keyNode) &&
+        Object.hasOwn(result, keyNode)
+      ) {
+        this.line = startLine || this.line;
+        this.position = startPos || this.position;
+        return this.throwError("duplicated mapping key");
+      }
+      Object.defineProperty(result, keyNode, {
+        value: valueNode,
+        writable: true,
+        enumerable: true,
+        configurable: true,
+      });
+      overridableKeys.delete(keyNode);
+    }
+
+    return result;
+  }
+
+  readLineBreak() {
+    const ch = this.peek();
+
+    if (ch === LINE_FEED) {
+      this.position++;
+    } else if (ch === CARRIAGE_RETURN) {
+      this.position++;
+      if (this.peek() === LINE_FEED) {
+        this.position++;
+      }
+    } else {
+      return this.throwError("a line break is expected");
+    }
+
+    this.line += 1;
+    this.lineStart = this.position;
+  }
+
+  skipSeparationSpace(
+    allowComments: boolean,
+    checkIndent: number,
+  ): number {
+    let lineBreaks = 0;
+    let ch = this.peek();
+
+    while (ch !== 0) {
+      while (isWhiteSpace(ch)) {
+        ch = this.next();
+      }
+
+      if (allowComments && ch === SHARP) {
+        do {
+          ch = this.next();
+        } while (ch !== LINE_FEED && ch !== CARRIAGE_RETURN && ch !== 0);
+      }
+
+      if (isEOL(ch)) {
+        this.readLineBreak();
+
+        ch = this.peek();
+        lineBreaks++;
+        this.lineIndent = 0;
+
+        this.readIndent();
+        ch = this.peek();
+      } else {
+        break;
+      }
+    }
+
+    if (
+      checkIndent !== -1 &&
+      lineBreaks !== 0 &&
+      this.lineIndent < checkIndent
+    ) {
+      this.dispatchWarning("deficient indentation");
+    }
+
+    return lineBreaks;
+  }
+
+  testDocumentSeparator(): boolean {
+    let ch = this.peek();
+
+    // Condition this.position === this.lineStart is tested
+    // in parent on each call, for efficiency. No needs to test here again.
+    if (
+      (ch === MINUS || ch === DOT) &&
+      ch === this.peek(1) &&
+      ch === this.peek(2)
+    ) {
+      ch = this.peek(3);
+
+      if (ch === 0 || isWhiteSpaceOrEOL(ch)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  writeFoldedLines(count: number) {
+    if (count === 1) {
+      this.result += " ";
+    } else if (count > 1) {
+      this.result += "\n".repeat(count - 1);
+    }
+  }
+
+  readPlainScalar(
+    nodeIndent: number,
+    withinFlowCollection: boolean,
+  ): boolean {
+    const kind = this.kind;
+    const result = this.result;
+    let ch = this.peek();
+
+    if (
+      isWhiteSpaceOrEOL(ch) ||
+      isFlowIndicator(ch) ||
+      ch === SHARP ||
+      ch === AMPERSAND ||
+      ch === ASTERISK ||
+      ch === EXCLAMATION ||
+      ch === VERTICAL_LINE ||
+      ch === GREATER_THAN ||
+      ch === SINGLE_QUOTE ||
+      ch === DOUBLE_QUOTE ||
+      ch === PERCENT ||
+      ch === COMMERCIAL_AT ||
+      ch === GRAVE_ACCENT
+    ) {
+      return false;
+    }
+
+    let following: number;
+    if (ch === QUESTION || ch === MINUS) {
+      following = this.peek(1);
+
+      if (
+        isWhiteSpaceOrEOL(following) ||
+        (withinFlowCollection && isFlowIndicator(following))
+      ) {
+        return false;
+      }
+    }
+
+    this.kind = "scalar";
+    this.result = "";
+    let captureEnd = this.position;
+    let captureStart = this.position;
+    let hasPendingContent = false;
+    let line = 0;
+    while (ch !== 0) {
+      if (ch === COLON) {
+        following = this.peek(1);
+
+        if (
+          isWhiteSpaceOrEOL(following) ||
+          (withinFlowCollection && isFlowIndicator(following))
+        ) {
+          break;
+        }
+      } else if (ch === SHARP) {
+        const preceding = this.peek(-1);
+
+        if (isWhiteSpaceOrEOL(preceding)) {
+          break;
+        }
+      } else if (
+        (this.position === this.lineStart &&
+          this.testDocumentSeparator()) ||
+        (withinFlowCollection && isFlowIndicator(ch))
+      ) {
+        break;
+      } else if (isEOL(ch)) {
+        line = this.line;
+        const lineStart = this.lineStart;
+        const lineIndent = this.lineIndent;
+        this.skipSeparationSpace(false, -1);
+
+        if (this.lineIndent >= nodeIndent) {
+          hasPendingContent = true;
+          ch = this.peek();
+          continue;
+        } else {
+          this.position = captureEnd;
+          this.line = line;
+          this.lineStart = lineStart;
+          this.lineIndent = lineIndent;
+          break;
+        }
+      }
+
+      if (hasPendingContent) {
+        this.captureSegment(captureStart, captureEnd, false);
+        this.writeFoldedLines(this.line - line);
+        captureStart = captureEnd = this.position;
+        hasPendingContent = false;
+      }
+
+      if (!isWhiteSpace(ch)) {
+        captureEnd = this.position + 1;
+      }
+
+      ch = this.next();
+    }
+
+    this.captureSegment(captureStart, captureEnd, false);
+
+    if (this.result) {
+      return true;
+    }
+
+    this.kind = kind;
+    this.result = result;
+    return false;
+  }
+
+  readSingleQuotedScalar(
+    nodeIndent: number,
+  ): boolean {
+    let ch;
+    let captureStart;
+    let captureEnd;
+
+    ch = this.peek();
+
+    if (ch !== SINGLE_QUOTE) {
+      return false;
+    }
+
+    this.kind = "scalar";
+    this.result = "";
+    this.position++;
+    captureStart = captureEnd = this.position;
+
+    while ((ch = this.peek()) !== 0) {
+      if (ch === SINGLE_QUOTE) {
+        this.captureSegment(captureStart, this.position, true);
+        ch = this.next();
+
+        if (ch === SINGLE_QUOTE) {
+          captureStart = this.position;
+          this.position++;
+          captureEnd = this.position;
+        } else {
+          return true;
+        }
+      } else if (isEOL(ch)) {
+        this.captureSegment(captureStart, captureEnd, true);
+        this.writeFoldedLines(
+          this.skipSeparationSpace(false, nodeIndent),
+        );
+        captureStart = captureEnd = this.position;
+      } else if (
+        this.position === this.lineStart &&
+        this.testDocumentSeparator()
+      ) {
+        return this.throwError(
+          "unexpected end of the document within a single quoted scalar",
+        );
+      } else {
+        this.position++;
+        captureEnd = this.position;
+      }
+    }
+
+    return this.throwError(
+      "unexpected end of the stream within a single quoted scalar",
+    );
+  }
+
+  readDoubleQuotedScalar(
+    nodeIndent: number,
+  ): boolean {
+    let ch = this.peek();
+
+    if (ch !== DOUBLE_QUOTE) {
+      return false;
+    }
+
+    this.kind = "scalar";
+    this.result = "";
+    this.position++;
+    let captureEnd = this.position;
+    let captureStart = this.position;
+    let tmp: number;
+    while ((ch = this.peek()) !== 0) {
+      if (ch === DOUBLE_QUOTE) {
+        this.captureSegment(captureStart, this.position, true);
+        this.position++;
+        return true;
+      }
+      if (ch === BACKSLASH) {
+        this.captureSegment(captureStart, this.position, true);
+        ch = this.next();
+
+        if (isEOL(ch)) {
+          this.skipSeparationSpace(false, nodeIndent);
+        } else if (ch < 256 && SIMPLE_ESCAPE_SEQUENCES.has(ch)) {
+          this.result += SIMPLE_ESCAPE_SEQUENCES.get(ch);
+          this.position++;
+        } else if ((tmp = ESCAPED_HEX_LENGTHS.get(ch) ?? 0) > 0) {
+          let hexLength = tmp;
+          let hexResult = 0;
+
+          for (; hexLength > 0; hexLength--) {
+            ch = this.next();
+
+            if ((tmp = hexCharCodeToNumber(ch)) >= 0) {
+              hexResult = (hexResult << 4) + tmp;
+            } else {
+              return this.throwError("expected hexadecimal character");
+            }
+          }
+
+          this.result += codepointToChar(hexResult);
+
+          this.position++;
+        } else {
+          return this.throwError("unknown escape sequence");
+        }
+
+        captureStart = captureEnd = this.position;
+      } else if (isEOL(ch)) {
+        this.captureSegment(captureStart, captureEnd, true);
+        this.writeFoldedLines(
+          this.skipSeparationSpace(false, nodeIndent),
+        );
+        captureStart = captureEnd = this.position;
+      } else if (
+        this.position === this.lineStart &&
+        this.testDocumentSeparator()
+      ) {
+        return this.throwError(
+          "unexpected end of the document within a double quoted scalar",
+        );
+      } else {
+        this.position++;
+        captureEnd = this.position;
+      }
+    }
+
+    return this.throwError(
+      "unexpected end of the stream within a double quoted scalar",
+    );
+  }
+
+  readFlowCollection(nodeIndent: number): boolean {
+    let ch = this.peek();
+    let terminator: number;
+    let isMapping = true;
+    let result: ResultType = {};
+    if (ch === LEFT_SQUARE_BRACKET) {
+      terminator = RIGHT_SQUARE_BRACKET;
+      isMapping = false;
+      result = [];
+    } else if (ch === LEFT_CURLY_BRACKET) {
+      terminator = RIGHT_CURLY_BRACKET;
+    } else {
+      return false;
+    }
+
+    if (this.anchor !== null && typeof this.anchor !== "undefined") {
+      this.anchorMap.set(this.anchor, result);
+    }
+
+    ch = this.next();
+
+    const tag = this.tag;
+    const anchor = this.anchor;
+    let readNext = true;
+    let valueNode = null;
+    let keyNode = null;
+    let keyTag: string | null = null;
+    let isExplicitPair = false;
+    let isPair = false;
+    let following = 0;
+    let line = 0;
+    const overridableKeys = new Set<string>();
+    while (ch !== 0) {
+      this.skipSeparationSpace(true, nodeIndent);
+
+      ch = this.peek();
+
+      if (ch === terminator) {
+        this.position++;
+        this.tag = tag;
+        this.anchor = anchor;
+        this.kind = isMapping ? "mapping" : "sequence";
+        this.result = result;
+        return true;
+      }
+      if (!readNext) {
+        return this.throwError("missed comma between flow collection entries");
+      }
+
+      keyTag = keyNode = valueNode = null;
+      isPair = isExplicitPair = false;
+
+      if (ch === QUESTION) {
+        following = this.peek(1);
+
+        if (isWhiteSpaceOrEOL(following)) {
+          isPair = isExplicitPair = true;
+          this.position++;
+          this.skipSeparationSpace(true, nodeIndent);
+        }
+      }
+
+      line = this.line;
+      this.composeNode(nodeIndent, CONTEXT_FLOW_IN, false, true);
+      keyTag = this.tag || null;
+      keyNode = this.result;
+      this.skipSeparationSpace(true, nodeIndent);
+
+      ch = this.peek();
+
+      if ((isExplicitPair || this.line === line) && ch === COLON) {
+        isPair = true;
+        ch = this.next();
+        this.skipSeparationSpace(true, nodeIndent);
+        this.composeNode(nodeIndent, CONTEXT_FLOW_IN, false, true);
+        valueNode = this.result;
+      }
+
+      if (isMapping) {
+        this.storeMappingPair(
+          result,
+          overridableKeys,
+          keyTag,
+          keyNode,
+          valueNode,
+        );
+      } else if (isPair) {
+        (result as ArrayObject[]).push(
+          this.storeMappingPair(
+            null,
+            overridableKeys,
+            keyTag,
+            keyNode,
+            valueNode,
+          ),
+        );
+      } else {
+        (result as ResultType[]).push(keyNode as ResultType);
+      }
+
+      this.skipSeparationSpace(true, nodeIndent);
+
+      ch = this.peek();
+
+      if (ch === COMMA) {
+        readNext = true;
+        ch = this.next();
+      } else {
+        readNext = false;
+      }
+    }
+
+    return this.throwError(
+      "unexpected end of the stream within a flow collection",
+    );
+  }
+
+  // Handles block scaler styles: e.g. '|', '>', '|-' and '>-'.
+  // https://yaml.org/spec/1.2.2/#81-block-scalar-styles
+  readBlockScalar(nodeIndent: number): boolean {
+    let chomping = CHOMPING_CLIP;
+    let didReadContent = false;
+    let detectedIndent = false;
+    let textIndent = nodeIndent;
+    let emptyLines = 0;
+    let atMoreIndented = false;
+
+    let ch = this.peek();
+
+    let folding = false;
+    if (ch === VERTICAL_LINE) {
+      folding = false;
+    } else if (ch === GREATER_THAN) {
+      folding = true;
+    } else {
+      return false;
+    }
+
+    this.kind = "scalar";
+    this.result = "";
+
+    let tmp = 0;
+    while (ch !== 0) {
+      ch = this.next();
+
+      if (ch === PLUS || ch === MINUS) {
+        if (CHOMPING_CLIP === chomping) {
+          chomping = ch === PLUS ? CHOMPING_KEEP : CHOMPING_STRIP;
+        } else {
+          return this.throwError("repeat of a chomping mode identifier");
+        }
+      } else if ((tmp = decimalCharCodeToNumber(ch)) >= 0) {
+        if (tmp === 0) {
+          return this.throwError(
+            "bad explicit indentation width of a block scalar; it cannot be less than one",
+          );
+        } else if (!detectedIndent) {
+          textIndent = nodeIndent + tmp - 1;
+          detectedIndent = true;
+        } else {
+          return this.throwError("repeat of an indentation width identifier");
+        }
+      } else {
+        break;
+      }
+    }
+
+    if (isWhiteSpace(ch)) {
+      do {
+        ch = this.next();
+      } while (isWhiteSpace(ch));
+
+      if (ch === SHARP) {
+        do {
+          ch = this.next();
+        } while (!isEOL(ch) && ch !== 0);
+      }
+    }
+
+    while (ch !== 0) {
+      this.readLineBreak();
+      this.lineIndent = 0;
+
+      ch = this.peek();
+
+      while (
+        (!detectedIndent || this.lineIndent < textIndent) &&
+        ch === SPACE
+      ) {
+        this.lineIndent++;
+        ch = this.next();
+      }
+
+      if (!detectedIndent && this.lineIndent > textIndent) {
+        textIndent = this.lineIndent;
+      }
+
+      if (isEOL(ch)) {
+        emptyLines++;
+        continue;
+      }
+
+      // End of the scalar.
+      if (this.lineIndent < textIndent) {
+        // Perform the chomping.
+        if (chomping === CHOMPING_KEEP) {
+          this.result += "\n".repeat(
+            didReadContent ? 1 + emptyLines : emptyLines,
+          );
+        } else if (chomping === CHOMPING_CLIP) {
+          if (didReadContent) {
+            // i.e. only if the scalar is not empty.
+            this.result += "\n";
+          }
+        }
+
+        // Break this `while` cycle and go to the 's epilogue.
+        break;
+      }
+
+      // Folded style: use fancy rules to handle line breaks.
+      if (folding) {
+        // Lines starting with white space characters (more-indented lines) are not folded.
+        if (isWhiteSpace(ch)) {
+          atMoreIndented = true;
+          // except for the first content line (cf. Example 8.1)
+          this.result += "\n".repeat(
+            didReadContent ? 1 + emptyLines : emptyLines,
+          );
+
+          // End of more-indented block.
+        } else if (atMoreIndented) {
+          atMoreIndented = false;
+          this.result += "\n".repeat(emptyLines + 1);
+
+          // Just one line break - perceive as the same line.
+        } else if (emptyLines === 0) {
+          if (didReadContent) {
+            // i.e. only if we have already read some scalar content.
+            this.result += " ";
+          }
+
+          // Several line breaks - perceive as different lines.
+        } else {
+          this.result += "\n".repeat(emptyLines);
+        }
+
+        // Literal style: just add exact number of line breaks between content lines.
+      } else {
+        // Keep all line breaks except the header line break.
+        this.result += "\n".repeat(
+          didReadContent ? 1 + emptyLines : emptyLines,
+        );
+      }
+
+      didReadContent = true;
+      detectedIndent = true;
+      emptyLines = 0;
+      const captureStart = this.position;
+
+      while (!isEOL(ch) && ch !== 0) {
+        ch = this.next();
+      }
+
+      this.captureSegment(captureStart, this.position, false);
+    }
+
+    return true;
+  }
+
+  readBlockSequence(nodeIndent: number): boolean {
+    let line: number;
+    let following: number;
+    let detected = false;
+    let ch: number;
+    const tag = this.tag;
+    const anchor = this.anchor;
+    const result: unknown[] = [];
+
+    if (this.anchor !== null && typeof this.anchor !== "undefined") {
+      this.anchorMap.set(this.anchor, result);
+    }
+
+    ch = this.peek();
+
+    while (ch !== 0) {
+      if (ch !== MINUS) {
+        break;
+      }
+
+      following = this.peek(1);
+
+      if (!isWhiteSpaceOrEOL(following)) {
+        break;
+      }
+
+      detected = true;
+      this.position++;
+
+      if (this.skipSeparationSpace(true, -1)) {
+        if (this.lineIndent <= nodeIndent) {
+          result.push(null);
+          ch = this.peek();
+          continue;
+        }
+      }
+
+      line = this.line;
+      this.composeNode(nodeIndent, CONTEXT_BLOCK_IN, false, true);
+      result.push(this.result);
+      this.skipSeparationSpace(true, -1);
+
+      ch = this.peek();
+
+      if ((this.line === line || this.lineIndent > nodeIndent) && ch !== 0) {
+        return this.throwError("bad indentation of a sequence entry");
+      } else if (this.lineIndent < nodeIndent) {
+        break;
+      }
+    }
+
+    if (detected) {
+      this.tag = tag;
+      this.anchor = anchor;
+      this.kind = "sequence";
+      this.result = result;
+      return true;
+    }
+    return false;
+  }
+
+  readBlockMapping(
+    nodeIndent: number,
+    flowIndent: number,
+  ): boolean {
+    const tag = this.tag;
+    const anchor = this.anchor;
+    const result = {};
+    const overridableKeys = new Set<string>();
+    let following: number;
+    let allowCompact = false;
+    let line: number;
+    let pos: number;
+    let keyTag = null;
+    let keyNode = null;
+    let valueNode = null;
+    let atExplicitKey = false;
+    let detected = false;
+    let ch: number;
+
+    if (this.anchor !== null && typeof this.anchor !== "undefined") {
+      this.anchorMap.set(this.anchor, result);
+    }
+
+    ch = this.peek();
+
+    while (ch !== 0) {
+      following = this.peek(1);
+      line = this.line; // Save the current line.
+      pos = this.position;
+
+      //
+      // Explicit notation case. There are two separate blocks:
+      // first for the key (denoted by "?") and second for the value (denoted by ":")
+      //
+      if ((ch === QUESTION || ch === COLON) && isWhiteSpaceOrEOL(following)) {
+        if (ch === QUESTION) {
+          if (atExplicitKey) {
+            this.storeMappingPair(
+              result,
+              overridableKeys,
+              keyTag as string,
+              keyNode,
+              null,
+            );
+            keyTag = keyNode = valueNode = null;
+          }
+
+          detected = true;
+          atExplicitKey = true;
+          allowCompact = true;
+        } else if (atExplicitKey) {
+          // i.e. 0x3A/* : */ === character after the explicit key.
+          atExplicitKey = false;
+          allowCompact = true;
+        } else {
+          return this.throwError(
+            "incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line",
+          );
+        }
+
+        this.position += 1;
+        ch = following;
+
+        //
+        // Implicit notation case. Flow-style node as the key first, then ":", and the value.
+        //
+      } else if (
+        this.composeNode(flowIndent, CONTEXT_FLOW_OUT, false, true)
+      ) {
+        if (this.line === line) {
+          ch = this.peek();
+
+          while (isWhiteSpace(ch)) {
+            ch = this.next();
+          }
+
+          if (ch === COLON) {
+            ch = this.next();
+
+            if (!isWhiteSpaceOrEOL(ch)) {
+              return this.throwError(
+                "a whitespace character is expected after the key-value separator within a block mapping",
+              );
+            }
+
+            if (atExplicitKey) {
+              this.storeMappingPair(
+                result,
+                overridableKeys,
+                keyTag as string,
+                keyNode,
+                null,
+              );
+              keyTag = keyNode = valueNode = null;
+            }
+
+            detected = true;
+            atExplicitKey = false;
+            allowCompact = false;
+            keyTag = this.tag;
+            keyNode = this.result;
+          } else if (detected) {
+            return this.throwError(
+              "can not read an implicit mapping pair; a colon is missed",
+            );
+          } else {
+            this.tag = tag;
+            this.anchor = anchor;
+            return true; // Keep the result of `composeNode`.
+          }
+        } else if (detected) {
+          return this.throwError(
+            "can not read a block mapping entry; a multiline key may not be an implicit key",
+          );
+        } else {
+          this.tag = tag;
+          this.anchor = anchor;
+          return true; // Keep the result of `composeNode`.
+        }
+      } else {
+        break; // Reading is done. Go to the epilogue.
+      }
+
+      //
+      // Common reading code for both explicit and implicit notations.
+      //
+      if (this.line === line || this.lineIndent > nodeIndent) {
+        if (
+          this.composeNode(
+            nodeIndent,
+            CONTEXT_BLOCK_OUT,
+            true,
+            allowCompact,
+          )
+        ) {
+          if (atExplicitKey) {
+            keyNode = this.result;
+          } else {
+            valueNode = this.result;
+          }
+        }
+
+        if (!atExplicitKey) {
+          this.storeMappingPair(
+            result,
+            overridableKeys,
+            keyTag as string,
+            keyNode,
+            valueNode,
+            line,
+            pos,
+          );
+          keyTag = keyNode = valueNode = null;
+        }
+
+        this.skipSeparationSpace(true, -1);
+        ch = this.peek();
+      }
+
+      if (this.lineIndent > nodeIndent && ch !== 0) {
+        return this.throwError("bad indentation of a mapping entry");
+      } else if (this.lineIndent < nodeIndent) {
+        break;
+      }
+    }
+
+    //
+    // Epilogue.
+    //
+
+    // Special case: last mapping's node contains only the key in explicit notation.
+    if (atExplicitKey) {
+      this.storeMappingPair(
+        result,
+        overridableKeys,
+        keyTag as string,
+        keyNode,
+        null,
+      );
+    }
+
+    // Expose the resulting mapping.
+    if (detected) {
+      this.tag = tag;
+      this.anchor = anchor;
+      this.kind = "mapping";
+      this.result = result;
+    }
+
+    return detected;
+  }
+
+  readTagProperty(): boolean {
+    let position: number;
+    let isVerbatim = false;
+    let isNamed = false;
+    let tagHandle = "";
+    let tagName: string;
+    let ch: number;
+
+    ch = this.peek();
+
+    if (ch !== EXCLAMATION) return false;
+
+    if (this.tag !== null) {
+      return this.throwError("duplication of a tag property");
+    }
+
+    ch = this.next();
+
+    if (ch === SMALLER_THAN) {
+      isVerbatim = true;
+      ch = this.next();
+    } else if (ch === EXCLAMATION) {
+      isNamed = true;
+      tagHandle = "!!";
+      ch = this.next();
+    } else {
+      tagHandle = "!";
+    }
+
+    position = this.position;
+
+    if (isVerbatim) {
+      do {
+        ch = this.next();
+      } while (ch !== 0 && ch !== GREATER_THAN);
+
+      if (this.position < this.length) {
+        tagName = this.input.slice(position, this.position);
+        ch = this.next();
+      } else {
+        return this.throwError(
+          "unexpected end of the stream within a verbatim tag",
+        );
+      }
+    } else {
+      while (ch !== 0 && !isWhiteSpaceOrEOL(ch)) {
+        if (ch === EXCLAMATION) {
+          if (!isNamed) {
+            tagHandle = this.input.slice(position - 1, this.position + 1);
+
+            if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
+              return this.throwError(
+                "named tag handle cannot contain such characters",
+              );
+            }
+
+            isNamed = true;
+            position = this.position + 1;
+          } else {
+            return this.throwError(
+              "tag suffix cannot contain exclamation marks",
+            );
+          }
+        }
+
+        ch = this.next();
+      }
+
+      tagName = this.input.slice(position, this.position);
+
+      if (PATTERN_FLOW_INDICATORS.test(tagName)) {
+        return this.throwError(
+          "tag suffix cannot contain flow indicator characters",
+        );
+      }
+    }
+
+    if (tagName && !PATTERN_TAG_URI.test(tagName)) {
+      return this.throwError(
+        `tag name cannot contain such characters: ${tagName}`,
+      );
+    }
+
+    if (isVerbatim) {
+      this.tag = tagName;
+    } else if (this.tagMap.has(tagHandle)) {
+      this.tag = this.tagMap.get(tagHandle) + tagName;
+    } else if (tagHandle === "!") {
+      this.tag = `!${tagName}`;
+    } else if (tagHandle === "!!") {
+      this.tag = `tag:yaml.org,2002:${tagName}`;
+    } else {
+      return this.throwError(`undeclared tag handle "${tagHandle}"`);
+    }
+
+    return true;
+  }
+
+  readAnchorProperty(): boolean {
+    let ch = this.peek();
+    if (ch !== AMPERSAND) return false;
+
+    if (this.anchor !== null) {
+      return this.throwError("duplication of an anchor property");
+    }
+    ch = this.next();
+
+    const position = this.position;
+    while (ch !== 0 && !isWhiteSpaceOrEOL(ch) && !isFlowIndicator(ch)) {
+      ch = this.next();
+    }
+
+    if (this.position === position) {
+      return this.throwError(
+        "name of an anchor node must contain at least one character",
+      );
+    }
+
+    this.anchor = this.input.slice(position, this.position);
+    return true;
+  }
+
+  readAlias(): boolean {
+    if (this.peek() !== ASTERISK) return false;
+
+    let ch = this.next();
+
+    const position = this.position;
+
+    while (ch !== 0 && !isWhiteSpaceOrEOL(ch) && !isFlowIndicator(ch)) {
+      ch = this.next();
+    }
+
+    if (this.position === position) {
+      return this.throwError(
+        "name of an alias node must contain at least one character",
+      );
+    }
+
+    const alias = this.input.slice(position, this.position);
+    if (!this.anchorMap.has(alias)) {
+      return this.throwError(`unidentified alias "${alias}"`);
+    }
+
+    this.result = this.anchorMap.get(alias);
+    this.skipSeparationSpace(true, -1);
+    return true;
+  }
+
+  composeNode(
+    parentIndent: number,
+    nodeContext: number,
+    allowToSeek: boolean,
+    allowCompact: boolean,
+  ): boolean {
+    let allowBlockScalars: boolean;
+    let allowBlockCollections: boolean;
+    let indentStatus = 1; // 1: this>parent, 0: this=parent, -1: this<parent
+    let atNewLine = false;
+    let hasContent = false;
+    let type: Type<KindType>;
+    let flowIndent: number;
+    let blockIndent: number;
+
+    this.tag = null;
+    this.anchor = null;
+    this.kind = null;
+    this.result = null;
+
+    const allowBlockStyles = (allowBlockScalars =
+      allowBlockCollections =
+        CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext);
+
+    if (allowToSeek) {
+      if (this.skipSeparationSpace(true, -1)) {
+        atNewLine = true;
+
+        if (this.lineIndent > parentIndent) {
+          indentStatus = 1;
+        } else if (this.lineIndent === parentIndent) {
+          indentStatus = 0;
+        } else if (this.lineIndent < parentIndent) {
+          indentStatus = -1;
+        }
+      }
+    }
+
+    if (indentStatus === 1) {
+      while (this.readTagProperty() || this.readAnchorProperty()) {
+        if (this.skipSeparationSpace(true, -1)) {
+          atNewLine = true;
+          allowBlockCollections = allowBlockStyles;
+
+          if (this.lineIndent > parentIndent) {
+            indentStatus = 1;
+          } else if (this.lineIndent === parentIndent) {
+            indentStatus = 0;
+          } else if (this.lineIndent < parentIndent) {
+            indentStatus = -1;
+          }
+        } else {
+          allowBlockCollections = false;
+        }
+      }
+    }
+
+    if (allowBlockCollections) {
+      allowBlockCollections = atNewLine || allowCompact;
+    }
+
+    if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
+      const cond = CONTEXT_FLOW_IN === nodeContext ||
+        CONTEXT_FLOW_OUT === nodeContext;
+      flowIndent = cond ? parentIndent : parentIndent + 1;
+
+      blockIndent = this.position - this.lineStart;
+
+      if (indentStatus === 1) {
+        if (
+          (allowBlockCollections &&
+            (this.readBlockSequence(blockIndent) ||
+              this.readBlockMapping(blockIndent, flowIndent))) ||
+          this.readFlowCollection(flowIndent)
+        ) {
+          hasContent = true;
+        } else {
+          if (
+            (allowBlockScalars && this.readBlockScalar(flowIndent)) ||
+            this.readSingleQuotedScalar(flowIndent) ||
+            this.readDoubleQuotedScalar(flowIndent)
+          ) {
+            hasContent = true;
+          } else if (this.readAlias()) {
+            hasContent = true;
+
+            if (this.tag !== null || this.anchor !== null) {
+              return this.throwError(
+                "alias node should not have Any properties",
+              );
+            }
+          } else if (
+            this.readPlainScalar(
+              flowIndent,
+              CONTEXT_FLOW_IN === nodeContext,
+            )
+          ) {
+            hasContent = true;
+
+            if (this.tag === null) {
+              this.tag = "?";
+            }
+          }
+
+          if (this.anchor !== null) {
+            this.anchorMap.set(this.anchor, this.result);
+          }
+        }
+      } else if (indentStatus === 0) {
+        // Special case: block sequences are allowed to have same indentation level as the parent.
+        // http://www.yaml.org/spec/1.2/spec.html#id2799784
+        hasContent = allowBlockCollections &&
+          this.readBlockSequence(blockIndent);
+      }
+    }
+
+    if (this.tag !== null && this.tag !== "!") {
+      if (this.tag === "?") {
+        for (
+          let typeIndex = 0;
+          typeIndex < this.implicitTypes.length;
+          typeIndex++
+        ) {
+          type = this.implicitTypes[typeIndex]!;
+
+          // Implicit resolving is not allowed for non-scalar types, and '?'
+          // non-specific tag is only assigned to plain scalars. So, it isn't
+          // needed to check for 'kind' conformity.
+
+          if (type.resolve(this.result)) {
+            // `this.result` updated in resolver if matched
+            this.result = type.construct(this.result);
+            this.tag = type.tag;
+            if (this.anchor !== null) {
+              this.anchorMap.set(this.anchor, this.result);
+            }
+            break;
+          }
+        }
+      } else if (this.typeMap[this.kind ?? "fallback"].has(this.tag)) {
+        const map = this.typeMap[this.kind ?? "fallback"];
+        type = map.get(this.tag)!;
+
+        if (this.result !== null && type.kind !== this.kind) {
+          return this.throwError(
+            `unacceptable node kind for !<${this.tag}> tag; it should be "${type.kind}", not "${this.kind}"`,
+          );
+        }
+
+        if (!type.resolve(this.result)) {
+          // `this.result` updated in resolver if matched
+          return this.throwError(
+            `cannot resolve a node with !<${this.tag}> explicit tag`,
+          );
+        } else {
+          this.result = type.construct(this.result);
+          if (this.anchor !== null) {
+            this.anchorMap.set(this.anchor, this.result);
+          }
+        }
+      } else {
+        return this.throwError(`unknown tag !<${this.tag}>`);
+      }
+    }
+
+    return this.tag !== null || this.anchor !== null || hasContent;
+  }
+
   readDocument() {
     const documentStart = this.position;
     let position: number;
@@ -224,7 +1587,7 @@ export class LoaderState {
     this.anchorMap = new Map();
 
     while ((ch = this.peek()) !== 0) {
-      skipSeparationSpace(this, true, -1);
+      this.skipSeparationSpace(true, -1);
 
       ch = this.peek();
 
@@ -272,14 +1635,14 @@ export class LoaderState {
         directiveArgs.push(this.input.slice(position, this.position));
       }
 
-      if (ch !== 0) readLineBreak(this);
+      if (ch !== 0) this.readLineBreak();
 
       switch (directiveName) {
         case "YAML":
-          yamlDirectiveHandler(this, ...directiveArgs);
+          this.yamlDirectiveHandler(...directiveArgs);
           break;
         case "TAG":
-          tagDirectiveHandler(this, ...directiveArgs);
+          this.tagDirectiveHandler(...directiveArgs);
           break;
         default:
           this.dispatchWarning(
@@ -289,7 +1652,7 @@ export class LoaderState {
       }
     }
 
-    skipSeparationSpace(this, true, -1);
+    this.skipSeparationSpace(true, -1);
 
     if (
       this.lineIndent === 0 &&
@@ -298,13 +1661,13 @@ export class LoaderState {
       this.peek(2) === MINUS
     ) {
       this.position += 3;
-      skipSeparationSpace(this, true, -1);
+      this.skipSeparationSpace(true, -1);
     } else if (hasDirectives) {
       return this.throwError("directives end mark is expected");
     }
 
-    composeNode(this, this.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
-    skipSeparationSpace(this, true, -1);
+    this.composeNode(this.lineIndent - 1, CONTEXT_BLOCK_OUT, false, true);
+    this.skipSeparationSpace(true, -1);
 
     if (
       this.checkLineBreaks &&
@@ -315,10 +1678,10 @@ export class LoaderState {
       this.dispatchWarning("non-ASCII line breaks are interpreted as content");
     }
 
-    if (this.position === this.lineStart && testDocumentSeparator(this)) {
+    if (this.position === this.lineStart && this.testDocumentSeparator()) {
       if (this.peek() === DOT) {
         this.position += 3;
-        skipSeparationSpace(this, true, -1);
+        this.skipSeparationSpace(true, -1);
       }
     } else if (this.position < this.length - 1) {
       return this.throwError(
@@ -334,1358 +1697,4 @@ export class LoaderState {
       yield this.readDocument();
     }
   }
-}
-
-function yamlDirectiveHandler(state: LoaderState, ...args: string[]) {
-  if (state.version !== null) {
-    return state.throwError("duplication of %YAML directive");
-  }
-
-  if (args.length !== 1) {
-    return state.throwError("YAML directive accepts exactly one argument");
-  }
-
-  const match = /^([0-9]+)\.([0-9]+)$/.exec(args[0]!);
-  if (match === null) {
-    return state.throwError("ill-formed argument of the YAML directive");
-  }
-
-  const major = parseInt(match[1]!, 10);
-  const minor = parseInt(match[2]!, 10);
-  if (major !== 1) {
-    return state.throwError("unacceptable YAML version of the document");
-  }
-
-  state.version = args[0] ?? null;
-  state.checkLineBreaks = minor < 2;
-  if (minor !== 1 && minor !== 2) {
-    return state.dispatchWarning("unsupported YAML version of the document");
-  }
-}
-function tagDirectiveHandler(state: LoaderState, ...args: string[]) {
-  if (args.length !== 2) {
-    return state.throwError("TAG directive accepts exactly two arguments");
-  }
-
-  const handle = args[0]!;
-  const prefix = args[1]!;
-
-  if (!PATTERN_TAG_HANDLE.test(handle)) {
-    return state.throwError(
-      "ill-formed tag handle (first argument) of the TAG directive",
-    );
-  }
-
-  if (state.tagMap.has(handle)) {
-    return state.throwError(
-      `there is a previously declared suffix for "${handle}" tag handle`,
-    );
-  }
-
-  if (!PATTERN_TAG_URI.test(prefix)) {
-    return state.throwError(
-      "ill-formed tag prefix (second argument) of the TAG directive",
-    );
-  }
-
-  state.tagMap.set(handle, prefix);
-}
-
-function captureSegment(
-  state: LoaderState,
-  start: number,
-  end: number,
-  checkJson: boolean,
-) {
-  let result: string;
-  if (start < end) {
-    result = state.input.slice(start, end);
-
-    if (checkJson) {
-      for (
-        let position = 0;
-        position < result.length;
-        position++
-      ) {
-        const character = result.charCodeAt(position);
-        if (
-          !(character === 0x09 || (0x20 <= character && character <= 0x10ffff))
-        ) {
-          return state.throwError("expected valid JSON character");
-        }
-      }
-    } else if (PATTERN_NON_PRINTABLE.test(result)) {
-      return state.throwError("the stream contains non-printable characters");
-    }
-
-    state.result += result;
-  }
-}
-
-function mergeMappings(
-  state: LoaderState,
-  destination: ArrayObject,
-  source: ArrayObject,
-  overridableKeys: Set<string>,
-) {
-  if (!isObject(source)) {
-    return state.throwError(
-      "cannot merge mappings; the provided source object is unacceptable",
-    );
-  }
-
-  for (const [key, value] of Object.entries(source)) {
-    if (Object.hasOwn(destination, key)) continue;
-    Object.defineProperty(destination, key, {
-      value,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    });
-    overridableKeys.add(key);
-  }
-}
-
-function storeMappingPair(
-  state: LoaderState,
-  result: ArrayObject | null,
-  overridableKeys: Set<string>,
-  keyTag: string | null,
-  keyNode: Record<PropertyKey, unknown> | unknown[] | string | null,
-  valueNode: unknown,
-  startLine?: number,
-  startPos?: number,
-): ArrayObject {
-  // The output is a plain object here, so keys can only be strings.
-  // We need to convert keyNode to a string, but doing so can hang the process
-  // (deeply nested arrays that explode exponentially using aliases).
-  if (Array.isArray(keyNode)) {
-    keyNode = Array.prototype.slice.call(keyNode);
-
-    for (let index = 0; index < keyNode.length; index++) {
-      if (Array.isArray(keyNode[index])) {
-        return state.throwError("nested arrays are not supported inside keys");
-      }
-
-      if (
-        typeof keyNode === "object" &&
-        getObjectTypeString(keyNode[index]) === "[object Object]"
-      ) {
-        keyNode[index] = "[object Object]";
-      }
-    }
-  }
-
-  // Avoid code execution in load() via toString property
-  // (still use its own toString for arrays, timestamps,
-  // and whatever user schema extensions happen to have @@toStringTag)
-  if (
-    typeof keyNode === "object" &&
-    getObjectTypeString(keyNode) === "[object Object]"
-  ) {
-    keyNode = "[object Object]";
-  }
-
-  keyNode = String(keyNode);
-
-  if (result === null) {
-    result = {};
-  }
-
-  if (keyTag === "tag:yaml.org,2002:merge") {
-    if (Array.isArray(valueNode)) {
-      for (
-        let index = 0;
-        index < valueNode.length;
-        index++
-      ) {
-        mergeMappings(state, result, valueNode[index], overridableKeys);
-      }
-    } else {
-      mergeMappings(state, result, valueNode as ArrayObject, overridableKeys);
-    }
-  } else {
-    if (
-      !state.allowDuplicateKeys &&
-      !overridableKeys.has(keyNode) &&
-      Object.hasOwn(result, keyNode)
-    ) {
-      state.line = startLine || state.line;
-      state.position = startPos || state.position;
-      return state.throwError("duplicated mapping key");
-    }
-    Object.defineProperty(result, keyNode, {
-      value: valueNode,
-      writable: true,
-      enumerable: true,
-      configurable: true,
-    });
-    overridableKeys.delete(keyNode);
-  }
-
-  return result;
-}
-
-function readLineBreak(state: LoaderState) {
-  const ch = state.peek();
-
-  if (ch === LINE_FEED) {
-    state.position++;
-  } else if (ch === CARRIAGE_RETURN) {
-    state.position++;
-    if (state.peek() === LINE_FEED) {
-      state.position++;
-    }
-  } else {
-    return state.throwError("a line break is expected");
-  }
-
-  state.line += 1;
-  state.lineStart = state.position;
-}
-
-function skipSeparationSpace(
-  state: LoaderState,
-  allowComments: boolean,
-  checkIndent: number,
-): number {
-  let lineBreaks = 0;
-  let ch = state.peek();
-
-  while (ch !== 0) {
-    while (isWhiteSpace(ch)) {
-      ch = state.next();
-    }
-
-    if (allowComments && ch === SHARP) {
-      do {
-        ch = state.next();
-      } while (ch !== LINE_FEED && ch !== CARRIAGE_RETURN && ch !== 0);
-    }
-
-    if (isEOL(ch)) {
-      readLineBreak(state);
-
-      ch = state.peek();
-      lineBreaks++;
-      state.lineIndent = 0;
-
-      state.readIndent();
-      ch = state.peek();
-    } else {
-      break;
-    }
-  }
-
-  if (
-    checkIndent !== -1 &&
-    lineBreaks !== 0 &&
-    state.lineIndent < checkIndent
-  ) {
-    state.dispatchWarning("deficient indentation");
-  }
-
-  return lineBreaks;
-}
-
-function testDocumentSeparator(state: LoaderState): boolean {
-  let ch = state.peek();
-
-  // Condition state.position === state.lineStart is tested
-  // in parent on each call, for efficiency. No needs to test here again.
-  if (
-    (ch === MINUS || ch === DOT) &&
-    ch === state.peek(1) &&
-    ch === state.peek(2)
-  ) {
-    ch = state.peek(3);
-
-    if (ch === 0 || isWhiteSpaceOrEOL(ch)) {
-      return true;
-    }
-  }
-
-  return false;
-}
-
-function writeFoldedLines(state: LoaderState, count: number) {
-  if (count === 1) {
-    state.result += " ";
-  } else if (count > 1) {
-    state.result += "\n".repeat(count - 1);
-  }
-}
-
-function readPlainScalar(
-  state: LoaderState,
-  nodeIndent: number,
-  withinFlowCollection: boolean,
-): boolean {
-  const kind = state.kind;
-  const result = state.result;
-  let ch = state.peek();
-
-  if (
-    isWhiteSpaceOrEOL(ch) ||
-    isFlowIndicator(ch) ||
-    ch === SHARP ||
-    ch === AMPERSAND ||
-    ch === ASTERISK ||
-    ch === EXCLAMATION ||
-    ch === VERTICAL_LINE ||
-    ch === GREATER_THAN ||
-    ch === SINGLE_QUOTE ||
-    ch === DOUBLE_QUOTE ||
-    ch === PERCENT ||
-    ch === COMMERCIAL_AT ||
-    ch === GRAVE_ACCENT
-  ) {
-    return false;
-  }
-
-  let following: number;
-  if (ch === QUESTION || ch === MINUS) {
-    following = state.peek(1);
-
-    if (
-      isWhiteSpaceOrEOL(following) ||
-      (withinFlowCollection && isFlowIndicator(following))
-    ) {
-      return false;
-    }
-  }
-
-  state.kind = "scalar";
-  state.result = "";
-  let captureEnd = state.position;
-  let captureStart = state.position;
-  let hasPendingContent = false;
-  let line = 0;
-  while (ch !== 0) {
-    if (ch === COLON) {
-      following = state.peek(1);
-
-      if (
-        isWhiteSpaceOrEOL(following) ||
-        (withinFlowCollection && isFlowIndicator(following))
-      ) {
-        break;
-      }
-    } else if (ch === SHARP) {
-      const preceding = state.peek(-1);
-
-      if (isWhiteSpaceOrEOL(preceding)) {
-        break;
-      }
-    } else if (
-      (state.position === state.lineStart && testDocumentSeparator(state)) ||
-      (withinFlowCollection && isFlowIndicator(ch))
-    ) {
-      break;
-    } else if (isEOL(ch)) {
-      line = state.line;
-      const lineStart = state.lineStart;
-      const lineIndent = state.lineIndent;
-      skipSeparationSpace(state, false, -1);
-
-      if (state.lineIndent >= nodeIndent) {
-        hasPendingContent = true;
-        ch = state.peek();
-        continue;
-      } else {
-        state.position = captureEnd;
-        state.line = line;
-        state.lineStart = lineStart;
-        state.lineIndent = lineIndent;
-        break;
-      }
-    }
-
-    if (hasPendingContent) {
-      captureSegment(state, captureStart, captureEnd, false);
-      writeFoldedLines(state, state.line - line);
-      captureStart = captureEnd = state.position;
-      hasPendingContent = false;
-    }
-
-    if (!isWhiteSpace(ch)) {
-      captureEnd = state.position + 1;
-    }
-
-    ch = state.next();
-  }
-
-  captureSegment(state, captureStart, captureEnd, false);
-
-  if (state.result) {
-    return true;
-  }
-
-  state.kind = kind;
-  state.result = result;
-  return false;
-}
-
-function readSingleQuotedScalar(
-  state: LoaderState,
-  nodeIndent: number,
-): boolean {
-  let ch;
-  let captureStart;
-  let captureEnd;
-
-  ch = state.peek();
-
-  if (ch !== SINGLE_QUOTE) {
-    return false;
-  }
-
-  state.kind = "scalar";
-  state.result = "";
-  state.position++;
-  captureStart = captureEnd = state.position;
-
-  while ((ch = state.peek()) !== 0) {
-    if (ch === SINGLE_QUOTE) {
-      captureSegment(state, captureStart, state.position, true);
-      ch = state.next();
-
-      if (ch === SINGLE_QUOTE) {
-        captureStart = state.position;
-        state.position++;
-        captureEnd = state.position;
-      } else {
-        return true;
-      }
-    } else if (isEOL(ch)) {
-      captureSegment(state, captureStart, captureEnd, true);
-      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
-      captureStart = captureEnd = state.position;
-    } else if (
-      state.position === state.lineStart &&
-      testDocumentSeparator(state)
-    ) {
-      return state.throwError(
-        "unexpected end of the document within a single quoted scalar",
-      );
-    } else {
-      state.position++;
-      captureEnd = state.position;
-    }
-  }
-
-  return state.throwError(
-    "unexpected end of the stream within a single quoted scalar",
-  );
-}
-
-function readDoubleQuotedScalar(
-  state: LoaderState,
-  nodeIndent: number,
-): boolean {
-  let ch = state.peek();
-
-  if (ch !== DOUBLE_QUOTE) {
-    return false;
-  }
-
-  state.kind = "scalar";
-  state.result = "";
-  state.position++;
-  let captureEnd = state.position;
-  let captureStart = state.position;
-  let tmp: number;
-  while ((ch = state.peek()) !== 0) {
-    if (ch === DOUBLE_QUOTE) {
-      captureSegment(state, captureStart, state.position, true);
-      state.position++;
-      return true;
-    }
-    if (ch === BACKSLASH) {
-      captureSegment(state, captureStart, state.position, true);
-      ch = state.next();
-
-      if (isEOL(ch)) {
-        skipSeparationSpace(state, false, nodeIndent);
-      } else if (ch < 256 && SIMPLE_ESCAPE_SEQUENCES.has(ch)) {
-        state.result += SIMPLE_ESCAPE_SEQUENCES.get(ch);
-        state.position++;
-      } else if ((tmp = ESCAPED_HEX_LENGTHS.get(ch) ?? 0) > 0) {
-        let hexLength = tmp;
-        let hexResult = 0;
-
-        for (; hexLength > 0; hexLength--) {
-          ch = state.next();
-
-          if ((tmp = hexCharCodeToNumber(ch)) >= 0) {
-            hexResult = (hexResult << 4) + tmp;
-          } else {
-            return state.throwError("expected hexadecimal character");
-          }
-        }
-
-        state.result += codepointToChar(hexResult);
-
-        state.position++;
-      } else {
-        return state.throwError("unknown escape sequence");
-      }
-
-      captureStart = captureEnd = state.position;
-    } else if (isEOL(ch)) {
-      captureSegment(state, captureStart, captureEnd, true);
-      writeFoldedLines(state, skipSeparationSpace(state, false, nodeIndent));
-      captureStart = captureEnd = state.position;
-    } else if (
-      state.position === state.lineStart &&
-      testDocumentSeparator(state)
-    ) {
-      return state.throwError(
-        "unexpected end of the document within a double quoted scalar",
-      );
-    } else {
-      state.position++;
-      captureEnd = state.position;
-    }
-  }
-
-  return state.throwError(
-    "unexpected end of the stream within a double quoted scalar",
-  );
-}
-
-function readFlowCollection(state: LoaderState, nodeIndent: number): boolean {
-  let ch = state.peek();
-  let terminator: number;
-  let isMapping = true;
-  let result: ResultType = {};
-  if (ch === LEFT_SQUARE_BRACKET) {
-    terminator = RIGHT_SQUARE_BRACKET;
-    isMapping = false;
-    result = [];
-  } else if (ch === LEFT_CURLY_BRACKET) {
-    terminator = RIGHT_CURLY_BRACKET;
-  } else {
-    return false;
-  }
-
-  if (state.anchor !== null && typeof state.anchor !== "undefined") {
-    state.anchorMap.set(state.anchor, result);
-  }
-
-  ch = state.next();
-
-  const tag = state.tag;
-  const anchor = state.anchor;
-  let readNext = true;
-  let valueNode = null;
-  let keyNode = null;
-  let keyTag: string | null = null;
-  let isExplicitPair = false;
-  let isPair = false;
-  let following = 0;
-  let line = 0;
-  const overridableKeys = new Set<string>();
-  while (ch !== 0) {
-    skipSeparationSpace(state, true, nodeIndent);
-
-    ch = state.peek();
-
-    if (ch === terminator) {
-      state.position++;
-      state.tag = tag;
-      state.anchor = anchor;
-      state.kind = isMapping ? "mapping" : "sequence";
-      state.result = result;
-      return true;
-    }
-    if (!readNext) {
-      return state.throwError("missed comma between flow collection entries");
-    }
-
-    keyTag = keyNode = valueNode = null;
-    isPair = isExplicitPair = false;
-
-    if (ch === QUESTION) {
-      following = state.peek(1);
-
-      if (isWhiteSpaceOrEOL(following)) {
-        isPair = isExplicitPair = true;
-        state.position++;
-        skipSeparationSpace(state, true, nodeIndent);
-      }
-    }
-
-    line = state.line;
-    composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
-    keyTag = state.tag || null;
-    keyNode = state.result;
-    skipSeparationSpace(state, true, nodeIndent);
-
-    ch = state.peek();
-
-    if ((isExplicitPair || state.line === line) && ch === COLON) {
-      isPair = true;
-      ch = state.next();
-      skipSeparationSpace(state, true, nodeIndent);
-      composeNode(state, nodeIndent, CONTEXT_FLOW_IN, false, true);
-      valueNode = state.result;
-    }
-
-    if (isMapping) {
-      storeMappingPair(
-        state,
-        result,
-        overridableKeys,
-        keyTag,
-        keyNode,
-        valueNode,
-      );
-    } else if (isPair) {
-      (result as ArrayObject[]).push(
-        storeMappingPair(
-          state,
-          null,
-          overridableKeys,
-          keyTag,
-          keyNode,
-          valueNode,
-        ),
-      );
-    } else {
-      (result as ResultType[]).push(keyNode as ResultType);
-    }
-
-    skipSeparationSpace(state, true, nodeIndent);
-
-    ch = state.peek();
-
-    if (ch === COMMA) {
-      readNext = true;
-      ch = state.next();
-    } else {
-      readNext = false;
-    }
-  }
-
-  return state.throwError(
-    "unexpected end of the stream within a flow collection",
-  );
-}
-
-// Handles block scaler styles: e.g. '|', '>', '|-' and '>-'.
-// https://yaml.org/spec/1.2.2/#81-block-scalar-styles
-function readBlockScalar(state: LoaderState, nodeIndent: number): boolean {
-  let chomping = CHOMPING_CLIP;
-  let didReadContent = false;
-  let detectedIndent = false;
-  let textIndent = nodeIndent;
-  let emptyLines = 0;
-  let atMoreIndented = false;
-
-  let ch = state.peek();
-
-  let folding = false;
-  if (ch === VERTICAL_LINE) {
-    folding = false;
-  } else if (ch === GREATER_THAN) {
-    folding = true;
-  } else {
-    return false;
-  }
-
-  state.kind = "scalar";
-  state.result = "";
-
-  let tmp = 0;
-  while (ch !== 0) {
-    ch = state.next();
-
-    if (ch === PLUS || ch === MINUS) {
-      if (CHOMPING_CLIP === chomping) {
-        chomping = ch === PLUS ? CHOMPING_KEEP : CHOMPING_STRIP;
-      } else {
-        return state.throwError("repeat of a chomping mode identifier");
-      }
-    } else if ((tmp = decimalCharCodeToNumber(ch)) >= 0) {
-      if (tmp === 0) {
-        return state.throwError(
-          "bad explicit indentation width of a block scalar; it cannot be less than one",
-        );
-      } else if (!detectedIndent) {
-        textIndent = nodeIndent + tmp - 1;
-        detectedIndent = true;
-      } else {
-        return state.throwError("repeat of an indentation width identifier");
-      }
-    } else {
-      break;
-    }
-  }
-
-  if (isWhiteSpace(ch)) {
-    do {
-      ch = state.next();
-    } while (isWhiteSpace(ch));
-
-    if (ch === SHARP) {
-      do {
-        ch = state.next();
-      } while (!isEOL(ch) && ch !== 0);
-    }
-  }
-
-  while (ch !== 0) {
-    readLineBreak(state);
-    state.lineIndent = 0;
-
-    ch = state.peek();
-
-    while (
-      (!detectedIndent || state.lineIndent < textIndent) &&
-      ch === SPACE
-    ) {
-      state.lineIndent++;
-      ch = state.next();
-    }
-
-    if (!detectedIndent && state.lineIndent > textIndent) {
-      textIndent = state.lineIndent;
-    }
-
-    if (isEOL(ch)) {
-      emptyLines++;
-      continue;
-    }
-
-    // End of the scalar.
-    if (state.lineIndent < textIndent) {
-      // Perform the chomping.
-      if (chomping === CHOMPING_KEEP) {
-        state.result += "\n".repeat(
-          didReadContent ? 1 + emptyLines : emptyLines,
-        );
-      } else if (chomping === CHOMPING_CLIP) {
-        if (didReadContent) {
-          // i.e. only if the scalar is not empty.
-          state.result += "\n";
-        }
-      }
-
-      // Break this `while` cycle and go to the function's epilogue.
-      break;
-    }
-
-    // Folded style: use fancy rules to handle line breaks.
-    if (folding) {
-      // Lines starting with white space characters (more-indented lines) are not folded.
-      if (isWhiteSpace(ch)) {
-        atMoreIndented = true;
-        // except for the first content line (cf. Example 8.1)
-        state.result += "\n".repeat(
-          didReadContent ? 1 + emptyLines : emptyLines,
-        );
-
-        // End of more-indented block.
-      } else if (atMoreIndented) {
-        atMoreIndented = false;
-        state.result += "\n".repeat(emptyLines + 1);
-
-        // Just one line break - perceive as the same line.
-      } else if (emptyLines === 0) {
-        if (didReadContent) {
-          // i.e. only if we have already read some scalar content.
-          state.result += " ";
-        }
-
-        // Several line breaks - perceive as different lines.
-      } else {
-        state.result += "\n".repeat(emptyLines);
-      }
-
-      // Literal style: just add exact number of line breaks between content lines.
-    } else {
-      // Keep all line breaks except the header line break.
-      state.result += "\n".repeat(didReadContent ? 1 + emptyLines : emptyLines);
-    }
-
-    didReadContent = true;
-    detectedIndent = true;
-    emptyLines = 0;
-    const captureStart = state.position;
-
-    while (!isEOL(ch) && ch !== 0) {
-      ch = state.next();
-    }
-
-    captureSegment(state, captureStart, state.position, false);
-  }
-
-  return true;
-}
-
-function readBlockSequence(state: LoaderState, nodeIndent: number): boolean {
-  let line: number;
-  let following: number;
-  let detected = false;
-  let ch: number;
-  const tag = state.tag;
-  const anchor = state.anchor;
-  const result: unknown[] = [];
-
-  if (state.anchor !== null && typeof state.anchor !== "undefined") {
-    state.anchorMap.set(state.anchor, result);
-  }
-
-  ch = state.peek();
-
-  while (ch !== 0) {
-    if (ch !== MINUS) {
-      break;
-    }
-
-    following = state.peek(1);
-
-    if (!isWhiteSpaceOrEOL(following)) {
-      break;
-    }
-
-    detected = true;
-    state.position++;
-
-    if (skipSeparationSpace(state, true, -1)) {
-      if (state.lineIndent <= nodeIndent) {
-        result.push(null);
-        ch = state.peek();
-        continue;
-      }
-    }
-
-    line = state.line;
-    composeNode(state, nodeIndent, CONTEXT_BLOCK_IN, false, true);
-    result.push(state.result);
-    skipSeparationSpace(state, true, -1);
-
-    ch = state.peek();
-
-    if ((state.line === line || state.lineIndent > nodeIndent) && ch !== 0) {
-      return state.throwError("bad indentation of a sequence entry");
-    } else if (state.lineIndent < nodeIndent) {
-      break;
-    }
-  }
-
-  if (detected) {
-    state.tag = tag;
-    state.anchor = anchor;
-    state.kind = "sequence";
-    state.result = result;
-    return true;
-  }
-  return false;
-}
-
-function readBlockMapping(
-  state: LoaderState,
-  nodeIndent: number,
-  flowIndent: number,
-): boolean {
-  const tag = state.tag;
-  const anchor = state.anchor;
-  const result = {};
-  const overridableKeys = new Set<string>();
-  let following: number;
-  let allowCompact = false;
-  let line: number;
-  let pos: number;
-  let keyTag = null;
-  let keyNode = null;
-  let valueNode = null;
-  let atExplicitKey = false;
-  let detected = false;
-  let ch: number;
-
-  if (state.anchor !== null && typeof state.anchor !== "undefined") {
-    state.anchorMap.set(state.anchor, result);
-  }
-
-  ch = state.peek();
-
-  while (ch !== 0) {
-    following = state.peek(1);
-    line = state.line; // Save the current line.
-    pos = state.position;
-
-    //
-    // Explicit notation case. There are two separate blocks:
-    // first for the key (denoted by "?") and second for the value (denoted by ":")
-    //
-    if ((ch === QUESTION || ch === COLON) && isWhiteSpaceOrEOL(following)) {
-      if (ch === QUESTION) {
-        if (atExplicitKey) {
-          storeMappingPair(
-            state,
-            result,
-            overridableKeys,
-            keyTag as string,
-            keyNode,
-            null,
-          );
-          keyTag = keyNode = valueNode = null;
-        }
-
-        detected = true;
-        atExplicitKey = true;
-        allowCompact = true;
-      } else if (atExplicitKey) {
-        // i.e. 0x3A/* : */ === character after the explicit key.
-        atExplicitKey = false;
-        allowCompact = true;
-      } else {
-        return state.throwError(
-          "incomplete explicit mapping pair; a key node is missed; or followed by a non-tabulated empty line",
-        );
-      }
-
-      state.position += 1;
-      ch = following;
-
-      //
-      // Implicit notation case. Flow-style node as the key first, then ":", and the value.
-      //
-    } else if (composeNode(state, flowIndent, CONTEXT_FLOW_OUT, false, true)) {
-      if (state.line === line) {
-        ch = state.peek();
-
-        while (isWhiteSpace(ch)) {
-          ch = state.next();
-        }
-
-        if (ch === COLON) {
-          ch = state.next();
-
-          if (!isWhiteSpaceOrEOL(ch)) {
-            return state.throwError(
-              "a whitespace character is expected after the key-value separator within a block mapping",
-            );
-          }
-
-          if (atExplicitKey) {
-            storeMappingPair(
-              state,
-              result,
-              overridableKeys,
-              keyTag as string,
-              keyNode,
-              null,
-            );
-            keyTag = keyNode = valueNode = null;
-          }
-
-          detected = true;
-          atExplicitKey = false;
-          allowCompact = false;
-          keyTag = state.tag;
-          keyNode = state.result;
-        } else if (detected) {
-          return state.throwError(
-            "can not read an implicit mapping pair; a colon is missed",
-          );
-        } else {
-          state.tag = tag;
-          state.anchor = anchor;
-          return true; // Keep the result of `composeNode`.
-        }
-      } else if (detected) {
-        return state.throwError(
-          "can not read a block mapping entry; a multiline key may not be an implicit key",
-        );
-      } else {
-        state.tag = tag;
-        state.anchor = anchor;
-        return true; // Keep the result of `composeNode`.
-      }
-    } else {
-      break; // Reading is done. Go to the epilogue.
-    }
-
-    //
-    // Common reading code for both explicit and implicit notations.
-    //
-    if (state.line === line || state.lineIndent > nodeIndent) {
-      if (
-        composeNode(state, nodeIndent, CONTEXT_BLOCK_OUT, true, allowCompact)
-      ) {
-        if (atExplicitKey) {
-          keyNode = state.result;
-        } else {
-          valueNode = state.result;
-        }
-      }
-
-      if (!atExplicitKey) {
-        storeMappingPair(
-          state,
-          result,
-          overridableKeys,
-          keyTag as string,
-          keyNode,
-          valueNode,
-          line,
-          pos,
-        );
-        keyTag = keyNode = valueNode = null;
-      }
-
-      skipSeparationSpace(state, true, -1);
-      ch = state.peek();
-    }
-
-    if (state.lineIndent > nodeIndent && ch !== 0) {
-      return state.throwError("bad indentation of a mapping entry");
-    } else if (state.lineIndent < nodeIndent) {
-      break;
-    }
-  }
-
-  //
-  // Epilogue.
-  //
-
-  // Special case: last mapping's node contains only the key in explicit notation.
-  if (atExplicitKey) {
-    storeMappingPair(
-      state,
-      result,
-      overridableKeys,
-      keyTag as string,
-      keyNode,
-      null,
-    );
-  }
-
-  // Expose the resulting mapping.
-  if (detected) {
-    state.tag = tag;
-    state.anchor = anchor;
-    state.kind = "mapping";
-    state.result = result;
-  }
-
-  return detected;
-}
-
-function readTagProperty(state: LoaderState): boolean {
-  let position: number;
-  let isVerbatim = false;
-  let isNamed = false;
-  let tagHandle = "";
-  let tagName: string;
-  let ch: number;
-
-  ch = state.peek();
-
-  if (ch !== EXCLAMATION) return false;
-
-  if (state.tag !== null) {
-    return state.throwError("duplication of a tag property");
-  }
-
-  ch = state.next();
-
-  if (ch === SMALLER_THAN) {
-    isVerbatim = true;
-    ch = state.next();
-  } else if (ch === EXCLAMATION) {
-    isNamed = true;
-    tagHandle = "!!";
-    ch = state.next();
-  } else {
-    tagHandle = "!";
-  }
-
-  position = state.position;
-
-  if (isVerbatim) {
-    do {
-      ch = state.next();
-    } while (ch !== 0 && ch !== GREATER_THAN);
-
-    if (state.position < state.length) {
-      tagName = state.input.slice(position, state.position);
-      ch = state.next();
-    } else {
-      return state.throwError(
-        "unexpected end of the stream within a verbatim tag",
-      );
-    }
-  } else {
-    while (ch !== 0 && !isWhiteSpaceOrEOL(ch)) {
-      if (ch === EXCLAMATION) {
-        if (!isNamed) {
-          tagHandle = state.input.slice(position - 1, state.position + 1);
-
-          if (!PATTERN_TAG_HANDLE.test(tagHandle)) {
-            return state.throwError(
-              "named tag handle cannot contain such characters",
-            );
-          }
-
-          isNamed = true;
-          position = state.position + 1;
-        } else {
-          return state.throwError(
-            "tag suffix cannot contain exclamation marks",
-          );
-        }
-      }
-
-      ch = state.next();
-    }
-
-    tagName = state.input.slice(position, state.position);
-
-    if (PATTERN_FLOW_INDICATORS.test(tagName)) {
-      return state.throwError(
-        "tag suffix cannot contain flow indicator characters",
-      );
-    }
-  }
-
-  if (tagName && !PATTERN_TAG_URI.test(tagName)) {
-    return state.throwError(
-      `tag name cannot contain such characters: ${tagName}`,
-    );
-  }
-
-  if (isVerbatim) {
-    state.tag = tagName;
-  } else if (state.tagMap.has(tagHandle)) {
-    state.tag = state.tagMap.get(tagHandle) + tagName;
-  } else if (tagHandle === "!") {
-    state.tag = `!${tagName}`;
-  } else if (tagHandle === "!!") {
-    state.tag = `tag:yaml.org,2002:${tagName}`;
-  } else {
-    return state.throwError(`undeclared tag handle "${tagHandle}"`);
-  }
-
-  return true;
-}
-
-function readAnchorProperty(state: LoaderState): boolean {
-  let ch = state.peek();
-  if (ch !== AMPERSAND) return false;
-
-  if (state.anchor !== null) {
-    return state.throwError("duplication of an anchor property");
-  }
-  ch = state.next();
-
-  const position = state.position;
-  while (ch !== 0 && !isWhiteSpaceOrEOL(ch) && !isFlowIndicator(ch)) {
-    ch = state.next();
-  }
-
-  if (state.position === position) {
-    return state.throwError(
-      "name of an anchor node must contain at least one character",
-    );
-  }
-
-  state.anchor = state.input.slice(position, state.position);
-  return true;
-}
-
-function readAlias(state: LoaderState): boolean {
-  if (state.peek() !== ASTERISK) return false;
-
-  let ch = state.next();
-
-  const position = state.position;
-
-  while (ch !== 0 && !isWhiteSpaceOrEOL(ch) && !isFlowIndicator(ch)) {
-    ch = state.next();
-  }
-
-  if (state.position === position) {
-    return state.throwError(
-      "name of an alias node must contain at least one character",
-    );
-  }
-
-  const alias = state.input.slice(position, state.position);
-  if (!state.anchorMap.has(alias)) {
-    return state.throwError(`unidentified alias "${alias}"`);
-  }
-
-  state.result = state.anchorMap.get(alias);
-  skipSeparationSpace(state, true, -1);
-  return true;
-}
-
-function composeNode(
-  state: LoaderState,
-  parentIndent: number,
-  nodeContext: number,
-  allowToSeek: boolean,
-  allowCompact: boolean,
-): boolean {
-  let allowBlockScalars: boolean;
-  let allowBlockCollections: boolean;
-  let indentStatus = 1; // 1: this>parent, 0: this=parent, -1: this<parent
-  let atNewLine = false;
-  let hasContent = false;
-  let type: Type<KindType>;
-  let flowIndent: number;
-  let blockIndent: number;
-
-  state.tag = null;
-  state.anchor = null;
-  state.kind = null;
-  state.result = null;
-
-  const allowBlockStyles = (allowBlockScalars =
-    allowBlockCollections =
-      CONTEXT_BLOCK_OUT === nodeContext || CONTEXT_BLOCK_IN === nodeContext);
-
-  if (allowToSeek) {
-    if (skipSeparationSpace(state, true, -1)) {
-      atNewLine = true;
-
-      if (state.lineIndent > parentIndent) {
-        indentStatus = 1;
-      } else if (state.lineIndent === parentIndent) {
-        indentStatus = 0;
-      } else if (state.lineIndent < parentIndent) {
-        indentStatus = -1;
-      }
-    }
-  }
-
-  if (indentStatus === 1) {
-    while (readTagProperty(state) || readAnchorProperty(state)) {
-      if (skipSeparationSpace(state, true, -1)) {
-        atNewLine = true;
-        allowBlockCollections = allowBlockStyles;
-
-        if (state.lineIndent > parentIndent) {
-          indentStatus = 1;
-        } else if (state.lineIndent === parentIndent) {
-          indentStatus = 0;
-        } else if (state.lineIndent < parentIndent) {
-          indentStatus = -1;
-        }
-      } else {
-        allowBlockCollections = false;
-      }
-    }
-  }
-
-  if (allowBlockCollections) {
-    allowBlockCollections = atNewLine || allowCompact;
-  }
-
-  if (indentStatus === 1 || CONTEXT_BLOCK_OUT === nodeContext) {
-    const cond = CONTEXT_FLOW_IN === nodeContext ||
-      CONTEXT_FLOW_OUT === nodeContext;
-    flowIndent = cond ? parentIndent : parentIndent + 1;
-
-    blockIndent = state.position - state.lineStart;
-
-    if (indentStatus === 1) {
-      if (
-        (allowBlockCollections &&
-          (readBlockSequence(state, blockIndent) ||
-            readBlockMapping(state, blockIndent, flowIndent))) ||
-        readFlowCollection(state, flowIndent)
-      ) {
-        hasContent = true;
-      } else {
-        if (
-          (allowBlockScalars && readBlockScalar(state, flowIndent)) ||
-          readSingleQuotedScalar(state, flowIndent) ||
-          readDoubleQuotedScalar(state, flowIndent)
-        ) {
-          hasContent = true;
-        } else if (readAlias(state)) {
-          hasContent = true;
-
-          if (state.tag !== null || state.anchor !== null) {
-            return state.throwError(
-              "alias node should not have Any properties",
-            );
-          }
-        } else if (
-          readPlainScalar(state, flowIndent, CONTEXT_FLOW_IN === nodeContext)
-        ) {
-          hasContent = true;
-
-          if (state.tag === null) {
-            state.tag = "?";
-          }
-        }
-
-        if (state.anchor !== null) {
-          state.anchorMap.set(state.anchor, state.result);
-        }
-      }
-    } else if (indentStatus === 0) {
-      // Special case: block sequences are allowed to have same indentation level as the parent.
-      // http://www.yaml.org/spec/1.2/spec.html#id2799784
-      hasContent = allowBlockCollections &&
-        readBlockSequence(state, blockIndent);
-    }
-  }
-
-  if (state.tag !== null && state.tag !== "!") {
-    if (state.tag === "?") {
-      for (
-        let typeIndex = 0;
-        typeIndex < state.implicitTypes.length;
-        typeIndex++
-      ) {
-        type = state.implicitTypes[typeIndex]!;
-
-        // Implicit resolving is not allowed for non-scalar types, and '?'
-        // non-specific tag is only assigned to plain scalars. So, it isn't
-        // needed to check for 'kind' conformity.
-
-        if (type.resolve(state.result)) {
-          // `state.result` updated in resolver if matched
-          state.result = type.construct(state.result);
-          state.tag = type.tag;
-          if (state.anchor !== null) {
-            state.anchorMap.set(state.anchor, state.result);
-          }
-          break;
-        }
-      }
-    } else if (state.typeMap[state.kind ?? "fallback"].has(state.tag)) {
-      const map = state.typeMap[state.kind ?? "fallback"];
-      type = map.get(state.tag)!;
-
-      if (state.result !== null && type.kind !== state.kind) {
-        return state.throwError(
-          `unacceptable node kind for !<${state.tag}> tag; it should be "${type.kind}", not "${state.kind}"`,
-        );
-      }
-
-      if (!type.resolve(state.result)) {
-        // `state.result` updated in resolver if matched
-        return state.throwError(
-          `cannot resolve a node with !<${state.tag}> explicit tag`,
-        );
-      } else {
-        state.result = type.construct(state.result);
-        if (state.anchor !== null) {
-          state.anchorMap.set(state.anchor, state.result);
-        }
-      }
-    } else {
-      return state.throwError(`unknown tag !<${state.tag}>`);
-    }
-  }
-
-  return state.tag !== null || state.anchor !== null || hasContent;
 }


### PR DESCRIPTION
**Changes**
This PR moves state functions into the `LoaderState` class as methods.

**Reasoning**
It removes the need to pass `state` as an argument.
This change also allows for the removal of obsolete code and optimizations of some functions in other PRs.

**Note**
The diff of this PR looks like there are lots of changes. The code inside the functions is untouched except using `this` instead of the `state`.