### PR TITLE
test(uuid): assert error message of `version()`

### DIFF
--- a/uuid/common_test.ts
+++ b/uuid/common_test.ts
@@ -26,9 +26,12 @@ Deno.test("version() detects the RFC version of a UUID", () => {
   assertThrows(() => version(""));
   assertThrows(() => version("not a UUID"));
   assertThrows(() => version("00000000000000000000000000000000"));
-  assertThrows(() =>
-    version(
-      "=Y00a-f*v00b*-00c-00d#-p00f\b-00g-00h-####00i^^^-00j*1*2*3&-L00k-\n00l-/00m-----00n-fg000-00p-00r+",
-    )
+  assertThrows(
+    () =>
+      version(
+        "=Y00a-f*v00b*-00c-00d#-p00f\b-00g-00h-####00i^^^-00j*1*2*3&-L00k-\n00l-/00m-----00n-fg000-00p-00r+",
+      ),
+    TypeError,
+    "Cannot detect UUID version: received =Y00a-f*v00b*-00c-00d#-p00f\b-00g-00h-####00i^^^-00j*1*2*3&-L00k-\n00l-/00m-----00n-fg000-00p-00r+",
   );
 });


### PR DESCRIPTION
This PR improves the test of `version` function of `@std/uuid` package