### PR TITLE
fix(msgpack): accept readonly input data in `encode()`

### DIFF
--- a/msgpack/encode.ts
+++ b/msgpack/encode.ts
@@ -13,7 +13,7 @@ export type ValueType =
   | boolean
   | null
   | Uint8Array
-  | ValueType[]
+  | readonly ValueType[]
   | ValueMap;
 
 /**

--- a/msgpack/encode_test.ts
+++ b/msgpack/encode_test.ts
@@ -214,3 +214,15 @@ Deno.test("encode() throws when the object is an instance of a custom class", ()
     "Cannot safely encode value into messagepack",
   );
 });
+
+Deno.test("encode() accepts `as const` data", () => {
+  const data = {
+    a: 1,
+    b: { c: 2 },
+    d: [3, { e: 4 }],
+  } as const;
+
+  void (() => {
+    encode(data);
+  });
+});


### PR DESCRIPTION
Towards https://github.com/denoland/std/issues/5831