### PR TITLE
refactor(webgpu): align additional error messages

### DIFF
--- a/webgpu/texture_with_data.ts
+++ b/webgpu/texture_with_data.ts
@@ -19,7 +19,7 @@ function normalizeExtent3D(size: GPUExtent3D): GPUExtent3DDict {
   if (Array.isArray(size)) {
     if (size[0] === undefined) {
       throw new TypeError(
-        "Cannot normalize Extend3d: size[0] specifies the width and it must be defined",
+        "Cannot normalize Extent3d: width is not defined",
       );
     }
     return {

--- a/webgpu/texture_with_data.ts
+++ b/webgpu/texture_with_data.ts
@@ -17,7 +17,11 @@ function textureDimensionArrayLayerCount(
 
 function normalizeExtent3D(size: GPUExtent3D): GPUExtent3DDict {
   if (Array.isArray(size)) {
-    if (size[0] === undefined) throw new TypeError("Width must be defined");
+    if (size[0] === undefined) {
+      throw new TypeError(
+        "Cannot normalize Extend3d: size[0] specifies the width and it must be defined",
+      );
+    }
     return {
       width: size[0],
       height: size[1],


### PR DESCRIPTION
Aligns the error messages in the `webgpu` folder to match the style guide.

https://github.com/denoland/std/issues/5574