### PR TITLE
refactor(uuid): align additional error messages

### DIFF
--- a/uuid/common.ts
+++ b/uuid/common.ts
@@ -65,7 +65,7 @@ export function validate(uuid: string): boolean {
  */
 export function version(uuid: string): number {
   if (!validate(uuid)) {
-    throw new TypeError("Invalid UUID");
+    throw new TypeError(`Cannot detect UUID version: received ${uuid}`);
   }
 
   return parseInt(uuid[14]!, 16);

--- a/uuid/v1.ts
+++ b/uuid/v1.ts
@@ -142,7 +142,7 @@ export function generate(options: GenerateOptions = {}): string {
 
   if (node.length !== 6) {
     throw new Error(
-      "Cannot create UUID. The node option must be an array of 6 bytes",
+      "Cannot create UUID: the node option must be an array of 6 bytes",
     );
   }
 

--- a/uuid/v1_test.ts
+++ b/uuid/v1_test.ts
@@ -49,7 +49,7 @@ Deno.test("generate() throws when node is passed with less than 6 numbers", () =
       generate({ node: [0x01, 0x23, 0x45, 0x67, 0x89] });
     },
     Error,
-    "Cannot create UUID. The node option must be an array of 6 bytes",
+    "Cannot create UUID: the node option must be an array of 6 bytes",
   );
 });
 
@@ -59,7 +59,7 @@ Deno.test("generate() throws when node is passed with more than 6 numbers", () =
       generate({ node: [0x01, 0x23, 0x45, 0x67, 0x89, 0x89, 0x89] });
     },
     Error,
-    "Cannot create UUID. The node option must be an array of 6 bytes",
+    "Cannot create UUID: the node option must be an array of 6 bytes",
   );
 });
 

--- a/uuid/v3.ts
+++ b/uuid/v3.ts
@@ -58,7 +58,7 @@ export async function generate(
   data: Uint8Array,
 ): Promise<string> {
   if (!validateCommon(namespace)) {
-    throw new TypeError("Invalid namespace UUID");
+    throw new TypeError(`Cannot generate UUID: invalid namespace ${namespace}`);
   }
   const namespaceBytes = uuidToBytes(namespace);
   const toHash = concat([namespaceBytes, data]);

--- a/uuid/v3_test.ts
+++ b/uuid/v3_test.ts
@@ -42,12 +42,12 @@ Deno.test("generate() throws on invalid namespace", async () => {
   await assertRejects(
     async () => await generate("invalid-uuid", new Uint8Array()),
     TypeError,
-    "Invalid namespace UUID",
+    "Cannot generate UUID: invalid namespace invalid-uuid",
   );
   await assertRejects(
     async () =>
       await generate("1b671a64-40d5-491e-99b0-da01ff1f334Z", new Uint8Array()),
     TypeError,
-    "Invalid namespace UUID",
+    "Cannot generate UUID: invalid namespace 1b671a64-40d5-491e-99b0-da01ff1f334Z",
   );
 });

--- a/uuid/v5.ts
+++ b/uuid/v5.ts
@@ -57,7 +57,7 @@ export async function generate(
   data: Uint8Array,
 ): Promise<string> {
   if (!validateCommon(namespace)) {
-    throw new TypeError("Invalid namespace UUID");
+    throw new TypeError(`Cannot generate UUID: invalid namespace ${namespace}`);
   }
 
   const namespaceBytes = uuidToBytes(namespace);

--- a/uuid/v5_test.ts
+++ b/uuid/v5_test.ts
@@ -42,12 +42,12 @@ Deno.test("generate() throws on invalid namespace", async () => {
   await assertRejects(
     async () => await generate("invalid-uuid", new Uint8Array()),
     TypeError,
-    "Invalid namespace UUID",
+    "Cannot generate UUID: invalid namespace invalid-uuid",
   );
   await assertRejects(
     async () =>
       await generate("1b671a64-40d5-491e-99b0-da01ff1f334Z", new Uint8Array()),
     TypeError,
-    "Invalid namespace UUID",
+    "Cannot generate UUID: invalid namespace 1b671a64-40d5-491e-99b0-da01ff1f334Z",
   );
 });


### PR DESCRIPTION
Aligns the error messages in the `uuid` folder to match the style guide.

https://github.com/denoland/std/issues/5574