### PR TITLE
refactor(assert): align additional error messages

### DIFF
--- a/assert/almost_equals.ts
+++ b/assert/almost_equals.ts
@@ -46,7 +46,7 @@ export function assertAlmostEquals(
     return;
   }
 
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   const f = (n: number) => Number.isInteger(n) ? n : n.toExponential();
   throw new AssertionError(
     `Expected actual: "${f(actual)}" to be close to "${f(expected)}": \

--- a/assert/array_includes.ts
+++ b/assert/array_includes.ts
@@ -49,7 +49,7 @@ export function assertArrayIncludes<T>(
     return;
   }
 
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   msg = `Expected actual: "${format(actual)}" to include: "${
     format(expected)
   }"${msgSuffix}\nmissing: ${format(missing)}`;

--- a/assert/array_includes_test.ts
+++ b/assert/array_includes_test.ts
@@ -24,7 +24,7 @@ Expected actual: "[
   "a",
 ]" to include: "[
   "b",
-]".
+]"
 missing: [
   "b",
 ]
@@ -46,7 +46,7 @@ Expected actual: "[
   {
     deno: "node",
   },
-]".
+]"
 missing: [
   {
     deno: "node",

--- a/assert/equals.ts
+++ b/assert/equals.ts
@@ -32,7 +32,7 @@ export function assertEquals<T>(
   if (equal(actual, expected)) {
     return;
   }
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   let message = `Values are not equal${msgSuffix}`;
 
   const actualString = format(actual);

--- a/assert/equals_test.ts
+++ b/assert/equals_test.ts
@@ -45,7 +45,7 @@ Deno.test({
       () => assertEquals(1, 2),
       AssertionError,
       [
-        "Values are not equal.",
+        "Values are not equal",
         ...createHeader(),
         removed(`-   ${yellow("1")}`),
         added(`+   ${yellow("2")}`),
@@ -62,7 +62,7 @@ Deno.test({
       () => assertEquals<unknown>(1, "1"),
       AssertionError,
       [
-        "Values are not equal.",
+        "Values are not equal",
         ...createHeader(),
         removed(`-   ${yellow("1")}`),
         added(`+   "1"`),
@@ -119,7 +119,7 @@ Deno.test({
         ),
       AssertionError,
       [
-        "Values are not equal.",
+        "Values are not equal",
         ...createHeader(),
         removed(`-   ${new Date(2019, 0, 3, 4, 20, 1, 10).toISOString()}`),
         added(`+   ${new Date(2019, 0, 3, 4, 20, 1, 20).toISOString()}`),
@@ -131,7 +131,7 @@ Deno.test({
         assertEquals(new Date("invalid"), new Date(2019, 0, 3, 4, 20, 1, 20)),
       AssertionError,
       [
-        "Values are not equal.",
+        "Values are not equal",
         ...createHeader(),
         removed(`-   ${new Date("invalid")}`),
         added(`+   ${new Date(2019, 0, 3, 4, 20, 1, 20).toISOString()}`),

--- a/assert/exists.ts
+++ b/assert/exists.ts
@@ -23,7 +23,7 @@ export function assertExists<T>(
   msg?: string,
 ): asserts actual is NonNullable<T> {
   if (actual === undefined || actual === null) {
-    const msgSuffix = msg ? `: ${msg}` : ".";
+    const msgSuffix = msg ? `: ${msg}` : "";
     msg =
       `Expected actual: "${actual}" to not be null or undefined${msgSuffix}`;
     throw new AssertionError(msg);

--- a/assert/exists_test.ts
+++ b/assert/exists_test.ts
@@ -24,12 +24,12 @@ Deno.test("assertExists() throws when value is null or undefined", () => {
   assertThrows(
     () => assertExists(undefined),
     AssertionError,
-    'Expected actual: "undefined" to not be null or undefined.',
+    'Expected actual: "undefined" to not be null or undefined',
   );
   assertThrows(
     () => assertExists(null),
     AssertionError,
-    'Expected actual: "null" to not be null or undefined.',
+    'Expected actual: "null" to not be null or undefined',
   );
 });
 

--- a/assert/fail.ts
+++ b/assert/fail.ts
@@ -16,6 +16,6 @@ import { AssertionError } from "./assertion_error.ts";
  * @returns Never returns, always throws.
  */
 export function fail(msg?: string): never {
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   throw new AssertionError(`Failed assertion${msgSuffix}`);
 }

--- a/assert/fail_test.ts
+++ b/assert/fail_test.ts
@@ -2,7 +2,7 @@
 import { AssertionError, assertThrows, fail } from "./mod.ts";
 
 Deno.test("AssertFail", function () {
-  assertThrows(fail, AssertionError, "Failed assertion.");
+  assertThrows(fail, AssertionError, "Failed assertion");
   assertThrows(
     () => {
       fail("foo");

--- a/assert/instance_of.ts
+++ b/assert/instance_of.ts
@@ -34,7 +34,7 @@ export function assertInstanceOf<T extends AnyConstructor>(
 ): asserts actual is GetConstructorType<T> {
   if (actual instanceof expectedType) return;
 
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   const expectedTypeStr = expectedType.name;
 
   let actualTypeStr = "";

--- a/assert/instance_of_test.ts
+++ b/assert/instance_of_test.ts
@@ -18,17 +18,17 @@ Deno.test({
     assertThrows(
       () => assertInstanceOf(new Date(), RegExp),
       AssertionError,
-      `Expected object to be an instance of "RegExp" but was "Date".`,
+      `Expected object to be an instance of "RegExp" but was "Date"`,
     );
     assertThrows(
       () => assertInstanceOf(5, Date),
       AssertionError,
-      `Expected object to be an instance of "Date" but was "number".`,
+      `Expected object to be an instance of "Date" but was "number"`,
     );
     assertThrows(
       () => assertInstanceOf(new TestClass1(), TestClass2),
       AssertionError,
-      `Expected object to be an instance of "TestClass2" but was "TestClass1".`,
+      `Expected object to be an instance of "TestClass2" but was "TestClass1"`,
     );
 
     // Custom message
@@ -42,7 +42,7 @@ Deno.test({
     assertThrows(
       () => assertInstanceOf(5, Number),
       AssertionError,
-      `Expected object to be an instance of "Number" but was "number".`,
+      `Expected object to be an instance of "Number" but was "number"`,
     );
 
     let TestClassWithSameName: new () => unknown;
@@ -53,38 +53,38 @@ Deno.test({
     assertThrows(
       () => assertInstanceOf(new TestClassWithSameName(), TestClass3),
       AssertionError,
-      `Expected object to be an instance of "TestClass3".`,
+      `Expected object to be an instance of "TestClass3"`,
     );
 
     assertThrows(
       () => assertInstanceOf(TestClass1, TestClass1),
       AssertionError,
-      `Expected object to be an instance of "TestClass1" but was not an instanced object.`,
+      `Expected object to be an instance of "TestClass1" but was not an instanced object`,
     );
     assertThrows(
       () => assertInstanceOf(() => {}, TestClass1),
       AssertionError,
-      `Expected object to be an instance of "TestClass1" but was not an instanced object.`,
+      `Expected object to be an instance of "TestClass1" but was not an instanced object`,
     );
     assertThrows(
       () => assertInstanceOf(null, TestClass1),
       AssertionError,
-      `Expected object to be an instance of "TestClass1" but was "null".`,
+      `Expected object to be an instance of "TestClass1" but was "null"`,
     );
     assertThrows(
       () => assertInstanceOf(undefined, TestClass1),
       AssertionError,
-      `Expected object to be an instance of "TestClass1" but was "undefined".`,
+      `Expected object to be an instance of "TestClass1" but was "undefined"`,
     );
     assertThrows(
       () => assertInstanceOf({}, TestClass1),
       AssertionError,
-      `Expected object to be an instance of "TestClass1" but was "Object".`,
+      `Expected object to be an instance of "TestClass1" but was "Object"`,
     );
     assertThrows(
       () => assertInstanceOf(Object.create(null), TestClass1),
       AssertionError,
-      `Expected object to be an instance of "TestClass1" but was "Object".`,
+      `Expected object to be an instance of "TestClass1" but was "Object"`,
     );
 
     // Test TypeScript types functionality, wrapped in a function that never runs

--- a/assert/is_error.ts
+++ b/assert/is_error.ts
@@ -33,7 +33,7 @@ export function assertIsError<E extends Error = Error>(
   msgMatches?: string | RegExp,
   msg?: string,
 ): asserts error is E {
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   if (!(error instanceof Error)) {
     throw new AssertionError(
       `Expected "error" to be an Error object${msgSuffix}}`,

--- a/assert/is_error_test.ts
+++ b/assert/is_error_test.ts
@@ -8,19 +8,19 @@ Deno.test("assertIsError() throws when given value isn't error", () => {
   assertThrows(
     () => assertIsError("Panic!", undefined, "Panic!"),
     AssertionError,
-    `Expected "error" to be an Error object.`,
+    `Expected "error" to be an Error object`,
   );
 
   assertThrows(
     () => assertIsError(null),
     AssertionError,
-    `Expected "error" to be an Error object.`,
+    `Expected "error" to be an Error object`,
   );
 
   assertThrows(
     () => assertIsError(undefined),
     AssertionError,
-    `Expected "error" to be an Error object.`,
+    `Expected "error" to be an Error object`,
   );
 });
 
@@ -33,7 +33,7 @@ Deno.test("assertIsError() allows custom error", () => {
   assertThrows(
     () => assertIsError(new AnotherCustomError("failed"), CustomError, "fail"),
     AssertionError,
-    'Expected error to be instance of "CustomError", but was "AnotherCustomError".',
+    'Expected error to be instance of "CustomError", but was "AnotherCustomError"',
   );
 });
 
@@ -46,7 +46,7 @@ Deno.test("assertIsError() throws with message diff containing double quotes", (
         'doesn\'t include "this message"',
       ),
     AssertionError,
-    `Expected error message to include "doesn't include \\"this message\\"", but got "error with \\"double quotes\\"".`,
+    `Expected error message to include "doesn't include \\"this message\\"", but got "error with \\"double quotes\\""`,
   );
 });
 

--- a/assert/match.ts
+++ b/assert/match.ts
@@ -24,7 +24,7 @@ export function assertMatch(
   msg?: string,
 ) {
   if (expected.test(actual)) return;
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   msg = `Expected actual: "${actual}" to match: "${expected}"${msgSuffix}`;
   throw new AssertionError(msg);
 }

--- a/assert/match_test.ts
+++ b/assert/match_test.ts
@@ -10,7 +10,7 @@ Deno.test("assertMatch() throws", () => {
   assertThrows(
     () => assertMatch("Denosaurus from Jurassic", RegExp(/Raptor/)),
     AssertionError,
-    `Expected actual: "Denosaurus from Jurassic" to match: "/Raptor/".`,
+    `Expected actual: "Denosaurus from Jurassic" to match: "/Raptor/"`,
   );
 });
 

--- a/assert/not_equals.ts
+++ b/assert/not_equals.ts
@@ -29,7 +29,7 @@ export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
   }
   const actualString = String(actual);
   const expectedString = String(expected);
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   throw new AssertionError(
     `Expected actual: ${actualString} not to be: ${expectedString}${msgSuffix}`,
   );

--- a/assert/not_equals_test.ts
+++ b/assert/not_equals_test.ts
@@ -17,7 +17,7 @@ Deno.test("assertNotEquals() throws", () => {
       assertNotEquals("foo", "foo");
     },
     AssertionError,
-    "Expected actual: foo not to be: foo.",
+    "Expected actual: foo not to be: foo",
   );
 });
 

--- a/assert/not_instance_of.ts
+++ b/assert/not_instance_of.ts
@@ -26,7 +26,7 @@ export function assertNotInstanceOf<A, T>(
   unexpectedType: new (...args: any[]) => T,
   msg?: string,
 ): asserts actual is Exclude<A, T> {
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   msg =
     `Expected object to not be an instance of "${typeof unexpectedType}"${msgSuffix}`;
   assertFalse(actual instanceof unexpectedType, msg);

--- a/assert/not_instance_of_test.ts
+++ b/assert/not_instance_of_test.ts
@@ -16,7 +16,7 @@ Deno.test({
     assertThrows(
       () => assertNotInstanceOf(new Date(), Date),
       AssertionError,
-      'Expected object to not be an instance of "function".',
+      'Expected object to not be an instance of "function"',
     );
   },
 });

--- a/assert/not_match.ts
+++ b/assert/not_match.ts
@@ -24,7 +24,7 @@ export function assertNotMatch(
   msg?: string,
 ) {
   if (!expected.test(actual)) return;
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   msg = `Expected actual: "${actual}" to not match: "${expected}"${msgSuffix}`;
   throw new AssertionError(msg);
 }

--- a/assert/not_match_test.ts
+++ b/assert/not_match_test.ts
@@ -9,7 +9,7 @@ Deno.test("assertNotMatch() throws", () => {
   assertThrows(
     () => assertNotMatch("Denosaurus from Jurassic", RegExp(/from/)),
     AssertionError,
-    `Expected actual: "Denosaurus from Jurassic" to not match: "/from/".`,
+    `Expected actual: "Denosaurus from Jurassic" to not match: "/from/"`,
   );
 });
 

--- a/assert/not_strict_equals.ts
+++ b/assert/not_strict_equals.ts
@@ -33,7 +33,7 @@ export function assertNotStrictEquals<T>(
     return;
   }
 
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   throw new AssertionError(
     `Expected "actual" to not be strictly equal to: ${
       format(actual)

--- a/assert/rejects.ts
+++ b/assert/rejects.ts
@@ -82,7 +82,7 @@ export async function assertRejects<E extends Error = Error>(
   }
   let doesThrow = false;
   let isPromiseReturned = false;
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   try {
     const possiblePromise = fn();
     if (

--- a/assert/rejects_test.ts
+++ b/assert/rejects_test.ts
@@ -19,7 +19,7 @@ Deno.test("assertRejects() with synchronous function that throws", async () => {
         throw { wrong: "true" };
       }),
     AssertionError,
-    "Function throws when expected to reject.",
+    "Function throws when expected to reject",
   );
 });
 
@@ -47,7 +47,7 @@ Deno.test("assertRejects() with non-error value rejected and error class", async
       );
     },
     AssertionError,
-    "A non-Error object was rejected.",
+    "A non-Error object was rejected",
   );
 });
 
@@ -103,7 +103,7 @@ Deno.test(
           "fail",
         ),
       AssertionError,
-      'Expected error to be instance of "CustomError", but was "AnotherCustomError".',
+      'Expected error to be instance of "CustomError", but was "AnotherCustomError"',
     );
   },
 );
@@ -113,7 +113,7 @@ Deno.test("assertRejects() throws when no promise is returned", async () => {
     // @ts-expect-error - testing invalid input
     async () => await assertRejects(() => {}),
     AssertionError,
-    "Function throws when expected to reject.",
+    "Function throws when expected to reject",
   );
 });
 
@@ -121,7 +121,7 @@ Deno.test("assertRejects() throws when the promise doesn't reject", async () => 
   await assertRejects(
     async () => await assertRejects(async () => await Promise.resolve(42)),
     AssertionError,
-    "Expected function to reject.",
+    "Expected function to reject",
   );
 });
 

--- a/assert/strict_equals.ts
+++ b/assert/strict_equals.ts
@@ -34,7 +34,7 @@ export function assertStrictEquals<T>(
     return;
   }
 
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   let message: string;
 
   const actualString = format(actual);

--- a/assert/strict_equals_test.ts
+++ b/assert/strict_equals_test.ts
@@ -67,7 +67,7 @@ Deno.test({
     assertThrows(
       () => assertStrictEquals({ a: 1, b: 2 }, { a: 1, b: 2 }),
       AssertionError,
-      `Values have the same structure but are not reference-equal.
+      `Values have the same structure but are not reference-equal
 
     {
       a: 1,

--- a/assert/string_includes.ts
+++ b/assert/string_includes.ts
@@ -24,7 +24,7 @@ export function assertStringIncludes(
   msg?: string,
 ) {
   if (actual.includes(expected)) return;
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   msg = `Expected actual: "${actual}" to contain: "${expected}"${msgSuffix}`;
   throw new AssertionError(msg);
 }

--- a/assert/string_includes_test.ts
+++ b/assert/string_includes_test.ts
@@ -26,7 +26,7 @@ Deno.test("assertStringIncludes() throws", () => {
   assertThrows(
     () => assertStringIncludes("Denosaurus from Jurassic", "Raptor"),
     AssertionError,
-    `Expected actual: "Denosaurus from Jurassic" to contain: "Raptor".`,
+    `Expected actual: "Denosaurus from Jurassic" to contain: "Raptor"`,
   );
 });
 

--- a/assert/throws.ts
+++ b/assert/throws.ts
@@ -86,7 +86,7 @@ export function assertThrows<E extends Error = Error>(
     msg = errorClassOrMsg;
   }
   let doesThrow = false;
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   try {
     fn();
   } catch (error) {

--- a/assert/throws_test.ts
+++ b/assert/throws_test.ts
@@ -43,7 +43,7 @@ Deno.test("assertThrows() throws when error class is expected but non-error valu
       );
     },
     AssertionError,
-    "A non-Error object was thrown.",
+    "A non-Error object was thrown",
   );
 });
 
@@ -134,7 +134,7 @@ Deno.test("assertThrows() throws when input function does not throw", () => {
       assertThrows(() => {});
     },
     AssertionError,
-    "Expected function to throw.",
+    "Expected function to throw",
   );
 });
 

--- a/assert/unimplemented.ts
+++ b/assert/unimplemented.ts
@@ -16,6 +16,6 @@ import { AssertionError } from "./assertion_error.ts";
  * @returns Never returns, always throws.
  */
 export function unimplemented(msg?: string): never {
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   throw new AssertionError(`Unimplemented${msgSuffix}`);
 }

--- a/assert/unimplemented_test.ts
+++ b/assert/unimplemented_test.ts
@@ -2,7 +2,7 @@
 import { AssertionError, assertThrows, unimplemented } from "./mod.ts";
 
 Deno.test("unimplemented() throws", function () {
-  assertThrows(() => unimplemented(), AssertionError, "Unimplemented.");
+  assertThrows(() => unimplemented(), AssertionError, "Unimplemented");
 });
 
 Deno.test("unimplemented() throws with custom message", function () {

--- a/assert/unreachable.ts
+++ b/assert/unreachable.ts
@@ -16,6 +16,6 @@ import { AssertionError } from "./assertion_error.ts";
  * @returns Never returns, always throws.
  */
 export function unreachable(msg?: string): never {
-  const msgSuffix = msg ? `: ${msg}` : ".";
+  const msgSuffix = msg ? `: ${msg}` : "";
   throw new AssertionError(`Unreachable${msgSuffix}`);
 }

--- a/assert/unreachable_test.ts
+++ b/assert/unreachable_test.ts
@@ -2,7 +2,7 @@
 import { AssertionError, assertThrows, unreachable } from "./mod.ts";
 
 Deno.test("unreachable()", () => {
-  assertThrows(() => unreachable(), AssertionError, "Unreachable.");
+  assertThrows(() => unreachable(), AssertionError, "Unreachable");
   assertThrows(
     () => unreachable("custom message"),
     AssertionError,

--- a/expect/_to_throw_test.ts
+++ b/expect/_to_throw_test.ts
@@ -33,7 +33,7 @@ Deno.test("expect().toThrow()", () => {
       }).toThrow(AssertionError);
     },
     AssertionError,
-    'Expected error to be instance of "AssertionError", but was "Error".',
+    'Expected error to be instance of "AssertionError", but was "Error"',
   );
 
   // Passes when error instance type is correct
@@ -49,7 +49,7 @@ Deno.test("expect().toThrow()", () => {
       }).toThrow(new AssertionError("hello world"));
     },
     AssertionError,
-    'Expected error to be instance of "AssertionError", but was "Error".',
+    'Expected error to be instance of "AssertionError", but was "Error"',
   );
 
   // Passes when literal string is in error
@@ -65,7 +65,7 @@ Deno.test("expect().toThrow()", () => {
       }).toThrow("goodbye");
     },
     AssertionError,
-    'Expected error message to include "goodbye", but got "hello world".',
+    'Expected error message to include "goodbye", but got "hello world"',
   );
 
   // Passes when error instance string is in error
@@ -81,7 +81,7 @@ Deno.test("expect().toThrow()", () => {
       }).toThrow(new AssertionError("goodbye"));
     },
     AssertionError,
-    'Expected error message to include "goodbye", but got "hello world".',
+    'Expected error message to include "goodbye", but got "hello world"',
   );
 
   // Passes when regex does match error
@@ -97,6 +97,6 @@ Deno.test("expect().toThrow()", () => {
       }).toThrow(/\d/);
     },
     AssertionError,
-    'Expected error message to include /\\d/, but got "hello world".',
+    'Expected error message to include /\\d/, but got "hello world"',
   );
 });

--- a/testing/mock_test.ts
+++ b/testing/mock_test.ts
@@ -1058,7 +1058,7 @@ Deno.test("assertSpyCall() works with function", () => {
         error: { msgIncludes: "x" },
       }),
     AssertionError,
-    "Spy call did not throw an error, a value was returned.",
+    "Spy call did not throw an error, a value was returned",
   );
   assertThrows(
     () => assertSpyCall(spyFunc, 1),
@@ -1191,7 +1191,7 @@ Deno.test("assertSpyCall() works with method", () => {
         error: { msgIncludes: "x" },
       }),
     AssertionError,
-    "Spy call did not throw an error, a value was returned.",
+    "Spy call did not throw an error, a value was returned",
   );
   assertThrows(
     () => assertSpyCall(spyMethod, 2),
@@ -1275,7 +1275,7 @@ Deno.test("assertSpyCall() works with error", () => {
         },
       }),
     AssertionError,
-    'Expected error to be instance of "OtherError", but was "ExampleError".',
+    'Expected error to be instance of "OtherError", but was "ExampleError"',
   );
   assertThrows(
     () =>
@@ -1286,7 +1286,7 @@ Deno.test("assertSpyCall() works with error", () => {
         },
       }),
     AssertionError,
-    'Expected error to be instance of "OtherError", but was "ExampleError".',
+    'Expected error to be instance of "OtherError", but was "ExampleError"',
   );
   assertThrows(
     () =>
@@ -1297,7 +1297,7 @@ Deno.test("assertSpyCall() works with error", () => {
         },
       }),
     AssertionError,
-    'Expected error message to include "x", but got "failed".',
+    'Expected error message to include "x", but got "failed"',
   );
   assertThrows(
     () =>
@@ -1308,7 +1308,7 @@ Deno.test("assertSpyCall() works with error", () => {
         },
       }),
     AssertionError,
-    'Expected error message to include "x", but got "failed".',
+    'Expected error message to include "x", but got "failed"',
   );
   assertThrows(
     () =>
@@ -1318,7 +1318,7 @@ Deno.test("assertSpyCall() works with error", () => {
         },
       }),
     AssertionError,
-    'Expected error message to include "x", but got "failed".',
+    'Expected error message to include "x", but got "failed"',
   );
   assertThrows(
     () =>
@@ -1326,7 +1326,7 @@ Deno.test("assertSpyCall() works with error", () => {
         returned: 7,
       }),
     AssertionError,
-    "Spy call did not return expected value, an error was thrown.",
+    "Spy call did not return expected value, an error was thrown",
   );
   assertThrows(
     () => assertSpyCall(spyFunc, 1),
@@ -1600,7 +1600,7 @@ Deno.test("assertSpyCallAsync() rejects on sync value", async () => {
   await assertRejects(
     () => assertSpyCallAsync(spyFunc, 0),
     AssertionError,
-    "Spy call did not return a promise, a value was returned.",
+    "Spy call did not return a promise, a value was returned",
   );
 });
 
@@ -1613,7 +1613,7 @@ Deno.test("assertSpyCallAsync() rejects on sync error", async () => {
   await assertRejects(
     () => assertSpyCallAsync(spyFunc, 0),
     AssertionError,
-    "Spy call did not return a promise, an error was thrown.",
+    "Spy call did not return a promise, an error was thrown",
   );
 });
 
@@ -1721,7 +1721,7 @@ Deno.test("assertSpyCallAsync() works with error", async () => {
         },
       }),
     AssertionError,
-    'Expected error message to include "x", but got "failed".',
+    'Expected error message to include "x", but got "failed"',
   );
   await assertRejects(
     () =>
@@ -1732,7 +1732,7 @@ Deno.test("assertSpyCallAsync() works with error", async () => {
         },
       }),
     AssertionError,
-    'Expected error message to include "x", but got "failed".',
+    'Expected error message to include "x", but got "failed"',
   );
   await assertRejects(
     () =>
@@ -1742,7 +1742,7 @@ Deno.test("assertSpyCallAsync() works with error", async () => {
         },
       }),
     AssertionError,
-    'Expected error message to include "x", but got "failed".',
+    'Expected error message to include "x", but got "failed"',
   );
   await assertRejects(
     () =>
@@ -1797,7 +1797,7 @@ Deno.test("assertSpyCallArg()", () => {
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 0, 2),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1814,7 +1814,7 @@ Deno.test("assertSpyCallArg()", () => {
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 0, 9),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1826,7 +1826,7 @@ Deno.test("assertSpyCallArg()", () => {
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 1, 7),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1838,7 +1838,7 @@ Deno.test("assertSpyCallArg()", () => {
   assertThrows(
     () => assertSpyCallArg(spyFunc, 0, 2, 7),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1863,7 +1863,7 @@ Deno.test("assertSpyCallArgs() throws without range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, [undefined]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1876,7 +1876,7 @@ Deno.test("assertSpyCallArgs() throws without range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, [2]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1892,7 +1892,7 @@ Deno.test("assertSpyCallArgs() throws without range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, [7, 9, undefined]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1907,7 +1907,7 @@ Deno.test("assertSpyCallArgs() throws without range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, [9, 7]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1935,7 +1935,7 @@ Deno.test("assertSpyCallArgs() throws with start only", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, [undefined]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1948,7 +1948,7 @@ Deno.test("assertSpyCallArgs() throws with start only", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, [2]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1964,7 +1964,7 @@ Deno.test("assertSpyCallArgs() throws with start only", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, [9, 8, undefined]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -1979,7 +1979,7 @@ Deno.test("assertSpyCallArgs() throws with start only", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, [9, 7]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -2007,7 +2007,7 @@ Deno.test("assertSpyCallArgs() throws with range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, 3, [undefined, undefined]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -2021,7 +2021,7 @@ Deno.test("assertSpyCallArgs() throws with range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 0, 1, 3, [2, 4]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -2038,7 +2038,7 @@ Deno.test("assertSpyCallArgs() throws with range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, 3, [9, 8, undefined]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected
@@ -2053,7 +2053,7 @@ Deno.test("assertSpyCallArgs() throws with range", () => {
   assertThrows(
     () => assertSpyCallArgs(spyFunc, 1, 1, 3, [9, 7]),
     AssertionError,
-    `Values are not equal.
+    `Values are not equal
 
 
     [Diff] Actual / Expected


### PR DESCRIPTION
Aligns the error messages in the `assert` folder to match the style guide.

https://github.com/denoland/std/issues/5574