### PR TITLE
fix(async,csv,fmt): assign default value when `undefined` is passed

### DIFF
--- a/async/retry_test.ts
+++ b/async/retry_test.ts
@@ -23,10 +23,20 @@ Deno.test("retry()", async () => {
   assertEquals(result, 3);
 });
 
-Deno.test("retry() fails after max errors is passed", async () => {
+Deno.test("retry() fails after five errors by default", async () => {
   const fiveErrors = generateErroringFunction(5);
   await assertRejects(() =>
     retry(fiveErrors, {
+      minTimeout: 100,
+    })
+  );
+});
+
+Deno.test("retry() fails after five errors when undefined is passed", async () => {
+  const fiveErrors = generateErroringFunction(5);
+  await assertRejects(() =>
+    retry(fiveErrors, {
+      maxAttempts: undefined,
       minTimeout: 100,
     })
   );

--- a/csv/_io.ts
+++ b/csv/_io.ts
@@ -51,11 +51,6 @@ export interface ReadOptions {
   fieldsPerRecord?: number;
 }
 
-export const defaultReadOptions: ReadOptions = {
-  separator: ",",
-  trimLeadingSpace: false,
-};
-
 export interface LineReader {
   readLine(): Promise<string | null>;
   isEOF(): boolean;

--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -3,7 +3,6 @@
 
 import {
   convertRowToObject,
-  defaultReadOptions,
   type LineReader,
   parseRecord,
   type ParseResult,
@@ -370,8 +369,9 @@ export class CsvParseStream<
    */
   constructor(options?: T) {
     this.#options = {
-      ...defaultReadOptions,
       ...options,
+      separator: options?.separator ?? ",",
+      trimLeadingSpace: options?.trimLeadingSpace ?? false,
     };
 
     if (

--- a/csv/parse_stream_test.ts
+++ b/csv/parse_stream_test.ts
@@ -82,12 +82,9 @@ Deno.test({
       },
       {
         name: "Separator is undefined",
-        input: "a;b;c\n",
+        input: "a,b,c\n",
+        output: [["a", "b", "c"]],
         separator: undefined,
-        error: {
-          klass: TypeError,
-          msg: "Cannot parse record: separator is required",
-        },
       },
       {
         name: "MultiLine",

--- a/fmt/duration.ts
+++ b/fmt/duration.ts
@@ -118,17 +118,18 @@ export interface FormatOptions {
  */
 export function format(
   ms: number,
-  options: FormatOptions = {},
+  options?: FormatOptions,
 ): string {
-  const opt = Object.assign(
-    { style: "narrow", ignoreZero: false },
-    options,
-  );
+  const {
+    style = "narrow",
+    ignoreZero = false,
+  } = options ?? {};
+
   const duration = millisecondsToDurationObject(ms);
   const durationArr = durationArray(duration);
-  switch (opt.style) {
+  switch (style) {
     case "narrow": {
-      if (opt.ignoreZero) {
+      if (ignoreZero) {
         return `${
           durationArr.filter((x) => x.value).map((x) =>
             `${x.value}${x.type === "us" ? "µs" : x.type}`
@@ -142,7 +143,7 @@ export function format(
       }`;
     }
     case "full": {
-      if (opt.ignoreZero) {
+      if (ignoreZero) {
         return `${
           durationArr.filter((x) => x.value).map((x) =>
             `${x.value} ${keyList[x.type]}`
@@ -159,7 +160,7 @@ export function format(
           ? addZero(x.value, 3)
           : addZero(x.value, 2)
       );
-      if (opt.ignoreZero) {
+      if (ignoreZero) {
         let cont = true;
         while (cont) {
           if (!Number(arr[arr.length - 1])) arr.pop();

--- a/fmt/duration_test.ts
+++ b/fmt/duration_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { assertEquals, assertExists, assertThrows } from "@std/assert";
+import { assertEquals, assertExists } from "@std/assert";
 import { format } from "./duration.ts";
 
 Deno.test({

--- a/fmt/duration_test.ts
+++ b/fmt/duration_test.ts
@@ -17,6 +17,16 @@ Deno.test({
 });
 
 Deno.test({
+  name: "format() handles default style (narrow)",
+  fn() {
+    assertEquals(
+      format(99674, { style: undefined }),
+      "0d 0h 1m 39s 674ms 0µs 0ns",
+    );
+  },
+});
+
+Deno.test({
   name: "format() handles full duration",
   fn() {
     assertEquals(
@@ -77,18 +87,5 @@ Deno.test({
   name: "format() handles duration rounding error",
   fn() {
     assertEquals(format(16.342, { ignoreZero: true }), "16ms 342µs");
-  },
-});
-
-Deno.test({
-  name: "format() handles default style error",
-  fn() {
-    assertThrows(
-      () => {
-        format(16.342, { style: undefined });
-      },
-      TypeError,
-      `style must be "narrow", "full", or "digital"!`,
-    );
   },
 });


### PR DESCRIPTION
Related https://github.com/denoland/std/pull/5892#discussion_r1741451494

When using spread syntax or `Object.assign`, if a property with `undefined` is passed, overrides it.

```js
const options = { foo: undefined };

const spreaded = { foo: 1, ...options };
// => { foo: undefined }

const assigned = Object.assign({ foo: 1 }, options);
// => { foo: undefined }
```

This PR solves that problem by delaying the assignment of default values.