### PR TITLE
refactor(yaml): simplify pair `construct()` function

### DIFF
--- a/yaml/_type/pairs.ts
+++ b/yaml/_type/pairs.ts
@@ -27,16 +27,7 @@ function resolveYamlPairs(data: unknown[][]): boolean {
 export const pairs: Type<"sequence"> = {
   tag: "tag:yaml.org,2002:pairs",
   construct(data: Record<string, unknown>[] | null): [string, unknown][] {
-    /**
-     * @example
-     * ```ts
-     * import { assertEquals } from "@std/assert"
-     * const data = [ { Monday: 3 }, { Tuesday: 4 } ]
-     * const actual = data.flatMap(Object.entries)
-     * const expected = [ [ "Monday", 3 ], [ "Tuesday", 4 ] ]
-     * assertEquals(actual, expected)
-     * ```
-     */
+    // Converts an array of objects into an array of key-value pairs.
     return data?.flatMap(Object.entries) ?? [];
   },
   kind: "sequence",

--- a/yaml/_type/pairs.ts
+++ b/yaml/_type/pairs.ts
@@ -26,7 +26,7 @@ function resolveYamlPairs(data: unknown[][]): boolean {
 function constructYamlPairs(
   data: Record<string, unknown>[] | null,
 ): [string, unknown][] {
-  if (data === null) return [];
+  return data !== null ? data.flatMap(Object.entries) : [];
   const result: [string, unknown][] = Array.from({ length: data.length });
   for (const [index, pair] of data.entries()) {
     const key = Object.keys(pair)[0] as keyof typeof pair;

--- a/yaml/_type/pairs.ts
+++ b/yaml/_type/pairs.ts
@@ -23,17 +23,20 @@ function resolveYamlPairs(data: unknown[][]): boolean {
 
   return true;
 }
+
 function constructYamlPairs(
   data: Record<string, unknown>[] | null,
 ): [string, unknown][] {
-  return data !== null ? data.flatMap(Object.entries) : [];
-  const result: [string, unknown][] = Array.from({ length: data.length });
-  for (const [index, pair] of data.entries()) {
-    const key = Object.keys(pair)[0] as keyof typeof pair;
-    const value = pair[key];
-    result[index] = [key, value];
-  }
-  return result;
+  /**
+   * @example
+   * ```ts
+   * import { assertEquals } from "@std/assert"
+   * const data = [ { Monday: 3 }, { Tuesday: 4 } ]
+   * const pairs = data.flatMap(Object.entries)
+   * assertEquals(pairs, [ [ "Monday", 3 ], [ "Tuesday", 4 ] ])
+   * ```
+   */
+  return data?.flatMap(Object.entries) ?? [];
 }
 
 export const pairs: Type<"sequence"> = {

--- a/yaml/_type/pairs.ts
+++ b/yaml/_type/pairs.ts
@@ -32,8 +32,9 @@ export const pairs: Type<"sequence"> = {
      * ```ts
      * import { assertEquals } from "@std/assert"
      * const data = [ { Monday: 3 }, { Tuesday: 4 } ]
-     * const pairs = data.flatMap(Object.entries)
-     * assertEquals(pairs, [ [ "Monday", 3 ], [ "Tuesday", 4 ] ])
+     * const actual = data.flatMap(Object.entries)
+     * const expected = [ [ "Monday", 3 ], [ "Tuesday", 4 ] ]
+     * assertEquals(actual, expected)
      * ```
      */
     return data?.flatMap(Object.entries) ?? [];

--- a/yaml/_type/pairs.ts
+++ b/yaml/_type/pairs.ts
@@ -25,19 +25,16 @@ function resolveYamlPairs(data: unknown[][]): boolean {
 
   return true;
 }
-function constructYamlPairs(data: string) {
+function constructYamlPairs(
+  data: Record<string, unknown>[] | null,
+): [string, unknown][] {
   if (data === null) return [];
-
-  const result = Array.from({ length: data.length });
-
-  for (let index = 0; index < data.length; index += 1) {
-    const pair = data[index]!;
-
-    const keys = Object.keys(pair);
-
-    result[index] = [keys[0], pair[keys[0] as keyof typeof pair]];
+  const result: [string, unknown][] = Array.from({ length: data.length });
+  for (const [index, pair] of data.entries()) {
+    const key = Object.keys(pair)[0] as keyof typeof pair;
+    const value = pair[key];
+    result[index] = [key, value];
   }
-
   return result;
 }
 

--- a/yaml/_type/pairs.ts
+++ b/yaml/_type/pairs.ts
@@ -24,24 +24,20 @@ function resolveYamlPairs(data: unknown[][]): boolean {
   return true;
 }
 
-function constructYamlPairs(
-  data: Record<string, unknown>[] | null,
-): [string, unknown][] {
-  /**
-   * @example
-   * ```ts
-   * import { assertEquals } from "@std/assert"
-   * const data = [ { Monday: 3 }, { Tuesday: 4 } ]
-   * const pairs = data.flatMap(Object.entries)
-   * assertEquals(pairs, [ [ "Monday", 3 ], [ "Tuesday", 4 ] ])
-   * ```
-   */
-  return data?.flatMap(Object.entries) ?? [];
-}
-
 export const pairs: Type<"sequence"> = {
   tag: "tag:yaml.org,2002:pairs",
-  construct: constructYamlPairs,
+  construct(data: Record<string, unknown>[] | null): [string, unknown][] {
+    /**
+     * @example
+     * ```ts
+     * import { assertEquals } from "@std/assert"
+     * const data = [ { Monday: 3 }, { Tuesday: 4 } ]
+     * const pairs = data.flatMap(Object.entries)
+     * assertEquals(pairs, [ [ "Monday", 3 ], [ "Tuesday", 4 ] ])
+     * ```
+     */
+    return data?.flatMap(Object.entries) ?? [];
+  },
   kind: "sequence",
   resolve: resolveYamlPairs,
 };


### PR DESCRIPTION
**Changes**
This PR simplifies the pair `construct()` function and adds correct types.