### PR TITLE
test(yaml): add invalid `represent` type test

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -28,7 +28,7 @@ import {
   VERTICAL_LINE,
 } from "./_chars.ts";
 import { DEFAULT_SCHEMA, type Schema } from "./_schema.ts";
-import type { KindType, RepresentFn, StyleVariant, Type } from "./_type.ts";
+import type { KindType, StyleVariant, Type } from "./_type.ts";
 import { isObject } from "./_utils.ts";
 
 const STYLE_PLAIN = 1;

--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -740,13 +740,13 @@ export class DumperState {
     if (typeof type.represent === "function") {
       return type.represent(value, style);
     }
-    if (Object.hasOwn(type.represent, style)) {
-      const represent = type.represent[style] as RepresentFn<unknown>;
-      return represent(value, style);
+    const represent = type.represent[style];
+    if (!represent) {
+      throw new TypeError(
+        `!<${type.tag}> tag resolver accepts not "${style}" style`,
+      );
     }
-    throw new TypeError(
-      `!<${type.tag}> tag resolver accepts not "${style}" style`,
-    );
+    return represent(value, style);
   }
 
   detectType(value: unknown): { tag: string | null; value: unknown } {

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -112,6 +112,12 @@ Deno.test({
       stringify([true, false], { styles: { "!!bool": "uppercase" } }),
       "- TRUE\n- FALSE\n",
     );
+
+    assertThrows(
+      () => stringify([true, false], { styles: { "!!bool": "octal" } }),
+      TypeError,
+      '!<tag:yaml.org,2002:bool> tag resolver accepts not "octal" style',
+    );
   },
 });
 


### PR DESCRIPTION
**Changes**
This PR adds test for invalid represent type value.
It also changes the function code to throw early.