### PR TITLE
fix(yaml): fix `sortKey` error message

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -666,7 +666,8 @@ export class DumperState {
     } else if (this.sortKeys) {
       // Something is wrong
       throw new TypeError(
-        '"sortKeys" must be a boolean or a function: received ${typeof this.sortKeys}',
+        `"sortKeys" must be a boolean or a function: received ${typeof this
+          .sortKeys}`,
       );
     }
 

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -535,6 +535,12 @@ Deno.test("stringify() changes the key order when the sortKeys option is specifi
 1.0.10: null
 `,
   );
+
+  assertThrows(
+    () => stringify(object, { sortKeys: "true" as unknown as boolean }),
+    TypeError,
+    '"sortKeys" must be a boolean or a function: received string',
+  );
 });
 
 Deno.test("stringify() changes line wrap behavior based on lineWidth option", () => {


### PR DESCRIPTION
**Changes**
This PR fixes the `sortKey` error message with template string and adds a test.

⚠️ **Note**
Instead of throwing an error, we might want to remove this type check completely, because it should be covered by typescript.
```ts
if (typeof this.sortKeys === "function") {
  objectKeyList.sort(this.sortKeys);
} else if (this.sortKeys) {
  objectKeyList.sort();
}
```
WDYT?