### PR TITLE
docs(url): update deprecation docs

### DIFF
--- a/url/basename.ts
+++ b/url/basename.ts
@@ -42,8 +42,8 @@ import { strip } from "./_strip.ts";
  * ```
  *
  * @deprecated Use
- * {@linkcode https://jsr.io/@std/path/doc/posix/~/basename | @std/path/posix/basename}
- * instead (examples included). `@std/url` will be removed in the future.
+ * {@linkcode https://jsr.io/@std/path/doc/~/basename | @std/path/basename}
+ * instead. `@std/url` will be removed in the future.
  */
 export function basename(url: string | URL, suffix?: string): string {
   url = new URL(url);

--- a/url/dirname.ts
+++ b/url/dirname.ts
@@ -23,8 +23,8 @@ import { strip } from "./_strip.ts";
  * ```
  *
  * @deprecated Use
- * {@linkcode https://jsr.io/@std/path/doc/posix/~/dirname | @std/path/posix/dirname}
- * instead (examples included). `@std/url` will be removed in the future.
+ * {@linkcode https://jsr.io/@std/path/doc/~/dirname | @std/path/dirname}
+ * instead. `@std/url` will be removed in the future.
  */
 
 export function dirname(url: string | URL): URL {

--- a/url/extname.ts
+++ b/url/extname.ts
@@ -25,8 +25,8 @@ import { strip } from "./_strip.ts";
  * ```
  *
  * @deprecated Use
- * {@linkcode https://jsr.io/@std/path/doc/posix/~/extname | @std/path/posix/extname}
- * instead (examples included). `@std/url` will be removed in the future.
+ * {@linkcode https://jsr.io/@std/path/doc/~/extname | @std/path/extname}
+ * instead. `@std/url` will be removed in the future.
  */
 export function extname(url: string | URL): string {
   url = new URL(url);

--- a/url/join.ts
+++ b/url/join.ts
@@ -22,8 +22,8 @@ import { join as posixJoin } from "@std/path/posix/join";
  * ```
  *
  * @deprecated Use
- * {@linkcode https://jsr.io/@std/path/doc/posix/~/join | @std/path/posix/join}
- * instead (examples included). `@std/url` will be removed in the future.
+ * {@linkcode https://jsr.io/@std/path/doc/~/join | @std/path/join}
+ * instead. `@std/url` will be removed in the future.
  */
 export function join(url: string | URL, ...paths: string[]): URL {
   url = new URL(url);

--- a/url/normalize.ts
+++ b/url/normalize.ts
@@ -21,8 +21,8 @@ import { normalize as posixNormalize } from "@std/path/posix/normalize";
  * ```
  *
  * @deprecated Use
- * {@linkcode https://jsr.io/@std/path/doc/posix/~/normalize | @std/path/posix/normalize}
- * instead (examples included). `@std/url` will be removed in the future.
+ * {@linkcode https://jsr.io/@std/path/doc/~/normalize | @std/path/normalize}
+ * instead. `@std/url` will be removed in the future.
  */
 export function normalize(url: string | URL): URL {
   url = new URL(url);


### PR DESCRIPTION
Now these `path` APIs directly support file URL input, and deprecation notes can be simplified.