### PR TITLE
fix(front-matter): remove os specific newline

### DIFF
--- a/front_matter/_formats.ts
+++ b/front_matter/_formats.ts
@@ -21,9 +21,7 @@ const JSON_HEADER = `(---json|${JSON_DELIMITER})\\s*`;
 const JSON_FOOTER = `(?:---|${JSON_DELIMITER})`;
 
 const DATA = "([\\s\\S]+?)";
-const NEWLINE = `${
-  globalThis?.Deno?.build?.os === "windows" ? "\\r?" : ""
-}(?:\\n)?`;
+const NEWLINE = "\\r?\\n?";
 
 export const RECOGNIZE_YAML_REGEXP = new RegExp(`^${YAML_HEADER}$`, "im");
 export const RECOGNIZE_TOML_REGEXP = new RegExp(`^${TOML_HEADER}$`, "im");


### PR DESCRIPTION
**Changes**
This PR removes the os specific check for `\r?` before `\n`.

**Reasoning**
This is the only occurrence where a os check is done. Even the `recognize()` function in the same module doesn't do it:
https://github.com/denoland/std/blob/99200dcd9039eea515f3f850b2f13cf7be585d03/front_matter/_shared.ts#L36