### PR TITLE
refactor(yaml): use `Set` in `inspectNode()`

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -396,15 +396,15 @@ function blockHeader(string: string, indentPerLevel: number): string {
 
 function inspectNode(
   object: unknown,
-  objects: unknown[],
+  objects: Set<unknown>,
   duplicateObjects: Set<unknown>,
 ) {
   if (!isObject(object)) return;
-  if (objects.includes(object)) {
+  if (objects.has(object)) {
     duplicateObjects.add(object);
     return;
   }
-  objects.push(object);
+  objects.add(object);
   const entries = Array.isArray(object) ? object : Object.values(object);
   for (const value of entries) {
     inspectNode(value, objects, duplicateObjects);
@@ -885,7 +885,7 @@ export class DumperState {
   }
 
   getDuplicateReferences(value: unknown) {
-    const values: unknown[] = [];
+    const values: Set<unknown> = new Set();
     const duplicateObjects: Set<unknown> = new Set();
 
     inspectNode(value, values, duplicateObjects);


### PR DESCRIPTION
**Changes**
This PR replaces the usage of an array with a `Set`.

**Reasoning**
The array is only used to check existing data.