### PR TITLE
fix(dotenv): handle single-quotes in values in `stringify()`

### DIFF
--- a/dotenv/stringify.ts
+++ b/dotenv/stringify.ts
@@ -27,7 +27,7 @@ export function stringify(object: Record<string, string>): string {
         `key starts with a '#' indicates a comment and is ignored: '${key}'`,
       );
       continue;
-    } else if (escapedValue.includes("\n")) {
+    } else if (escapedValue.includes("\n") || escapedValue.includes("'")) {
       // escape inner new lines
       escapedValue = escapedValue.replaceAll("\n", "\\n");
       quote = `"`;

--- a/dotenv/stringify_test.ts
+++ b/dotenv/stringify_test.ts
@@ -80,7 +80,7 @@ Deno.test("stringify()", async (t) => {
       ),
   );
   await t.step(
-    "parse", 
+    "parse",
     () =>
       assertEquals(
         parse(stringify({ PARSE: "par'se" })),

--- a/dotenv/stringify_test.ts
+++ b/dotenv/stringify_test.ts
@@ -79,7 +79,12 @@ Deno.test("stringify()", async (t) => {
         `NULL=`,
       ),
   );
-  await t.step("parse", () =>
-    assertEquals(parse(stringify({ PARSE: "par'se" })), { PARSE: "par'se" })
+  await t.step(
+    "parse", 
+    () =>
+      assertEquals(
+        parse(stringify({ PARSE: "par'se" })),
+        { PARSE: "par'se" },
+      ),
   );
 });

--- a/dotenv/stringify_test.ts
+++ b/dotenv/stringify_test.ts
@@ -2,6 +2,7 @@
 
 import { assertEquals } from "@std/assert";
 import { stringify } from "./stringify.ts";
+import { parse } from "./parse.ts";
 
 Deno.test("stringify()", async (t) => {
   await t.step(
@@ -77,5 +78,8 @@ Deno.test("stringify()", async (t) => {
         stringify({ "NULL": null } as unknown as Record<string, string>),
         `NULL=`,
       ),
+  );
+  await t.step("parse", () =>
+    assertEquals(parse(stringify({ PARSE: "par'se" })), { PARSE: "par'se" })
   );
 });

--- a/dotenv/stringify_test.ts
+++ b/dotenv/stringify_test.ts
@@ -2,7 +2,6 @@
 
 import { assertEquals } from "@std/assert";
 import { stringify } from "./stringify.ts";
-import { parse } from "./parse.ts";
 
 Deno.test("stringify()", async (t) => {
   await t.step(
@@ -79,12 +78,9 @@ Deno.test("stringify()", async (t) => {
         `NULL=`,
       ),
   );
-  await t.step(
-    "parse",
-    () =>
-      assertEquals(
-        parse(stringify({ PARSE: "par'se" })),
-        { PARSE: "par'se" },
-      ),
-  );
+  await t.step("handles single-quote characters", () =>
+    assertEquals(
+      stringify({ PARSE: "par'se" }),
+      `PARSE="par'se"`,
+    ));
 });


### PR DESCRIPTION
Currently, stringify has a bug to parse JSON string.

Here is an example:
```ts
input { FOO: "{'key': 'value'}" }
input_stringify FOO='{\'key\': \'value\'}'
parsed_input { FOO: "{\\" }
```

After fix
```ts
input { FOO: "{'key': 'value'}" }
input_stringify FOO="{'key': 'value'}"
parsed_input { FOO: "{'key': 'value'}" }
```

Codebase to test
```ts
const input = { FOO: "{'key': 'value'}" };
const input_stringify = dotenv.stringify(input);
const parsed_input = dotenv.parse(input_stringify);

console.log("input", input);
console.log("input_stringify", input_stringify);
console.log("parsed_input", parsed_input);
```