### PR TITLE
refactor(internal): align additional error messages

### DIFF
--- a/internal/diff.ts
+++ b/internal/diff.ts
@@ -77,7 +77,9 @@ export function assertFp(value: unknown): asserts value is FarthestPoint {
     typeof (value as FarthestPoint)?.y !== "number" ||
     typeof (value as FarthestPoint)?.id !== "number"
   ) {
-    throw new Error("Unexpected missing FarthestPoint");
+    throw new Error(
+      `Unexpected value, expected 'FarthestPoint': received ${typeof value}`,
+    );
   }
 }
 

--- a/internal/diff_test.ts
+++ b/internal/diff_test.ts
@@ -134,11 +134,26 @@ Deno.test({
 Deno.test({
   name: "assertFp() throws",
   fn() {
-    const error = "Unexpected missing FarthestPoint";
-    assertThrows(() => assertFp({ id: 0 }), Error, error);
-    assertThrows(() => assertFp({ y: 0 }), Error, error);
-    assertThrows(() => assertFp(undefined), Error, error);
-    assertThrows(() => assertFp(null), Error, error);
+    assertThrows(
+      () => assertFp({ id: 0 }),
+      Error,
+      "Unexpected value, expected 'FarthestPoint': received object",
+    );
+    assertThrows(
+      () => assertFp({ y: 0 }),
+      Error,
+      "Unexpected value, expected 'FarthestPoint': received object",
+    );
+    assertThrows(
+      () => assertFp(undefined),
+      Error,
+      "Unexpected value, expected 'FarthestPoint': received undefined",
+    );
+    assertThrows(
+      () => assertFp(null),
+      Error,
+      "Unexpected value, expected 'FarthestPoint': received object",
+    );
   },
 });
 


### PR DESCRIPTION
Aligns the error messages in the `internal` folder to match the style guide.

https://github.com/denoland/std/issues/5574