### PR TITLE
fix(io): don't use `Deno.Buffer` in examples

### DIFF
--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -121,13 +121,13 @@ export interface ReadLineResult {
  *
  * @example Usage
  * ```ts
- * import { BufReader } from "@std/io";
+ * import { BufReader, Buffer } from "@std/io";
  * import { assertEquals } from "@std/assert/equals";
  *
  * const encoder = new TextEncoder();
  * const decoder = new TextDecoder();
  *
- * const reader = new BufReader(new Deno.Buffer(encoder.encode("hello world")));
+ * const reader = new BufReader(new Buffer(encoder.encode("hello world")));
  * const buf = new Uint8Array(11);
  * await reader.read(buf);
  * assertEquals(decoder.decode(buf), "hello world");

--- a/io/read_int.ts
+++ b/io/read_int.ts
@@ -8,11 +8,12 @@ import { readShort } from "./read_short.ts";
  *
  * @example Usage
  * ```ts
+ * import { Buffer } from "@std/io/buffer"
  * import { BufReader } from "@std/io/buf-reader";
  * import { readInt } from "@std/io/read-int";
  * import { assertEquals } from "@std/assert/equals";
  *
- * const buf = new BufReader(new Deno.Buffer(new Uint8Array([0x12, 0x34, 0x56, 0x78])));
+ * const buf = new BufReader(new Buffer(new Uint8Array([0x12, 0x34, 0x56, 0x78])));
  * const int = await readInt(buf);
  * assertEquals(int, 0x12345678);
  * ```

--- a/io/read_long.ts
+++ b/io/read_long.ts
@@ -10,11 +10,12 @@ const MAX_SAFE_INTEGER = BigInt(Number.MAX_SAFE_INTEGER);
  *
  * @example Usage
  * ```ts
+ * import { Buffer } from "@std/io/buffer"
  * import { BufReader } from "@std/io/buf-reader";
  * import { readLong } from "@std/io/read-long";
  * import { assertEquals } from "@std/assert/equals";
  *
- * const buf = new BufReader(new Deno.Buffer(new Uint8Array([0, 0, 0, 0x12, 0x34, 0x56, 0x78, 0x9a])));
+ * const buf = new BufReader(new Buffer(new Uint8Array([0, 0, 0, 0x12, 0x34, 0x56, 0x78, 0x9a])));
  * const long = await readLong(buf);
  * assertEquals(long, 0x123456789a);
  * ```

--- a/io/read_short.ts
+++ b/io/read_short.ts
@@ -7,11 +7,12 @@ import type { BufReader } from "./buf_reader.ts";
  *
  * @example Usage
  * ```ts
+ * import { Buffer } from "@std/io/buffer"
  * import { BufReader } from "@std/io/buf-reader";
  * import { readShort } from "@std/io/read-short";
  * import { assertEquals } from "@std/assert/equals";
  *
- * const buf = new BufReader(new Deno.Buffer(new Uint8Array([0x12, 0x34])));
+ * const buf = new BufReader(new Buffer(new Uint8Array([0x12, 0x34])));
  * const short = await readShort(buf);
  * assertEquals(short, 0x1234);
  * ```


### PR DESCRIPTION
To fix the CI linting errors 