### PR TITLE
refactor(semver): align additional error messages

### DIFF
--- a/semver/_shared.ts
+++ b/semver/_shared.ts
@@ -6,7 +6,9 @@ export function compareNumber(
   a: number,
   b: number,
 ): 1 | 0 | -1 {
-  if (isNaN(a) || isNaN(b)) throw new Error("Comparison against non-numbers");
+  if (isNaN(a) || isNaN(b)) {
+    throw new Error("Cannot compare against non-numbers");
+  }
   return a === b ? 0 : a < b ? -1 : 1;
 }
 

--- a/semver/increment.ts
+++ b/semver/increment.ts
@@ -191,6 +191,8 @@ export function increment(
       };
     }
     default:
-      throw new TypeError(`Invalid increment argument: ${release}`);
+      throw new TypeError(
+        `Cannot increment version: invalid argument ${release}`,
+      );
   }
 }

--- a/semver/parse.ts
+++ b/semver/parse.ts
@@ -29,24 +29,33 @@ import { FULL_REGEXP, MAX_LENGTH } from "./_shared.ts";
 export function parse(value: string): SemVer {
   if (typeof value !== "string") {
     throw new TypeError(
-      `version must be a string`,
+      `Cannot parse version as version must be a string: received ${typeof value}`,
     );
   }
 
   if (value.length > MAX_LENGTH) {
     throw new TypeError(
-      `version is longer than ${MAX_LENGTH} characters`,
+      `Cannot parse version as version length is too long: length is ${value.length}, max length is ${MAX_LENGTH}`,
     );
   }
 
   value = value.trim();
 
   const groups = value.match(FULL_REGEXP)?.groups;
-  if (!groups) throw new TypeError(`Invalid version: ${value}`);
+  if (!groups) throw new TypeError(`Cannot parse version: ${value}`);
 
-  const major = parseNumber(groups.major!, "Invalid major version");
-  const minor = parseNumber(groups.minor!, "Invalid minor version");
-  const patch = parseNumber(groups.patch!, "Invalid patch version");
+  const major = parseNumber(
+    groups.major!,
+    `Cannot parse version ${value}: invalid major version`,
+  );
+  const minor = parseNumber(
+    groups.minor!,
+    `Cannot parse version ${value}: invalid minor version`,
+  );
+  const patch = parseNumber(
+    groups.patch!,
+    `Cannot parse version ${value}: invalid patch version`,
+  );
 
   const prerelease = groups.prerelease
     ? parsePrerelease(groups.prerelease)

--- a/semver/parse_range.ts
+++ b/semver/parse_range.ts
@@ -32,14 +32,17 @@ function parseComparator(comparator: string): Comparator | null {
 
   const semver = groups.major
     ? {
-      major: parseNumber(groups.major, "Invalid major version"),
+      major: parseNumber(
+        groups.major,
+        `Cannot parse comparator ${comparator}: invalid major version`,
+      ),
       minor: parseNumber(
         groups.minor!,
-        "Invalid minor version",
+        `Cannot parse comparator ${comparator}: invalid minor version`,
       ),
       patch: parseNumber(
         groups.patch!,
-        "Invalid patch version",
+        `Cannot parse comparator ${comparator}: invalid patch version`,
       ),
       prerelease: prerelease ? parsePrerelease(prerelease) : [],
       build: buildmetadata ? parseBuild(buildmetadata) : [],
@@ -372,7 +375,9 @@ function parseOperatorRange(string: string): Comparator | Comparator[] | null {
     case "":
       return handleEqualOperator(groups);
     default:
-      throw new Error(`'${groups.operator}' is not a valid operator.`);
+      throw new Error(
+        `Cannot parse version range: '${groups.operator}' is not a valid operator`,
+      );
   }
 }
 function parseOperatorRanges(string: string): (Comparator | null)[] {
@@ -410,7 +415,9 @@ export function parseRange(value: string): Range {
     .split(/\s*\|\|\s*/)
     .map((string) => parseHyphenRange(string) || parseOperatorRanges(string));
   if (result.some((r) => r.includes(null))) {
-    throw new TypeError(`Invalid range: ${value}`);
+    throw new TypeError(
+      `Cannot parse version range: range "${value}" is invalid`,
+    );
   }
   return result as Range;
 }

--- a/semver/parse_range_test.ts
+++ b/semver/parse_range_test.ts
@@ -660,5 +660,9 @@ Deno.test("parseRange() parses ranges with caret", () => {
 });
 
 Deno.test("parseRange() throws on invalid range", () => {
-  assertThrows(() => parseRange("blerg"), TypeError, "Invalid range: blerg");
+  assertThrows(
+    () => parseRange("blerg"),
+    TypeError,
+    'Cannot parse version range: range "blerg" is invalid',
+  );
 });


### PR DESCRIPTION
Aligns the error messages in the `semver` folder to match the style guide.

https://github.com/denoland/std/issues/5574