### PR TITLE
refactor(yaml): change error message in `stringifyNode()`

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -29,7 +29,7 @@ import {
 } from "./_chars.ts";
 import { DEFAULT_SCHEMA, type Schema } from "./_schema.ts";
 import type { KindType, RepresentFn, StyleVariant, Type } from "./_type.ts";
-import { getObjectTypeString, isObject } from "./_utils.ts";
+import { isObject } from "./_utils.ts";
 
 const STYLE_PLAIN = 1;
 const STYLE_SINGLE = 2;
@@ -838,9 +838,7 @@ export class DumperState {
         }
       } else {
         if (this.skipInvalid) return null;
-        throw new TypeError(
-          `Cannot stringify object of type: ${getObjectTypeString(value)}`,
-        );
+        throw new TypeError(`Cannot stringify ${typeof value}`);
       }
 
       if (tag !== null && tag !== "?") {

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -140,11 +140,15 @@ Deno.test({
 Deno.test({
   name: "stringify() throws with `!!js/*` yaml types with default schemas",
   fn() {
-    const object = { undefined: undefined };
     assertThrows(
-      () => stringify(object),
+      () => stringify(undefined),
       TypeError,
-      "Cannot stringify object of type: [object Undefined]",
+      "Cannot stringify undefined",
+    );
+    assertThrows(
+      () => stringify(() => {}),
+      TypeError,
+      "Cannot stringify function",
     );
   },
 });
@@ -676,7 +680,10 @@ Deno.test("stringify() uses quotes around deprecated boolean notations when `com
 });
 
 Deno.test("stringify() handles undefined with skipInvalid option", () => {
-  assertEquals(stringify(undefined, { skipInvalid: true }), "");
+  assertEquals(
+    stringify(undefined, { skipInvalid: true }),
+    "",
+  );
 });
 
 Deno.test({


### PR DESCRIPTION
**Changes**
This PR changes the error message in `stringifyNode()`.
**Reasoning**
The error will not throw if the value is an object. so `object` should be dropped from the message.
For the same reason, `typeof` should suffice. 