### PR TITLE
chore: specify import map path in version_bump workflow

### DIFF
--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Run version bump
         run: |
           git fetch --unshallow origin
-          deno run -A jsr:@deno/bump-workspaces@^0.1/cli
+          deno run -A jsr:@deno/bump-workspaces@^0.1/cli --import-map import_map.json
         env:
           GITHUB_TOKEN: ${{ secrets.DENOBOT_PAT }}
           GIT_USER_NAME: ${{ github.actor }}


### PR DESCRIPTION
This PR specifies import map path in version_bump workflow using https://github.com/denoland/bump-workspaces/pull/31

This is now necessary as we use custom (non-`deno.json`) import map path.