### PR TITLE
fix(assert): value-equal complex keys

### DIFF
--- a/assert/equal.ts
+++ b/assert/equal.ts
@@ -124,9 +124,11 @@ export function equal(c: unknown, d: unknown): boolean {
             /* Given that Map keys can be references, we need
              * to ensure that they are also deeply equal */
 
+            if (!compare(aKey, bKey)) continue;
+
             if (
-              (aKey === aValue && bKey === bValue && compare(aKey, bKey)) ||
-              (compare(aKey, bKey) && compare(aValue, bValue))
+              (aKey === aValue && bKey === bValue) ||
+              (compare(aValue, bValue))
             ) {
               unmatchedEntries--;
               break;

--- a/assert/equal_test.ts
+++ b/assert/equal_test.ts
@@ -304,3 +304,43 @@ Deno.test("equal() fast path for primitive keyed collections", () => {
   const map6 = new Map(arr.with(-1, -1).map((v, i) => [i, v]));
   assertFalse(equal(map5, map6));
 });
+
+Deno.test("equal() keyed collection edge cases", () => {
+  assert(equal(new Set([{ b: 2 }, { a: 1 }]), new Set([{ a: 1 }, { b: 2 }])));
+  assertFalse(
+    equal(new Set([{ b: 2 }, { a: 1 }]), new Set([{ a: 1 }, { b: 3 }])),
+  );
+
+  const sym = Symbol();
+  assert(equal(new Set([sym]), new Set([sym])));
+  assert(equal(new Set([sym, "a"]), new Set(["a", sym])));
+  assertFalse(equal(new Set([sym, "a"]), new Set(["b", sym])));
+  assertFalse(equal(new Set([Symbol()]), new Set([Symbol()])));
+  assert(equal(new Set([Symbol.for("x")]), new Set([Symbol.for("x")])));
+
+  assert(equal(
+    new Map([[{ b: 2 }, 2], [{ a: 1 }, 1]]),
+    new Map([[{ a: 1 }, 1], [{ b: 2 }, 2]]),
+  ));
+  assertFalse(equal(
+    new Map([[{ b: 2 }, 2], [{ a: 1 }, 1]]),
+    new Map([[{ a: 1 }, 1], [{ b: 2 }, 3]]),
+  ));
+  assertFalse(equal(
+    new Map([[{ b: 2 }, 2], [{ a: 1 }, 1]]),
+    new Map([[{ a: 1 }, 1], [{ b: 3 }, 2]]),
+  ));
+
+  assert(equal(
+    new Map([[2, { b: 2 }], [1, { a: 1 }]]),
+    new Map([[1, { a: 1 }], [2, { b: 2 }]]),
+  ));
+  assertFalse(equal(
+    new Map([[2, { b: 2 }], [1, { a: 1 }]]),
+    new Map([[1, { a: 1 }], [3, { b: 2 }]]),
+  ));
+  assertFalse(equal(
+    new Map([[2, { b: 2 }], [1, { a: 1 }]]),
+    new Map([[1, { a: 1 }], [2, { b: 3 }]]),
+  ));
+});


### PR DESCRIPTION
Split from https://github.com/denoland/std/pull/5913. As with that PR, I haven't yet made any corresponding changes for `expect`.

Fixes (?) https://github.com/denoland/std/issues/5912 (not 100% sure it will be fixed for every possible edge case though)
