### PR TITLE
refactor(assert,datetime,fmt,io,streams): consistently `throw new Error()` instead of `throw Error()`

### DIFF
--- a/assert/rejects.ts
+++ b/assert/rejects.ts
@@ -93,7 +93,7 @@ export async function assertRejects<E extends Error = Error>(
       isPromiseReturned = true;
       await possiblePromise;
     } else {
-      throw Error();
+      throw new Error();
     }
   } catch (error) {
     if (!isPromiseReturned) {

--- a/datetime/_date_time_formatter.ts
+++ b/datetime/_date_time_formatter.ts
@@ -191,7 +191,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `FormatterError: value "${part.value}" is not supported`,
               );
           }
@@ -209,7 +209,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `FormatterError: value "${part.value}" is not supported`,
               );
           }
@@ -227,7 +227,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `FormatterError: value "${part.value}" is not supported`,
               );
           }
@@ -249,7 +249,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `FormatterError: value "${part.value}" is not supported`,
               );
           }
@@ -267,7 +267,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `FormatterError: value "${part.value}" is not supported`,
               );
           }
@@ -285,7 +285,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `FormatterError: value "${part.value}" is not supported`,
               );
           }
@@ -313,7 +313,7 @@ export class DateTimeFormatter {
         }
 
         default:
-          throw Error(`FormatterError: { ${part.type} ${part.value} }`);
+          throw new Error(`FormatterError: { ${part.type} ${part.value} }`);
       }
     }
 
@@ -339,7 +339,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `ParserError: value "${part.value}" is not supported`,
               );
           }
@@ -368,7 +368,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `ParserError: value "${part.value}" is not supported`,
               );
           }
@@ -385,7 +385,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `ParserError: value "${part.value}" is not supported`,
               );
           }
@@ -412,7 +412,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `ParserError: value "${part.value}" is not supported`,
               );
           }
@@ -429,7 +429,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `ParserError: value "${part.value}" is not supported`,
               );
           }
@@ -446,7 +446,7 @@ export class DateTimeFormatter {
               break;
             }
             default:
-              throw Error(
+              throw new Error(
                 `ParserError: value "${part.value}" is not supported`,
               );
           }
@@ -481,7 +481,7 @@ export class DateTimeFormatter {
         }
         case "literal": {
           if (!string.startsWith(part.value as string)) {
-            throw Error(
+            throw new Error(
               `Literal "${part.value}" not found "${string.slice(0, 25)}"`,
             );
           }
@@ -490,13 +490,13 @@ export class DateTimeFormatter {
         }
 
         default:
-          throw Error(
+          throw new Error(
             `Cannot format the date, the value (${part.value}) of the type (${part.type}) is given`,
           );
       }
 
       if (!value) {
-        throw Error(
+        throw new Error(
           `Cannot format value: The value is not valid for part { ${type} ${value} } ${
             string.slice(
               0,
@@ -511,7 +511,7 @@ export class DateTimeFormatter {
     }
 
     if (string.length) {
-      throw Error(
+      throw new Error(
         `datetime string was not fully parsed! ${string.slice(0, 25)}`,
       );
     }

--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -242,7 +242,7 @@ class Printf {
           }
           break;
         default:
-          throw Error(
+          throw new Error(
             `State ${this.state} should be unreachable, please file a bug report against Deno at https://github.com/denoland/std/issues`,
           );
       }

--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -226,7 +226,7 @@ export class BufReader implements Reader {
     }
 
     if (this.#w >= this.#buf.byteLength) {
-      throw Error("Buffer full while filling");
+      throw new Error("Buffer full while filling");
     }
 
     // Read new data: try a limited number of times.
@@ -636,7 +636,7 @@ export class BufReader implements Reader {
    */
   async peek(n: number): Promise<Uint8Array | null> {
     if (n < 0) {
-      throw Error("Peek count cannot be negative");
+      throw new Error("Peek count cannot be negative");
     }
 
     let avail = this.#w - this.#r;

--- a/io/buf_reader_test.ts
+++ b/io/buf_reader_test.ts
@@ -21,7 +21,7 @@ class OneByteReader implements Reader {
       return Promise.resolve(0);
     }
     if (!(p instanceof Uint8Array)) {
-      throw Error("Expected Uint8Array");
+      throw new Error("Expected Uint8Array");
     }
     return Promise.resolve(this.r.read(p.subarray(0, 1)));
   }
@@ -35,7 +35,7 @@ class HalfReader implements Reader {
 
   read(p: Uint8Array): Promise<number | null> {
     if (!(p instanceof Uint8Array)) {
-      throw Error("Expected Uint8Array");
+      throw new Error("Expected Uint8Array");
     }
     const half = Math.floor((p.byteLength + 1) / 2);
     return Promise.resolve(this.r.read(p.subarray(0, half)));

--- a/io/buffer.ts
+++ b/io/buffer.ts
@@ -171,7 +171,7 @@ export class Buffer implements Writer, WriterSync, Reader, ReaderSync {
       return;
     }
     if (n < 0 || n > this.length) {
-      throw Error("Buffer truncation out of range");
+      throw new Error("Buffer truncation out of range");
     }
     this.#reslice(this.#off + n);
   }
@@ -389,7 +389,7 @@ export class Buffer implements Writer, WriterSync, Reader, ReaderSync {
    */
   grow(n: number) {
     if (n < 0) {
-      throw Error("Buffer growth cannot be negative");
+      throw new Error("Buffer growth cannot be negative");
     }
     const m = this.#grow(n);
     this.#reslice(m);

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -315,7 +315,7 @@ export class Buffer {
       return;
     }
     if (n < 0 || n > this.length) {
-      throw Error(
+      throw new Error(
         `Buffer truncation value "${n}" is not between 0 and ${this.length}`,
       );
     }
@@ -417,7 +417,7 @@ export class Buffer {
    */
   grow(n: number) {
     if (n < 0) {
-      throw Error(
+      throw new Error(
         `Cannot grow buffer as growth must be positive: received ${n}`,
       );
     }


### PR DESCRIPTION
…nstead of `throw`

To ensure consistency across the codebase, this commit refactors the codebase to use `throw new Error` instead of `throw` for throwing errors.

https://github.com/denoland/std/issues/5854