### PR TITLE
refactor(async): align the error messages to the style guide

### DIFF
--- a/async/pool.ts
+++ b/async/pool.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 /** Error message emitted from the thrown error while mapping. */
-const ERROR_WHILE_MAPPING_MESSAGE = "Threw while mapping.";
+const ERROR_WHILE_MAPPING_MESSAGE = "Threw while mapping";
 
 /**
  * pooledMap transforms values from an (async) iterable into another async

--- a/async/pool.ts
+++ b/async/pool.ts
@@ -2,7 +2,8 @@
 // This module is browser compatible.
 
 /** Error message emitted from the thrown error while mapping. */
-const ERROR_WHILE_MAPPING_MESSAGE = "Cannot complete the mapping as an error was thrown from an item";
+const ERROR_WHILE_MAPPING_MESSAGE =
+  "Cannot complete the mapping as an error was thrown from an item";
 
 /**
  * pooledMap transforms values from an (async) iterable into another async

--- a/async/pool.ts
+++ b/async/pool.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 /** Error message emitted from the thrown error while mapping. */
-const ERROR_WHILE_MAPPING_MESSAGE = "Threw while mapping";
+const ERROR_WHILE_MAPPING_MESSAGE = "Cannot complete the mapping as an error was thrown from an item";
 
 /**
  * pooledMap transforms values from an (async) iterable into another async

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -38,7 +38,7 @@ Deno.test("pooledMap() handles errors", async () => {
       }
     },
     AggregateError,
-    "Threw while mapping.",
+    "Threw while mapping",
   );
   assertEquals(error.errors.length, 2);
   assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -38,7 +38,7 @@ Deno.test("pooledMap() handles errors", async () => {
       }
     },
     AggregateError,
-    "Threw while mapping",
+    "Cannot complete the mapping as an error was thrown from an item",
   );
   assertEquals(error.errors.length, 2);
   assertStringIncludes(error.errors[0].stack, "Error: Bad number: 1");

--- a/async/retry.ts
+++ b/async/retry.ts
@@ -134,11 +134,21 @@ export async function retry<T>(
     ...opts,
   };
 
-  if (options.maxTimeout <= 0) throw new TypeError("maxTimeout is less than 0");
-  if (options.minTimeout > options.maxTimeout) {
-    throw new TypeError("minTimeout is greater than maxTimeout");
+  if (options.maxTimeout <= 0) {
+    throw new TypeError(
+      `'maxTimeout' must be positive: current value is ${options.maxTimeout}`,
+    );
   }
-  if (options.jitter > 1) throw new TypeError("jitter is greater than 1");
+  if (options.minTimeout > options.maxTimeout) {
+    throw new TypeError(
+      `'minTimeout' must be <= 'maxTimeout': current values 'minTimeout=${options.minTimeout}', 'maxTimeout=${options.maxTimeout}'`,
+    );
+  }
+  if (options.jitter > 1) {
+    throw new TypeError(
+      `'jitter' must be <= 1: current value is ${options.jitter}`,
+    );
+  }
 
   let attempt = 0;
   while (true) {

--- a/async/retry.ts
+++ b/async/retry.ts
@@ -136,17 +136,17 @@ export async function retry<T>(
 
   if (options.maxTimeout <= 0) {
     throw new TypeError(
-      `'maxTimeout' must be positive: current value is ${options.maxTimeout}`,
+      `Cannot retry as 'maxTimeout' must be positive: current value is ${options.maxTimeout}`,
     );
   }
   if (options.minTimeout > options.maxTimeout) {
     throw new TypeError(
-      `'minTimeout' must be <= 'maxTimeout': current values 'minTimeout=${options.minTimeout}', 'maxTimeout=${options.maxTimeout}'`,
+      `Cannot retry as 'minTimeout' must be <= 'maxTimeout': current values 'minTimeout=${options.minTimeout}', 'maxTimeout=${options.maxTimeout}'`,
     );
   }
   if (options.jitter > 1) {
     throw new TypeError(
-      `'jitter' must be <= 1: current value is ${options.jitter}`,
+      `Cannot retry as 'jitter' must be <= 1: current value is ${options.jitter}`,
     );
   }
 

--- a/async/retry_test.ts
+++ b/async/retry_test.ts
@@ -64,7 +64,7 @@ Deno.test(
           maxTimeout: 100,
         }),
       TypeError,
-      "minTimeout is greater than maxTimeout",
+      "'minTimeout' must be <= 'maxTimeout': current values 'minTimeout=1000', 'maxTimeout=100'",
     );
   },
 );
@@ -78,7 +78,7 @@ Deno.test(
           maxTimeout: -1,
         }),
       TypeError,
-      "maxTimeout is less than 0",
+      "'maxTimeout' must be positive: current value is -1",
     );
   },
 );
@@ -92,7 +92,7 @@ Deno.test(
           jitter: 2,
         }),
       TypeError,
-      "jitter is greater than 1",
+      "'jitter' must be <= 1: current value is 2",
     );
   },
 );

--- a/async/retry_test.ts
+++ b/async/retry_test.ts
@@ -64,7 +64,7 @@ Deno.test(
           maxTimeout: 100,
         }),
       TypeError,
-      "'minTimeout' must be <= 'maxTimeout': current values 'minTimeout=1000', 'maxTimeout=100'",
+      "Cannot retry as 'minTimeout' must be <= 'maxTimeout': current values 'minTimeout=1000', 'maxTimeout=100'",
     );
   },
 );
@@ -78,7 +78,7 @@ Deno.test(
           maxTimeout: -1,
         }),
       TypeError,
-      "'maxTimeout' must be positive: current value is -1",
+      "Cannot retry as 'maxTimeout' must be positive: current value is -1",
     );
   },
 );
@@ -92,7 +92,7 @@ Deno.test(
           jitter: 2,
         }),
       TypeError,
-      "'jitter' must be <= 1: current value is 2",
+      "Cannot retry as 'jitter' must be <= 1: current value is 2",
     );
   },
 );


### PR DESCRIPTION
Aligns the error messages in the `async` folder to match the style guide.

https://github.com/denoland/std/issues/5574