### PR TITLE
refactor(log): align additional error messages

### DIFF
--- a/log/levels.ts
+++ b/log/levels.ts
@@ -43,7 +43,7 @@ export function getLevelByName(name: LevelName): LogLevel {
   if (level !== undefined) {
     return level;
   }
-  throw new Error(`no log level found for name: ${name}`);
+  throw new Error(`Cannot get log level: no level named ${name}`);
 }
 
 /** Returns the stringy log level name provided the numeric log level. */
@@ -52,5 +52,5 @@ export function getLevelName(level: LogLevel): LevelName {
   if (levelName) {
     return levelName;
   }
-  throw new Error(`no level name found for level: ${level}`);
+  throw new Error(`Cannot get log level: no name for level: ${level}`);
 }

--- a/log/rotating_file_handler.ts
+++ b/log/rotating_file_handler.ts
@@ -67,11 +67,13 @@ export class RotatingFileHandler extends FileHandler {
   override setup() {
     if (this.#maxBytes < 1) {
       this.destroy();
-      throw new Error("maxBytes cannot be less than 1");
+      throw new Error(`"maxBytes" must be >= 1: received ${this.#maxBytes}`);
     }
     if (this.#maxBackupCount < 1) {
       this.destroy();
-      throw new Error("maxBackupCount cannot be less than 1");
+      throw new Error(
+        `"maxBackupCount" must be >= 1: received ${this.#maxBackupCount}`,
+      );
     }
     super.setup();
 

--- a/log/rotating_file_handler_test.ts
+++ b/log/rotating_file_handler_test.ts
@@ -231,7 +231,7 @@ Deno.test({
         fileHandler.setup();
       },
       Error,
-      "maxBytes cannot be less than 1",
+      '"maxBytes" must be >= 1: received 0',
     );
   },
 });
@@ -250,7 +250,7 @@ Deno.test({
         fileHandler.setup();
       },
       Error,
-      "maxBackupCount cannot be less than 1",
+      '"maxBackupCount" must be >= 1: received 0',
     );
   },
 });


### PR DESCRIPTION
Aligns the error messages in the `log` folder to match the style guide.

https://github.com/denoland/std/issues/5574