### PR TITLE
refactor(encoding): align additional error messages

### DIFF
--- a/encoding/_base32_common.ts
+++ b/encoding/_base32_common.ts
@@ -22,7 +22,9 @@ function getLens(b32: string): [number, number] {
   const len = b32.length;
 
   if (len % 8 > 0) {
-    throw new Error("Invalid string. Length must be a multiple of 8");
+    throw new Error(
+      `String length must be a multiple of 8: received length ${len}`,
+    );
   }
 
   let validLen = b32.indexOf("=");

--- a/encoding/_validate_binary_like.ts
+++ b/encoding/_validate_binary_like.ts
@@ -22,8 +22,8 @@ export function validateBinaryLike(source: unknown): Uint8Array {
     return new Uint8Array(source);
   }
   throw new TypeError(
-    `The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type ${
+    `The input must be a Uint8Array, a string, or an ArrayBuffer: received a value of the type ${
       getTypeName(source)
-    }.`,
+    }`,
   );
 }

--- a/encoding/_validate_binary_like_test.ts
+++ b/encoding/_validate_binary_like_test.ts
@@ -21,41 +21,41 @@ Deno.test("validateBinaryLike() throws on invalid inputs", () => {
       validateBinaryLike(1);
     },
     TypeError,
-    "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type number.",
+    "The input must be a Uint8Array, a string, or an ArrayBuffer: received a value of the type number",
   );
   assertThrows(
     () => {
       validateBinaryLike(undefined);
     },
     TypeError,
-    "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type undefined.",
+    "The input must be a Uint8Array, a string, or an ArrayBuffer: received a value of the type undefined",
   );
   assertThrows(
     () => {
       validateBinaryLike(null);
     },
     TypeError,
-    "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type null.",
+    "The input must be a Uint8Array, a string, or an ArrayBuffer: received a value of the type null",
   );
   assertThrows(
     () => {
       validateBinaryLike({});
     },
     TypeError,
-    "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type Object.",
+    "The input must be a Uint8Array, a string, or an ArrayBuffer: received a value of the type Object",
   );
   assertThrows(
     () => {
       validateBinaryLike(new class MyClass {}());
     },
     TypeError,
-    "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type MyClass.",
+    "The input must be a Uint8Array, a string, or an ArrayBuffer: received a value of the type MyClass",
   );
   assertThrows(
     () => {
       validateBinaryLike(Object.create(null));
     },
     TypeError,
-    "The input must be a Uint8Array, a string, or an ArrayBuffer. Received a value of the type object.",
+    "The input must be a Uint8Array, a string, or an ArrayBuffer: received a value of the type object",
   );
 });

--- a/encoding/base32_test.ts
+++ b/encoding/base32_test.ts
@@ -39,7 +39,7 @@ Deno.test({
     assertThrows(
       () => decodeBase32("OOOO=="),
       Error,
-      "Invalid string. Length must be a multiple of 8",
+      "String length must be a multiple of 8: received length 6",
     );
   },
 });

--- a/encoding/base32hex_test.ts
+++ b/encoding/base32hex_test.ts
@@ -39,7 +39,7 @@ Deno.test({
     assertThrows(
       () => decodeBase32Hex("OOOO=="),
       Error,
-      "Invalid string. Length must be a multiple of 8",
+      "String length must be a multiple of 8: received length 6",
     );
   },
 });

--- a/encoding/base64url.ts
+++ b/encoding/base64url.ts
@@ -21,7 +21,7 @@ function addPaddingToBase64url(base64url: string): string {
   if (base64url.length % 4 === 2) return base64url + "==";
   if (base64url.length % 4 === 3) return base64url + "=";
   if (base64url.length % 4 === 1) {
-    throw new TypeError("Illegal base64url string!");
+    throw new TypeError("Illegal base64url string");
   }
   return base64url;
 }

--- a/encoding/base64url_test.ts
+++ b/encoding/base64url_test.ts
@@ -67,7 +67,7 @@ Deno.test("decodeBase64Url() throws on illegal base64url string", () => {
     assertThrows(
       () => decodeBase64Url(illegalBase64url),
       TypeError,
-      "Illegal base64url string!",
+      "Illegal base64url string",
     );
   }
 });

--- a/encoding/hex.ts
+++ b/encoding/hex.ts
@@ -36,8 +36,8 @@ function errInvalidByte(byte: number) {
   return new TypeError(`Invalid byte '${String.fromCharCode(byte)}'`);
 }
 
-function errLength() {
-  return new RangeError("Odd length hex string");
+function errLength(len: number) {
+  return new RangeError(`Hex length should be even: length is ${len}`);
 }
 
 /** Converts a hex character into its value. */
@@ -111,7 +111,7 @@ export function decodeHex(src: string): Uint8Array {
     // Check for invalid char before reporting bad length,
     // since the invalid char (if present) is an earlier problem.
     fromHexChar(u8[dst.length * 2]!);
-    throw errLength();
+    throw errLength(u8.length);
   }
 
   return dst;

--- a/encoding/varint.ts
+++ b/encoding/varint.ts
@@ -131,7 +131,7 @@ export function decodeVarint(buf: Uint8Array, offset = 0): [bigint, number] {
   // If 11 bytes have been read it means that the varint is malformed
   // If `i` is bigger than the buffer it means we overread the buffer and the varint is malformed
   if ((nRead === 10 && intermediate > -1) || nRead === 11 || i > buf.length) {
-    throw new RangeError("malformed or overflow varint");
+    throw new RangeError("Malformed or overflow varint");
   }
 
   // Write the intermediate value to the "empty" slot
@@ -178,7 +178,7 @@ export function decodeVarint32(buf: Uint8Array, offset = 0): [number, number] {
     decoded += (byte & REST) * Math.pow(2, shift);
     if (!(byte & MSB)) return [decoded, i + 1];
   }
-  throw new RangeError("malformed or overflow varint");
+  throw new RangeError("Malformed or overflow varint");
 }
 
 /**
@@ -214,7 +214,11 @@ export function encodeVarint(
   offset = 0,
 ): [Uint8Array, number] {
   num = BigInt(num);
-  if (num < 0n) throw new RangeError("signed input given");
+  if (num < 0n) {
+    throw new RangeError(
+      "Argument 'num' should be unsigned: received a signed number",
+    );
+  }
   for (
     let i = offset;
     i <= Math.min(buf.length, MaxVarintLen64);
@@ -228,5 +232,5 @@ export function encodeVarint(
     buf[i] = Number((num & 0xFFn) | MSBN);
     num >>= SHIFTN;
   }
-  throw new RangeError(`${num} overflows uint64`);
+  throw new RangeError(`Overflow error: ${num} overflows uint64`);
 }

--- a/encoding/varint_test.ts
+++ b/encoding/varint_test.ts
@@ -114,7 +114,11 @@ Deno.test("encodeVarint() throws on overflow uint64", () => {
   assertThrows(() => encodeVarint(1e+30), RangeError, "overflows uint64");
 });
 Deno.test("encodeVarint() throws on overflow with negative", () => {
-  assertThrows(() => encodeVarint(-1), RangeError, "signed input given");
+  assertThrows(
+    () => encodeVarint(-1),
+    RangeError,
+    "Argument 'num' should be unsigned: received a signed number",
+  );
 });
 Deno.test("encodeVarint() encodes with offset", () => {
   let uint = new Uint8Array(3);


### PR DESCRIPTION
Aligns the error messages in the `encoding` folder to match the style guide.

https://github.com/denoland/std/issues/5574