### PR TITLE
refactor(jsonc): align additional error messages

### DIFF
--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -23,7 +23,7 @@ export type { JsonValue };
  */
 export function parse(text: string): JsonValue {
   if (new.target) {
-    throw new TypeError("Cannot instantiate parse: parse is not a constructor");
+    throw new TypeError("Cannot create an instance: parse is not a constructor");
   }
   return new JSONCParser(text).parse();
 }

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -23,7 +23,7 @@ export type { JsonValue };
  */
 export function parse(text: string): JsonValue {
   if (new.target) {
-    throw new TypeError("parse is not a constructor");
+    throw new TypeError("Cannot instantiate parse: parse is not a constructor");
   }
   return new JSONCParser(text).parse();
 }
@@ -83,7 +83,9 @@ class JSONCParser {
   #getNext(): Token {
     const { done, value } = this.#tokenized.next();
     if (done) {
-      throw new SyntaxError("Unexpected end of JSONC input");
+      throw new SyntaxError(
+        "Cannot parse JSONC: unexpected end of JSONC input",
+      );
     }
     return value;
   }
@@ -106,7 +108,9 @@ class JSONCParser {
           }
         }
         if (!hasEndOfComment) {
-          throw new SyntaxError("Unexpected end of JSONC input");
+          throw new SyntaxError(
+            "Cannot parse JSONC: unexpected end of JSONC input",
+          );
         }
         i++;
         continue;
@@ -362,5 +366,5 @@ function buildErrorMessage({ type, sourceText, position }: Token): string {
         : sourceText;
       break;
   }
-  return `Unexpected token ${token} in JSONC at position ${position}`;
+  return `Cannot parse JSONC: unexpected token "${token}" in JSONC at position ${position}`;
 }

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -23,7 +23,9 @@ export type { JsonValue };
  */
 export function parse(text: string): JsonValue {
   if (new.target) {
-    throw new TypeError("Cannot create an instance: parse is not a constructor");
+    throw new TypeError(
+      "Cannot create an instance: parse is not a constructor",
+    );
   }
   return new JSONCParser(text).parse();
 }

--- a/jsonc/parse_test.ts
+++ b/jsonc/parse_test.ts
@@ -93,37 +93,37 @@ Deno.test({
     assertInvalidParse(
       `:::::`,
       SyntaxError,
-      "Unexpected token : in JSONC at position 0",
+      'Cannot parse JSONC: unexpected token ":" in JSONC at position 0',
     );
     assertInvalidParse(
       `[`,
       SyntaxError,
-      "Unexpected end of JSONC input",
+      "Cannot parse JSONC: unexpected end of JSONC input",
     );
     assertInvalidParse(
       `[]100`,
       SyntaxError,
-      "Unexpected token 100 in JSONC at position 2",
+      'Cannot parse JSONC: unexpected token "100" in JSONC at position 2',
     );
     assertInvalidParse(
       `[aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa]`,
       SyntaxError,
-      "Unexpected token aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa... in JSONC at position 1",
+      'Cannot parse JSONC: unexpected token "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa..." in JSONC at position 1',
     );
     assertInvalidParse(
       `}`,
       SyntaxError,
-      "Unexpected token } in JSONC at position 0",
+      'Cannot parse JSONC: unexpected token "}" in JSONC at position 0',
     );
     assertInvalidParse(
       `]`,
       SyntaxError,
-      "Unexpected token ] in JSONC at position 0",
+      'Cannot parse JSONC: unexpected token "]" in JSONC at position 0',
     );
     assertInvalidParse(
       `,`,
       SyntaxError,
-      "Unexpected token , in JSONC at position 0",
+      'Cannot parse JSONC: unexpected token "," in JSONC at position 0',
     );
   },
 });
@@ -163,7 +163,7 @@ Deno.test({
       // deno-lint-ignore no-explicit-any
       undefined as any,
       SyntaxError,
-      "Unexpected token undefined in JSONC at position 0",
+      'Cannot parse JSONC: unexpected token "undefined" in JSONC at position 0',
     );
     // deno-lint-ignore no-explicit-any
     assertValidParse(0 as any, 0);


### PR DESCRIPTION
Aligns the error messages in the `jsonc` folder to match the style guide.

https://github.com/denoland/std/issues/5574