### PR TITLE
fix(path/unstable): support `string | URL` in the 2nd overload of `basename`, `dirname`, and `extname`

### DIFF
--- a/path/basename.ts
+++ b/path/basename.ts
@@ -43,8 +43,10 @@ export function basename(path: string, suffix?: string): string;
  * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
+ *   assertEquals(basename("C:\\user\\Documents\\image.png"), "image.png");
  *   assertEquals(basename(new URL("file:///C:/user/Documents/image.png")), "image.png");
  * } else {
+ *   assertEquals(basename("/home/user/Documents/image.png"), "image.png");
  *   assertEquals(basename(new URL("file:///home/user/Documents/image.png")), "image.png");
  * }
  * ```
@@ -57,8 +59,6 @@ export function basename(path: string, suffix?: string): string;
 export function basename(path: string | URL, suffix?: string): string;
 export function basename(path: string | URL, suffix = ""): string {
   return isWindows
-    // deno-lint-ignore no-explicit-any
-    ? windowsBasename(path as any, suffix)
-    // deno-lint-ignore no-explicit-any
-    : posixBasename(path as any, suffix);
+    ? windowsBasename(path, suffix)
+    : posixBasename(path, suffix);
 }

--- a/path/dirname.ts
+++ b/path/dirname.ts
@@ -35,8 +35,10 @@ export function dirname(path: string): string;
  * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
+ *   assertEquals(dirname("C:\\home\\user\\Documents\\image.png"), "C:\\home\\user\\Documents");
  *   assertEquals(dirname(new URL("file:///C:/home/user/Documents/image.png")), "C:\\home\\user\\Documents");
  * } else {
+ *   assertEquals(dirname("/home/user/Documents/image.png"), "/home/user/Documents");
  *   assertEquals(dirname(new URL("file:///home/user/Documents/image.png")), "/home/user/Documents");
  * }
  * ```
@@ -44,8 +46,7 @@ export function dirname(path: string): string;
  * @param path Path to extract the directory from.
  * @returns The directory path.
  */
-export function dirname(path: URL): string;
+export function dirname(path: string | URL): string;
 export function dirname(path: string | URL): string {
-  // deno-lint-ignore no-explicit-any
-  return isWindows ? windowsDirname(path as any) : posixDirname(path as any);
+  return isWindows ? windowsDirname(path) : posixDirname(path);
 }

--- a/path/extname.ts
+++ b/path/extname.ts
@@ -34,8 +34,10 @@ export function extname(path: string): string;
  * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
+ *   assertEquals(extname("C:\\home\\user\\Documents\\image.png"), ".png");
  *   assertEquals(extname(new URL("file:///C:/home/user/Documents/image.png")), ".png");
  * } else {
+ *   assertEquals(extname("/home/user/Documents/image.png"), ".png");
  *   assertEquals(extname(new URL("file:///home/user/Documents/image.png")), ".png");
  * }
  * ```
@@ -43,8 +45,7 @@ export function extname(path: string): string;
  * @param path Path with extension.
  * @returns The file extension. E.g. returns `.ts` for `file.ts`.
  */
-export function extname(path: URL): string;
+export function extname(path: string | URL): string;
 export function extname(path: string | URL): string {
-  // deno-lint-ignore no-explicit-any
-  return isWindows ? windowsExtname(path as any) : posixExtname(path as any);
+  return isWindows ? windowsExtname(path) : posixExtname(path);
 }

--- a/path/posix/basename.ts
+++ b/path/posix/basename.ts
@@ -40,6 +40,9 @@ export function basename(path: string, suffix?: string): string;
  * import { basename } from "@std/path/posix/basename";
  * import { assertEquals } from "@std/assert";
  *
+ * assertEquals(basename("/home/user/Documents/"), "Documents");
+ * assertEquals(basename("/home/user/Documents/image.png"), "image.png");
+ * assertEquals(basename("/home/user/Documents/image.png", ".png"), "image");
  * assertEquals(basename(new URL("file:///home/user/Documents/image.png")), "image.png");
  * assertEquals(basename(new URL("file:///home/user/Documents/image.png"), ".png"), "image");
  * ```
@@ -48,7 +51,7 @@ export function basename(path: string, suffix?: string): string;
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
  */
-export function basename(path: URL, suffix?: string): string;
+export function basename(path: string | URL, suffix?: string): string;
 export function basename(path: string | URL, suffix = ""): string {
   path = path instanceof URL ? fromFileUrl(path) : path;
   assertArgs(path, suffix);

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -16,18 +16,6 @@ import { fromFileUrl } from "./from_file_url.ts";
  *
  * assertEquals(dirname("/home/user/Documents/"), "/home/user");
  * assertEquals(dirname("/home/user/Documents/image.png"), "/home/user/Documents");
- * assertEquals(dirname("https://deno.land/std/path/mod.ts"), "https://deno.land/std/path");
- * ```
- *
- * @example Working with URLs
- *
- * ```ts
- * import { dirname } from "@std/path/posix/dirname";
- * import { assertEquals } from "@std/assert";
- *
- * assertEquals(dirname("https://deno.land/std/path/mod.ts"), "https://deno.land/std/path");
- * assertEquals(dirname("https://deno.land/std/path/mod.ts?a=b"), "https://deno.land/std/path");
- * assertEquals(dirname("https://deno.land/std/path/mod.ts#header"), "https://deno.land/std/path");
  * ```
  *
  * @param path The path to get the directory from.
@@ -44,13 +32,15 @@ export function dirname(path: string): string;
  * import { dirname } from "@std/path/posix/dirname";
  * import { assertEquals } from "@std/assert";
  *
+ * assertEquals(dirname("/home/user/Documents/"), "/home/user");
+ * assertEquals(dirname("/home/user/Documents/image.png"), "/home/user/Documents");
  * assertEquals(dirname(new URL("file:///home/user/Documents/image.png")), "/home/user/Documents");
  * ```
  *
  * @param path The file url to get the directory from.
  * @returns The directory path.
  */
-export function dirname(path: URL): string;
+export function dirname(path: string | URL): string;
 export function dirname(path: string | URL): string {
   if (path instanceof URL) {
     path = fromFileUrl(path);

--- a/path/posix/extname.ts
+++ b/path/posix/extname.ts
@@ -36,6 +36,9 @@ export function extname(path: string): string;
  * import { extname } from "@std/path/posix/extname";
  * import { assertEquals } from "@std/assert";
  *
+ * assertEquals(extname("/home/user/Documents/file.ts"), ".ts");
+ * assertEquals(extname("/home/user/Documents/"), "");
+ * assertEquals(extname("/home/user/Documents/image.png"), ".png");
  * assertEquals(extname(new URL("file:///home/user/Documents/file.ts")), ".ts");
  * assertEquals(extname(new URL("file:///home/user/Documents/file.ts?a=b")), ".ts");
  * assertEquals(extname(new URL("file:///home/user/Documents/file.ts#header")), ".ts");
@@ -44,7 +47,7 @@ export function extname(path: string): string;
  * @param path The path to get the extension from.
  * @returns The extension (ex. for `file.ts` returns `.ts`).
  */
-export function extname(path: URL): string;
+export function extname(path: string | URL): string;
 export function extname(path: string | URL): string {
   if (path instanceof URL) {
     path = fromFileUrl(path);

--- a/path/posix/join.ts
+++ b/path/posix/join.ts
@@ -31,8 +31,8 @@ export function join(...paths: string[]): string;
  * import { join } from "@std/path/posix/join";
  * import { assertEquals } from "@std/assert";
  *
- * const path = join(new URL("file:///foo"), "bar", "baz/asdf", "quux", "..");
- * assertEquals(path, "/foo/bar/baz/asdf");
+ * assertEquals(join("/foo", "bar", "baz/asdf", "quux", ".."), "/foo/bar/baz/asdf");
+ * assertEquals(join(new URL("file:///foo"), "bar", "baz/asdf", "quux", ".."), "/foo/bar/baz/asdf");
  * ```
  *
  * @param path The path to join. This can be string or file URL.

--- a/path/windows/basename.ts
+++ b/path/windows/basename.ts
@@ -41,6 +41,9 @@ export function basename(path: string, suffix?: string): string;
  * import { basename } from "@std/path/windows/basename";
  * import { assertEquals } from "@std/assert";
  *
+ * assertEquals(basename("C:\\user\\Documents\\"), "Documents");
+ * assertEquals(basename("C:\\user\\Documents\\image.png"), "image.png");
+ * assertEquals(basename("C:\\user\\Documents\\image.png", ".png"), "image");
  * assertEquals(basename(new URL("file:///C:/user/Documents/image.png")), "image.png");
  * assertEquals(basename(new URL("file:///C:/user/Documents/image.png"), ".png"), "image");
  * ```
@@ -49,7 +52,7 @@ export function basename(path: string, suffix?: string): string;
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
  */
-export function basename(path: URL, suffix?: string): string;
+export function basename(path: string | URL, suffix?: string): string;
 export function basename(path: string | URL, suffix = ""): string {
   path = path instanceof URL ? fromFileUrl(path) : path;
   assertArgs(path, suffix);

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -37,13 +37,14 @@ export function dirname(path: string): string;
  * import { dirname } from "@std/path/windows/dirname";
  * import { assertEquals } from "@std/assert";
  *
+ * assertEquals(dirname("C:\\foo\\bar\\baz.ext"), "C:\\foo\\bar");
  * assertEquals(dirname(new URL("file:///C:/foo/bar/baz.ext")), "C:\\foo\\bar");
  * ```
  *
  * @param path The path to get the directory from.
  * @returns The directory path.
  */
-export function dirname(path: URL): string;
+export function dirname(path: string | URL): string;
 export function dirname(path: string | URL): string {
   if (path instanceof URL) {
     path = fromFileUrl(path);

--- a/path/windows/extname.ts
+++ b/path/windows/extname.ts
@@ -32,14 +32,14 @@ export function extname(path: string): string;
  * import { extname } from "@std/path/windows/extname";
  * import { assertEquals } from "@std/assert";
  *
- * const ext = extname(new URL("file:///C:/foo/bar/baz.ext"));
- * assertEquals(ext, ".ext");
+ * assertEquals(extname("file.ts"), ".ts");
+ * assertEquals(extname(new URL("file:///C:/foo/bar/baz.ext")), ".ext");
  * ```
  *
  * @param path The path to get the extension from.
  * @returns The extension of the `path`.
  */
-export function extname(path: URL): string;
+export function extname(path: string | URL): string;
 export function extname(path: string | URL): string {
   if (path instanceof URL) {
     path = fromFileUrl(path);

--- a/path/windows/join.ts
+++ b/path/windows/join.ts
@@ -32,8 +32,8 @@ export function join(...paths: string[]): string;
  * import { join } from "@std/path/windows/join";
  * import { assertEquals } from "@std/assert";
  *
- * const joined = join(new URL("file:///C:/foo"), "bar", "baz\\..");
- * assertEquals(joined, "C:\\foo\\bar");
+ * assertEquals(join("C:\\foo", "bar", "baz\\.."), "C:\\foo\\bar");
+ * assertEquals(join(new URL("file:///C:/foo"), "bar", "baz\\.."), "C:\\foo\\bar");
  * ```
  *
  * @param path The path to join. This can be string or file URL.


### PR DESCRIPTION
This PR changes the (unstable) 2nd overloads of `basename`, `dirname`, and `extname` to accept `string | URL` type. Now the 2nd overloads show how the APIs look like when they are stabilized . This also reduces the internal use of `any` types.

related: #5537