### PR TITLE
refactor(media-types): align additional error messages

### DIFF
--- a/media_types/parse_media_type.ts
+++ b/media_types/parse_media_type.ts
@@ -56,7 +56,9 @@ export function parseMediaType(
         // ignore trailing semicolons
         break;
       }
-      throw new TypeError("Invalid media parameter.");
+      throw new TypeError(
+        `Cannot parse media type: invalid parameter "${type}"`,
+      );
     }
 
     let pmap = params;
@@ -68,7 +70,7 @@ export function parseMediaType(
       pmap = continuation.get(baseName)!;
     }
     if (key in pmap) {
-      throw new TypeError("Duplicate key parsed.");
+      throw new TypeError("Cannot parse media type: duplicate key");
     }
     pmap[key] = value;
     type = rest;

--- a/media_types/parse_media_type_test.ts
+++ b/media_types/parse_media_type_test.ts
@@ -95,17 +95,17 @@ Deno.test({
 Deno.test({
   name: "parseMediaType() throws on invalid media type",
   fn() {
-    const fixtures = [
-      `form-data; foo`,
-      `form-data; foo="bar"; baz`,
-    ] as const;
+    const fixtures = [{ type: `form-data; foo`, invalid: "; foo" }, {
+      type: `form-data; foo="bar"; baz`,
+      invalid: "; baz",
+    }] as const;
     for (const fixture of fixtures) {
       assertThrows(
         () => {
-          parseMediaType(fixture);
+          parseMediaType(fixture.type);
         },
         TypeError,
-        "Invalid media parameter.",
+        `Cannot parse media type: invalid parameter "${fixture.invalid}"`,
       );
     }
   },
@@ -123,7 +123,7 @@ Deno.test({
           parseMediaType(fixture);
         },
         TypeError,
-        "Duplicate key parsed.",
+        "Cannot parse media type: duplicate key",
       );
     }
   },


### PR DESCRIPTION
Aligns the error messages in the `media_types` folder to match the style guide.

https://github.com/denoland/std/issues/5574