### PR TITLE
docs: add a note about error message format exception

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -257,3 +257,9 @@ Bad: Cannot compute the square root for x: value must not be negative
 Good: Cannot compute the square root for x: current value is ${x}
 Better: Cannot compute the square root for x as x must be >= 0: current value is ${x}
 ```
+
+#### Exceptions
+
+The assertion package uses periods to end sentences in error messages. There are
+a number of downstream packages that expect this behavior and changing it would
+be a breaking change.


### PR DESCRIPTION
The assertion package uses a period at the end of the error message. While this doesn't conform to the standard error message format, it would be a breaking change to adjust this now. This change-set adds a note to the CONTRIBUTING.md file to explain this exception.

https://github.com/denoland/std/issues/5574