### PR TITLE
refactor(expect): align error messages in the matchers

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -301,7 +301,7 @@ export function toHaveLength(
   } else {
     if (!hasLength) {
       throw new AssertionError(
-        `Expected value to have length ${expected}, but it does not. (The value has length ${maybeLength})`,
+        `Expected value to have length ${expected}, but it does not: the value has length ${maybeLength}`,
       );
     }
   }
@@ -352,7 +352,7 @@ export function toHaveProperty(
       throw new AssertionError(
         `Expected the value not to have the property ${
           propPath.join(".")
-        }${ofValue}, but it does.`,
+        }${ofValue}, but it does`,
       );
     }
   } else {
@@ -360,7 +360,7 @@ export function toHaveProperty(
       throw new AssertionError(
         `Expected the value to have the property ${
           propPath.join(".")
-        }${ofValue}, but it does not.`,
+        }${ofValue}, but it does not`,
       );
     }
   }
@@ -417,7 +417,7 @@ export function toContainEqual(
   if (context.isNot) {
     if (doesContain) {
       throw new AssertionError(
-        `The value contains the expected item.
+        `The value contains the expected item:
 Value: ${fmtValue}
 Expected: ${fmtExpected}`,
       );
@@ -425,7 +425,7 @@ Expected: ${fmtExpected}`,
   } else {
     if (!doesContain) {
       throw new AssertionError(
-        `The value doesn't contain the expected item.
+        `The value doesn't contain the expected item:
 Value: ${fmtValue}
 Expected: ${fmtExpected}`,
       );
@@ -587,13 +587,13 @@ export function toHaveBeenLastCalledWith(
         throw new AssertionError(
           `Expected mock function to be last called with ${
             inspectArgs(expected)
-          }, but it was not.`,
+          }, but it was not`,
         );
       } else {
         throw new AssertionError(
           `Expected mock function to be last called with ${
             inspectArgs(expected)
-          }, but it was last called with ${inspectArgs(lastCall.args)}.`,
+          }, but it was last called with ${inspectArgs(lastCall.args)}`,
         );
       }
     }
@@ -605,7 +605,7 @@ export function toHaveBeenNthCalledWith(
   ...expected: unknown[]
 ): MatchResult {
   if (nth < 1) {
-    throw new Error(`nth must be greater than 0. ${nth} was given.`);
+    throw new Error(`nth must be greater than 0: received ${nth}`);
   }
 
   const calls = getMockCalls(context.value);
@@ -628,13 +628,13 @@ export function toHaveBeenNthCalledWith(
         throw new AssertionError(
           `Expected the n-th call (n=${nth}) of mock function is with ${
             inspectArgs(expected)
-          }, but the n-th call does not exist.`,
+          }, but the n-th call does not exist`,
         );
       } else {
         throw new AssertionError(
           `Expected the n-th call (n=${nth}) of mock function is with ${
             inspectArgs(expected)
-          }, but it was with ${inspectArgs(nthCall.args)}.`,
+          }, but it was with ${inspectArgs(nthCall.args)}`,
         );
       }
     }

--- a/expect/_to_contain_equal_test.ts
+++ b/expect/_to_contain_equal_test.ts
@@ -14,7 +14,7 @@ Deno.test("expect().toContainEqual()", () => {
       expect(arr).toContainEqual({ bar: 42 });
     },
     AssertionError,
-    `The value doesn't contain the expected item.
+    `The value doesn't contain the expected item:
 Value: [{foo: 42},{bar: 43},{baz: 44}]
 Expected: {bar: 42}`,
   );
@@ -24,7 +24,7 @@ Expected: {bar: 42}`,
       expect(arr).not.toContainEqual({ foo: 42 });
     },
     AssertionError,
-    `The value contains the expected item.
+    `The value contains the expected item:
 Value: [{foo: 42},{bar: 43},{baz: 44}]
 Expected: {foo: 42}`,
   );

--- a/expect/_to_have_been_last_called_with_test.ts
+++ b/expect/_to_have_been_last_called_with_test.ts
@@ -30,6 +30,6 @@ Deno.test("expect().toHaveBeenLastCalledWith() handles the case when the mock is
   assertThrows(
     () => expect(mockFn).toHaveBeenLastCalledWith(1, 2, 3),
     AssertionError,
-    "Expected mock function to be last called with 1, 2, 3, but it was not.",
+    "Expected mock function to be last called with 1, 2, 3, but it was not",
   );
 });

--- a/expect/_to_have_been_nth_called_with_test.ts
+++ b/expect/_to_have_been_nth_called_with_test.ts
@@ -39,7 +39,7 @@ Deno.test("expect().toHaveBeenNthCalledWith() should throw when mock call does n
       expect(mockFn).toHaveBeenNthCalledWith(2, "hello");
     },
     AssertionError,
-    'Expected the n-th call (n=2) of mock function is with "hello", but the n-th call does not exist.',
+    'Expected the n-th call (n=2) of mock function is with "hello", but the n-th call does not exist',
   );
 });
 
@@ -51,6 +51,6 @@ Deno.test("expect().toHaveBeenNthCalledWith() throw when n is not a positive int
       expect(mockFn).toHaveBeenNthCalledWith(0, "hello");
     },
     Error,
-    "nth must be greater than 0. 0 was given.",
+    "nth must be greater than 0: received 0",
   );
 });


### PR DESCRIPTION
Aligns the error messages in the matchers in `expect` folder to match the style guide.

https://github.com/denoland/std/issues/5574