### PR TITLE
docs(cache): document valid range information for TTL values

### DIFF
--- a/cache/ttl_cache.ts
+++ b/cache/ttl_cache.ts
@@ -35,8 +35,9 @@ export class TtlCache<K, V> extends Map<K, V>
    *
    * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
-   * @param defaultTtl The default time-to-live in milliseconds.
-   * This value should be in the range `-1 < n < 2 ** 31`.
+   * @param defaultTtl The default time-to-live in milliseconds. This value must
+   * be equal to or greater than 0. It's limit is determined by the current
+   * runtime's {@linkcode setTimeout} implementation.
    */
   constructor(defaultTtl: number) {
     super();
@@ -51,8 +52,9 @@ export class TtlCache<K, V> extends Map<K, V>
    * @param key The cache key
    * @param value The value to set
    * @param ttl A custom time-to-live. If supplied, overrides the cache's
-   * default TTL for this entry. This value should be in the range
-   * `-1 < n < 2 ** 31`.
+   * default TTL for this entry. This value must
+   * be equal to or greater than 0. It's limit is determined by the current
+   * runtime's {@linkcode setTimeout} implementation.
    * @returns `this` for chaining.
    *
    * @example Usage

--- a/cache/ttl_cache.ts
+++ b/cache/ttl_cache.ts
@@ -6,7 +6,7 @@ import type { MemoizationCache } from "./memoize.ts";
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
- * Automatically removes entries once the configured amount of time elapses.
+ * Automatically removes entries after the configured amount of time elapses.
  *
  * @typeParam K The type of the cache keys.
  * @typeParam V The type of the cache values.
@@ -35,7 +35,8 @@ export class TtlCache<K, V> extends Map<K, V>
    *
    * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
-   * @param defaultTtl The default time-to-live in milliseconds
+   * @param defaultTtl The default time-to-live in milliseconds.
+   * This value should be in the range `-1 < n < 2 ** 31`.
    */
   constructor(defaultTtl: number) {
     super();
@@ -49,7 +50,9 @@ export class TtlCache<K, V> extends Map<K, V>
    *
    * @param key The cache key
    * @param value The value to set
-   * @param ttl A custom time-to-live. If supplied, overrides the cache's default TTL for this entry.
+   * @param ttl A custom time-to-live. If supplied, overrides the cache's
+   * default TTL for this entry. This value should be in the range
+   * `-1 < n < 2 ** 31`.
    * @returns `this` for chaining.
    *
    * @example Usage

--- a/cache/ttl_cache.ts
+++ b/cache/ttl_cache.ts
@@ -36,7 +36,7 @@ export class TtlCache<K, V> extends Map<K, V>
    * @experimental **UNSTABLE**: New API, yet to be vetted.
    *
    * @param defaultTtl The default time-to-live in milliseconds. This value must
-   * be equal to or greater than 0. It's limit is determined by the current
+   * be equal to or greater than 0. Its limit is determined by the current
    * runtime's {@linkcode setTimeout} implementation.
    */
   constructor(defaultTtl: number) {
@@ -53,7 +53,7 @@ export class TtlCache<K, V> extends Map<K, V>
    * @param value The value to set
    * @param ttl A custom time-to-live. If supplied, overrides the cache's
    * default TTL for this entry. This value must
-   * be equal to or greater than 0. It's limit is determined by the current
+   * be equal to or greater than 0. Its limit is determined by the current
    * runtime's {@linkcode setTimeout} implementation.
    * @returns `this` for chaining.
    *

--- a/cache/ttl_cache_test.ts
+++ b/cache/ttl_cache_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { TtlCache } from "./ttl_cache.ts";
-import { assertEquals, AssertionError, assertRejects } from "@std/assert";
+import { assertEquals } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
 
 const UNSET = Symbol("UNSET");
@@ -33,29 +33,6 @@ function assertContentfulEntries<K, V>(
   assertEquals([...cache.keys()], keys);
   assertEquals([...cache.values()], values);
   assertEquals([...cache], entries);
-}
-
-async function assertTimerDoesNotCompletePrematurely(
-  interval: number,
-): Promise<void> {
-  let timestamp: number | undefined;
-  const expectedTimeStamp = Date.now() + interval;
-
-  const timerId = setTimeout(() => {
-    timestamp = Date.now();
-  }, interval);
-
-  await new Promise((resolve) => setTimeout(resolve, 1));
-
-  if (timestamp) {
-    throw new AssertionError(
-      `The callback completed ${
-        expectedTimeStamp - Date.now()
-      } ms earlier than expected.`,
-    );
-  }
-
-  clearTimeout(timerId);
 }
 
 Deno.test("TtlCache deletes entries", async (t) => {
@@ -125,18 +102,4 @@ Deno.test("TtlCache deletes entries", async (t) => {
     using cache = new TtlCache<number, string>(10);
     cache.set(1, "one");
   });
-});
-
-Deno.test("TTL implementation: setTimeout()", async (t) => {
-  await t.step(
-    "Schedules intervals less than 2 ** 31",
-    () => assertTimerDoesNotCompletePrematurely(2 ** 31 - 1),
-  );
-
-  await t.step(
-    "Fails to schedule intervals greater than or equal to 2 ** 31",
-    async () => {
-      await assertRejects(() => assertTimerDoesNotCompletePrematurely(2 ** 31));
-    },
-  );
 });


### PR DESCRIPTION
Ref:
- https://github.com/denoland/std/pull/5662#pullrequestreview-2261065977

/cc @iuioiua In response to [your comment](https://github.com/denoland/std/pull/5662#issuecomment-2311270279) — feel free to refactor as you see fit