### PR TITLE
fix(yaml): handle string instances

### DIFF
--- a/yaml/_dumper_state.ts
+++ b/yaml/_dumper_state.ts
@@ -744,8 +744,12 @@ export class DumperState {
     if (block) {
       block = this.flowLevel < 0 || this.flowLevel > level;
     }
-
-    if (isObject(value)) {
+    if (typeof value === "string" || value instanceof String) {
+      value = value instanceof String ? value.valueOf() : value;
+      if (tag !== "?") {
+        value = this.stringifyScalar(value as string, { level, isKey });
+      }
+    } else if (isObject(value)) {
       const duplicateIndex = this.duplicates.indexOf(value);
       const duplicate = duplicateIndex !== -1;
 
@@ -788,10 +792,6 @@ export class DumperState {
             value = `&ref_${duplicateIndex} ${value}`;
           }
         }
-      }
-    } else if (typeof value === "string") {
-      if (tag !== "?") {
-        value = this.stringifyScalar(value, { level, isKey });
       }
     } else {
       if (this.skipInvalid) return null;

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -694,6 +694,7 @@ Oren: Ben-Kiki
 
 Deno.test("stringify() handles string", () => {
   assertEquals(stringify("Hello World"), "Hello World\n");
+  assertEquals(stringify(new String("Hello World")), "Hello World\n");
 });
 
 Deno.test("stringify() uses quotes around deprecated boolean notations when `compatMode: true`", () => {


### PR DESCRIPTION
Ref: https://github.com/denoland/std/issues/5857

**Note**
It seems weird to handle special treat strings in `stringifyNode()`. Maybe there is a way to move the evaluation inside `Type.predicate` like other types in a future PR.