### PR TITLE
refactor(yaml): remove `ArrayObject`

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -28,7 +28,7 @@ import {
 } from "./_chars.ts";
 import { DEFAULT_SCHEMA, type Schema } from "./_schema.ts";
 import type { KindType, StyleVariant, Type } from "./_type.ts";
-import { type ArrayObject, getObjectTypeString, isObject } from "./_utils.ts";
+import { getObjectTypeString, isObject } from "./_utils.ts";
 
 const STYLE_PLAIN = 1;
 const STYLE_SINGLE = 2;
@@ -89,11 +89,11 @@ function charCodeToHexString(charCode: number): string {
 }
 
 function compileStyleMap(
-  map?: ArrayObject<StyleVariant> | null,
-): ArrayObject<StyleVariant> {
+  map?: Record<string, StyleVariant> | null,
+): Record<string, StyleVariant> {
   if (typeof map === "undefined" || map === null) return {};
 
-  const result: ArrayObject<StyleVariant> = {};
+  const result: Record<string, StyleVariant> = {};
   for (let tag of Object.keys(map)) {
     const style = String(map[tag]) as StyleVariant;
     if (tag.slice(0, 2) === "!!") {
@@ -429,7 +429,7 @@ export interface DumperStateOptions {
    */
   flowLevel?: number;
   /** Each tag may have own set of styles.	- "tag" => "style" map. */
-  styles?: ArrayObject<StyleVariant> | null;
+  styles?: Record<string, StyleVariant> | null;
   /** specifies a schema to use. */
   schema?: Schema;
   /**
@@ -477,7 +477,7 @@ export class DumperState {
   explicitTypes: Type<KindType>[];
   duplicates: unknown[] = [];
   usedDuplicates: Set<unknown> = new Set();
-  styleMap: ArrayObject<StyleVariant>;
+  styleMap: Record<string, StyleVariant>;
 
   constructor({
     schema = DEFAULT_SCHEMA,

--- a/yaml/_loader_state.ts
+++ b/yaml/_loader_state.ts
@@ -38,7 +38,7 @@ import {
 import { Mark } from "./_mark.ts";
 import { DEFAULT_SCHEMA, type Schema, type TypeMap } from "./_schema.ts";
 import type { KindType, Type } from "./_type.ts";
-import { type ArrayObject, getObjectTypeString, isObject } from "./_utils.ts";
+import { getObjectTypeString, isObject } from "./_utils.ts";
 
 const CONTEXT_FLOW_IN = 1;
 const CONTEXT_FLOW_OUT = 2;
@@ -424,8 +424,8 @@ function captureSegment(
 
 function mergeMappings(
   state: LoaderState,
-  destination: ArrayObject,
-  source: ArrayObject,
+  destination: Record<string, unknown>,
+  source: Record<string, unknown>,
   overridableKeys: Set<string>,
 ) {
   if (!isObject(source)) {
@@ -448,14 +448,14 @@ function mergeMappings(
 
 function storeMappingPair(
   state: LoaderState,
-  result: ArrayObject | null,
+  result: Record<string, unknown> | null,
   overridableKeys: Set<string>,
   keyTag: string | null,
   keyNode: Record<PropertyKey, unknown> | unknown[] | string | null,
   valueNode: unknown,
   startLine?: number,
   startPos?: number,
-): ArrayObject {
+): Record<string, unknown> {
   // The output is a plain object here, so keys can only be strings.
   // We need to convert keyNode to a string, but doing so can hang the process
   // (deeply nested arrays that explode exponentially using aliases).
@@ -502,7 +502,12 @@ function storeMappingPair(
         mergeMappings(state, result, valueNode[index], overridableKeys);
       }
     } else {
-      mergeMappings(state, result, valueNode as ArrayObject, overridableKeys);
+      mergeMappings(
+        state,
+        result,
+        valueNode as Record<string, unknown>,
+        overridableKeys,
+      );
     }
   } else {
     if (
@@ -935,14 +940,14 @@ function readFlowCollection(state: LoaderState, nodeIndent: number): boolean {
     if (isMapping) {
       storeMappingPair(
         state,
-        result,
+        result as Record<string, unknown>,
         overridableKeys,
         keyTag,
         keyNode,
         valueNode,
       );
     } else if (isPair) {
-      (result as ArrayObject[]).push(
+      (result as Record<string, unknown>[]).push(
         storeMappingPair(
           state,
           null,

--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -4,8 +4,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import type { ArrayObject } from "./_utils.ts";
-
 export type KindType = "sequence" | "scalar" | "mapping";
 /**
  * The style variation for `styles` option of {@linkcode stringify}
@@ -26,7 +24,7 @@ export interface Type<K extends KindType, D = any> {
   tag: string;
   kind: K;
   predicate?: (data: unknown) => data is D;
-  represent?: RepresentFn<D> | ArrayObject<RepresentFn<D>>;
+  represent?: RepresentFn<D> | Record<string, RepresentFn<D>>;
   defaultStyle?: StyleVariant;
   // deno-lint-ignore no-explicit-any
   resolve: (data: any) => boolean;

--- a/yaml/_utils.ts
+++ b/yaml/_utils.ts
@@ -3,11 +3,6 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-// deno-lint-ignore no-explicit-any
-export interface ArrayObject<T = any> {
-  [P: string]: T;
-}
-
 export function isBoolean(value: unknown): value is boolean {
   return typeof value === "boolean" || value instanceof Boolean;
 }


### PR DESCRIPTION
**Changes**
This PR replaces the `ArrayObject` type with `Record<string, unknown>`

**Reasoning**
`ArrayObject` is a generic `Record` type which doesn't need to be generic where it is used.