### PR TITLE
perf(cli,http,ini,internal,media-types): replace `trim()` comparisons with regexps

### DIFF
--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -371,8 +371,10 @@ const VALUE_REGEXP = /=(?<value>.+)/;
 const FLAG_NAME_REGEXP = /^--[^=]+$/;
 const SPECIAL_CHAR_REGEXP = /\W/;
 
+const NON_WHITESPACE_REGEXP = /\S/;
+
 function isNumber(string: string): boolean {
-  return string.trim() !== "" && Number.isFinite(Number(string));
+  return NON_WHITESPACE_REGEXP.test(string) && Number.isFinite(Number(string));
 }
 
 function setNested(

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -161,6 +161,9 @@ export async function eTag(
   return tag ? weak ? `W/"${tag}"` : `"${tag}"` : undefined;
 }
 
+const STAR_REGEXP = /^\s*\*\s*$/;
+const COMMA_REGEXP = /\s*,\s*/;
+
 /** A helper function that takes the value from the `If-Match` header and a
  * calculated etag for the target. By using strong comparison, return `true` if
  * the values match, otherwise `false`.
@@ -202,10 +205,10 @@ export function ifMatch(
   if (!value || !etag || etag.startsWith("W/")) {
     return false;
   }
-  if (value.trim() === "*") {
+  if (STAR_REGEXP.test(value)) {
     return true;
   }
-  const tags = value.split(/\s*,\s*/);
+  const tags = value.split(COMMA_REGEXP);
   return tags.includes(etag);
 }
 
@@ -249,11 +252,11 @@ export function ifNoneMatch(
   if (!value || !etag) {
     return true;
   }
-  if (value.trim() === "*") {
+  if (STAR_REGEXP.test(value)) {
     return false;
   }
   etag = etag.startsWith("W/") ? etag.slice(2) : etag;
-  const tags = value.split(/\s*,\s*/).map((tag) =>
+  const tags = value.split(COMMA_REGEXP).map((tag) =>
     tag.startsWith("W/") ? tag.slice(2) : tag
   );
   return !tags.includes(etag);

--- a/ini/_ini_map.ts
+++ b/ini/_ini_map.ts
@@ -49,6 +49,8 @@ function trimQuotes(value: string): string {
   return value;
 }
 
+const NON_WHITESPACE_REGEXP = /\S/;
+
 /**
  * Class implementation for fine control of INI data structures.
  */
@@ -315,7 +317,7 @@ export class IniMap<T = any> {
       } else if (isSection(trimmed, lineNumber)) {
         const sec = trimmed.substring(1, trimmed.length - 1);
 
-        if (sec.trim() === "") {
+        if (!NON_WHITESPACE_REGEXP.test(sec)) {
           throw new SyntaxError(
             `Unexpected empty section name at line ${lineNumber}`,
           );

--- a/internal/diff_str.ts
+++ b/internal/diff_str.ts
@@ -114,6 +114,8 @@ export function createDetails(
     });
 }
 
+const NON_WHITESPACE_REGEXP = /\S/;
+
 /**
  * Renders the differences between the actual and expected strings. Partially
  * inspired from {@link https://github.com/kpdecker/jsdiff}.
@@ -185,7 +187,7 @@ export function diffStr(A: string, B: string): DiffResult<string>[] {
       tokens = diff(tokenized[0], tokenized[1]);
       if (
         tokens.some(({ type, value }) =>
-          type === "common" && value.trim().length
+          type === "common" && NON_WHITESPACE_REGEXP.test(value)
         )
       ) {
         break;

--- a/media_types/parse_media_type.ts
+++ b/media_types/parse_media_type.ts
@@ -3,6 +3,7 @@
 
 import { consumeMediaParam, decode2331Encoding } from "./_util.ts";
 
+const SEMICOLON_REGEXP = /^\s*;\s*$/;
 /**
  * Parses the media type and any optional parameters, per
  * {@link https://www.rfc-editor.org/rfc/rfc1521.html | RFC 1521}.
@@ -51,7 +52,7 @@ export function parseMediaType(
     }
     const [key, value, rest] = consumeMediaParam(type);
     if (!key) {
-      if (rest.trim() === ";") {
+      if (SEMICOLON_REGEXP.test(rest)) {
         // ignore trailing semicolons
         break;
       }


### PR DESCRIPTION
**Changes**
This replaces comparisons done with `trim()` with `RegExp.test()`

**Reasoning**
`trim()` creates a new string which is only used for the comparison and thus not memory efficient.