### PR TITLE
refactor(fs): align additional error messages

### DIFF
--- a/fs/copy.ts
+++ b/fs/copy.ts
@@ -60,7 +60,7 @@ async function ensureValidCopy(
 
   if (options.isFolder && !destStat.isDirectory) {
     throw new Error(
-      `Cannot overwrite non-directory '${dest}' with directory '${src}'.`,
+      `Cannot overwrite non-directory '${dest}' with directory '${src}'`,
     );
   }
   if (!options.overwrite) {
@@ -87,11 +87,11 @@ function ensureValidCopySync(
 
   if (options.isFolder && !destStat.isDirectory) {
     throw new Error(
-      `Cannot overwrite non-directory '${dest}' with directory '${src}'.`,
+      `Cannot overwrite non-directory '${dest}' with directory '${src}'`,
     );
   }
   if (!options.overwrite) {
-    throw new Deno.errors.AlreadyExists(`'${dest}' already exists.`);
+    throw new Deno.errors.AlreadyExists(`'${dest}' already exists`);
   }
 
   return destStat;
@@ -313,14 +313,14 @@ export async function copy(
   dest = resolve(toPathString(dest));
 
   if (src === dest) {
-    throw new Error("Source and destination cannot be the same.");
+    throw new Error("Source and destination cannot be the same");
   }
 
   const srcStat = await Deno.lstat(src);
 
   if (srcStat.isDirectory && isSubdir(src, dest)) {
     throw new Error(
-      `Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`,
+      `Cannot copy '${src}' to a subdirectory of itself: '${dest}'`,
     );
   }
 
@@ -389,14 +389,14 @@ export function copySync(
   dest = resolve(toPathString(dest));
 
   if (src === dest) {
-    throw new Error("Source and destination cannot be the same.");
+    throw new Error("Source and destination cannot be the same");
   }
 
   const srcStat = Deno.lstatSync(src);
 
   if (srcStat.isDirectory && isSubdir(src, dest)) {
     throw new Error(
-      `Cannot copy '${src}' to a subdirectory of itself, '${dest}'.`,
+      `Cannot copy '${src}' to a subdirectory of itself: '${dest}'`,
     );
   }
 

--- a/fs/copy_test.ts
+++ b/fs/copy_test.ts
@@ -64,7 +64,7 @@ testCopy(
         await copy(srcFile, destFile);
       },
       Error,
-      "Source and destination cannot be the same.",
+      "Source and destination cannot be the same",
     );
   },
 );
@@ -102,7 +102,7 @@ testCopy(
         await copy(srcFile, destFile);
       },
       Error,
-      `'${destFile}' already exists.`,
+      `'${destFile}' already exists`,
     );
 
     // Modify destination file.
@@ -186,7 +186,7 @@ testCopy(
         await copy(srcDir, destDir);
       },
       Error,
-      `Cannot copy '${srcDir}' to a subdirectory of itself, '${destDir}'.`,
+      `Cannot copy '${srcDir}' to a subdirectory of itself: '${destDir}'`,
     );
   },
 );
@@ -205,7 +205,7 @@ testCopy(
         await copy(srcDir, destDir);
       },
       Error,
-      `Cannot overwrite non-directory '${destDir}' with directory '${srcDir}'.`,
+      `Cannot overwrite non-directory '${destDir}' with directory '${srcDir}'`,
     );
   },
 );
@@ -241,7 +241,7 @@ testCopy(
         await copy(srcDir, destDir);
       },
       Error,
-      `'${destDir}' already exists.`,
+      `'${destDir}' already exists`,
     );
 
     // Modify the file in the destination directory.
@@ -372,7 +372,7 @@ testCopySync(
         copySync(srcFile, srcFile);
       },
       Error,
-      "Source and destination cannot be the same.",
+      "Source and destination cannot be the same",
     );
   },
 );
@@ -401,7 +401,7 @@ testCopySync("copySync() copies file to new destination", (tempDir: string) => {
       copySync(srcFile, destFile);
     },
     Error,
-    `'${destFile}' already exists.`,
+    `'${destFile}' already exists`,
   );
 
   // Modify destination file.
@@ -432,7 +432,7 @@ testCopySync(
         copySync(srcDir, destDir);
       },
       Error,
-      `Cannot copy '${srcDir}' to a subdirectory of itself, '${destDir}'.`,
+      `Cannot copy '${srcDir}' to a subdirectory of itself: '${destDir}'`,
     );
   },
 );
@@ -451,7 +451,7 @@ testCopySync(
         copySync(srcDir, destDir);
       },
       Error,
-      `Cannot overwrite non-directory '${destDir}' with directory '${srcDir}'.`,
+      `Cannot overwrite non-directory '${destDir}' with directory '${srcDir}'`,
     );
   },
 );
@@ -485,7 +485,7 @@ testCopySync("copySync() copies a directory", (tempDir: string) => {
       copySync(srcDir, destDir);
     },
     Error,
-    `'${destDir}' already exists.`,
+    `'${destDir}' already exists`,
   );
 
   // Modify the file in the destination directory.

--- a/fs/ensure_dir.ts
+++ b/fs/ensure_dir.ts
@@ -100,7 +100,9 @@ export function ensureDirSync(dir: string | URL) {
 function throwIfNotDirectory(fileInfo: Deno.FileInfo) {
   if (!fileInfo.isDirectory) {
     throw new Error(
-      `Ensure path exists, expected 'dir', got '${getFileInfoType(fileInfo)}'`,
+      `Failed to ensure directory exists: expected 'dir', got '${
+        getFileInfoType(fileInfo)
+      }'`,
     );
   }
 }

--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -105,7 +105,7 @@ Deno.test("ensureDir() rejects if input is a file", async function () {
         await ensureDir(testFile);
       },
       Error,
-      `Ensure path exists, expected 'dir', got 'file'`,
+      `Failed to ensure directory exists: expected 'dir', got 'file'`,
     );
   } finally {
     await Deno.remove(baseDir, { recursive: true });
@@ -124,7 +124,7 @@ Deno.test("ensureDirSync() throws if input is a file", function () {
         ensureDirSync(testFile);
       },
       Error,
-      `Ensure path exists, expected 'dir', got 'file'`,
+      `Failed to ensure directory exists: expected 'dir', got 'file'`,
     );
   } finally {
     Deno.removeSync(baseDir, { recursive: true });
@@ -139,7 +139,7 @@ Deno.test("ensureDir() rejects links to files", async function () {
       await ensureDir(lf);
     },
     Error,
-    `Ensure path exists, expected 'dir', got 'file'`,
+    `Failed to ensure directory exists: expected 'dir', got 'file'`,
   );
 });
 
@@ -151,7 +151,7 @@ Deno.test("ensureDirSync() rejects links to files", function () {
       ensureDirSync(lf);
     },
     Error,
-    `Ensure path exists, expected 'dir', got 'file'`,
+    `Failed to ensure directory exists: expected 'dir', got 'file'`,
   );
 });
 

--- a/fs/ensure_file.ts
+++ b/fs/ensure_file.ts
@@ -32,7 +32,9 @@ export async function ensureFile(filePath: string | URL): Promise<void> {
     const stat = await Deno.lstat(filePath);
     if (!stat.isFile) {
       throw new Error(
-        `Ensure path exists, expected 'file', got '${getFileInfoType(stat)}'`,
+        `Failed to ensure file exists: expected 'file', got '${
+          getFileInfoType(stat)
+        }'`,
       );
     }
   } catch (err) {
@@ -77,7 +79,9 @@ export function ensureFileSync(filePath: string | URL): void {
     const stat = Deno.lstatSync(filePath);
     if (!stat.isFile) {
       throw new Error(
-        `Ensure path exists, expected 'file', got '${getFileInfoType(stat)}'`,
+        `Failed to ensure file exists: expected 'file', got '${
+          getFileInfoType(stat)
+        }'`,
       );
     }
   } catch (err) {

--- a/fs/ensure_file_test.ts
+++ b/fs/ensure_file_test.ts
@@ -79,7 +79,7 @@ Deno.test("ensureFile() rejects if input is dir", async function () {
         await ensureFile(testDir);
       },
       Error,
-      `Ensure path exists, expected 'file', got 'dir'`,
+      `Failed to ensure file exists: expected 'file', got 'dir'`,
     );
   } finally {
     await Deno.remove(testDir, { recursive: true });
@@ -97,7 +97,7 @@ Deno.test("ensureFileSync() throws if input is dir", function () {
         ensureFileSync(testDir);
       },
       Error,
-      `Ensure path exists, expected 'file', got 'dir'`,
+      `Failed to ensure file exists: expected 'file', got 'dir'`,
     );
   } finally {
     Deno.removeSync(testDir, { recursive: true });

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -123,7 +123,7 @@ export async function exists(
     ) {
       if (options.isDirectory && options.isFile) {
         throw new TypeError(
-          "ExistsOptions.options.isDirectory and ExistsOptions.options.isFile must not be true together.",
+          "ExistsOptions.options.isDirectory and ExistsOptions.options.isFile must not be true together",
         );
       }
       if (
@@ -252,7 +252,7 @@ export function existsSync(
     ) {
       if (options.isDirectory && options.isFile) {
         throw new TypeError(
-          "ExistsOptions.options.isDirectory and ExistsOptions.options.isFile must not be true together.",
+          "ExistsOptions.options.isDirectory and ExistsOptions.options.isFile must not be true together",
         );
       }
       if (

--- a/fs/exists_test.ts
+++ b/fs/exists_test.ts
@@ -335,7 +335,7 @@ Deno.test("exists() returns false when both isDirectory and isFile sets true", a
     assert(error instanceof TypeError);
     assertStringIncludes(
       error.message,
-      "ExistsOptions.options.isDirectory and ExistsOptions.options.isFile must not be true together.",
+      "ExistsOptions.options.isDirectory and ExistsOptions.options.isFile must not be true together",
     );
   } finally {
     await Deno.remove(tempDirPath, { recursive: true });
@@ -356,7 +356,7 @@ Deno.test("existsSync() returns false when both isDirectory and isFile sets true
     assert(error instanceof TypeError);
     assertStringIncludes(
       error.message,
-      "ExistsOptions.options.isDirectory and ExistsOptions.options.isFile must not be true together.",
+      "ExistsOptions.options.isDirectory and ExistsOptions.options.isFile must not be true together",
     );
   } finally {
     await Deno.remove(tempDirPath, { recursive: true });


### PR DESCRIPTION
Aligns the error messages in the `fs` folder to match the style guide.

https://github.com/denoland/std/issues/5574