### PR TITLE
refactor(expect): align additional error messages

### DIFF
--- a/expect/_equal.ts
+++ b/expect/_equal.ts
@@ -103,11 +103,11 @@ export function equal(c: unknown, d: unknown, options?: EqualOptions): boolean {
       }
       if (a instanceof WeakMap || b instanceof WeakMap) {
         if (!(a instanceof WeakMap && b instanceof WeakMap)) return false;
-        throw new TypeError("cannot compare WeakMap instances");
+        throw new TypeError("Cannot compare WeakMap instances");
       }
       if (a instanceof WeakSet || b instanceof WeakSet) {
         if (!(a instanceof WeakSet && b instanceof WeakSet)) return false;
-        throw new TypeError("cannot compare WeakSet instances");
+        throw new TypeError("Cannot compare WeakSet instances");
       }
       if (seen.get(a) === b) {
         return true;

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -156,7 +156,7 @@ export function expect<T extends Expected = Expected>(
 
       if (name === "resolves") {
         if (!isPromiseLike(value)) {
-          throw new AssertionError("expected value must be Promiselike");
+          throw new AssertionError("Expected value must be PromiseLike");
         }
 
         isPromised = true;
@@ -165,13 +165,13 @@ export function expect<T extends Expected = Expected>(
 
       if (name === "rejects") {
         if (!isPromiseLike(value)) {
-          throw new AssertionError("expected value must be a PromiseLike");
+          throw new AssertionError("Expected value must be a PromiseLike");
         }
 
         value = value.then(
           (value) => {
             throw new AssertionError(
-              `Promise did not reject. resolved to ${value}`,
+              `Promise did not reject: resolved to ${value}`,
             );
           },
           (err) => err,

--- a/expect/test.ts
+++ b/expect/test.ts
@@ -10,12 +10,12 @@ Deno.test("expect().resolves.toEqual()", async () => {
   assertThrows(
     () => expect(42).resolves.toEqual(42),
     AssertionError,
-    "expected value must be Promiselike",
+    "Expected value must be PromiseLike",
   );
   assertThrows(
     () => expect(null).resolves.toEqual(42),
     AssertionError,
-    "expected value must be Promiselike",
+    "Expected value must be PromiseLike",
   );
 });
 
@@ -26,12 +26,12 @@ Deno.test("expect().rejects.toEqual()", async () => {
   assertThrows(
     () => expect(42).rejects.toEqual(42),
     AssertionError,
-    "expected value must be a PromiseLike",
+    "Expected value must be a PromiseLike",
   );
   await assertRejects(
     () => expect(Promise.resolve(42)).rejects.toEqual(42),
     AssertionError,
-    "Promise did not reject. resolved to 42",
+    "Promise did not reject: resolved to 42",
   );
 });
 


### PR DESCRIPTION
Aligns the error messages in the `expect` folder to match the style guide. Only errors thrown during test setup are updated, errors thrown from matchers during execution are not updated.

https://github.com/denoland/std/issues/5574