### PR TITLE
feat(collections): support `Iterable` argument in `slidingWindows()`

### DIFF
--- a/collections/sliding_windows.ts
+++ b/collections/sliding_windows.ts
@@ -87,8 +87,8 @@ export function slidingWindows<T>(
     throw new RangeError("Both size and step must be positive integer.");
   }
   if (
-    options.maxWindows &&
-    (Number.isInteger(options.maxWindows) && options.maxWindows <= 0)
+    options.maxWindows !== undefined &&
+    (!Number.isInteger(options.maxWindows) || options.maxWindows <= 0)
   ) {
     throw new RangeError("maxWindows must be a positive integer");
   }

--- a/collections/sliding_windows.ts
+++ b/collections/sliding_windows.ts
@@ -17,10 +17,16 @@ export interface SlidingWindowsOptions {
    * @default {false}
    */
   partial?: boolean;
+
+  /**
+   * If maxWindows is set, windows will be generated until the number of windows reaches maxWindows.
+   * This is particularly useful when you have an infinite iterable.
+   */
+  maxWindows?: number;
 }
 
 /**
- * Generates sliding views of the given array of the given size and returns a
+ * Generates sliding views of the given iterable of the given size and returns a
  * new array containing all of them.
  *
  * If step is set, each window will start that many elements after the last
@@ -29,13 +35,13 @@ export interface SlidingWindowsOptions {
  * If partial is set, windows will be generated for the last elements of the
  * collection, resulting in some undefined values if size is greater than 1.
  *
- * @typeParam T The type of the array elements.
+ * @typeParam T The type of the elements in the iterable.
  *
- * @param array The array to generate sliding windows from.
+ * @param iterable  The iterable to take elements from.
  * @param size The size of the sliding windows.
  * @param options The options for generating sliding windows.
  *
- * @returns A new array containing all sliding windows of the given size.
+ * @returns An array containing all sliding windows of the given size.
  *
  * @example Usage
  * ```ts
@@ -67,20 +73,61 @@ export interface SlidingWindowsOptions {
  * ```
  */
 export function slidingWindows<T>(
-  array: readonly T[],
+  iterable: Iterable<T>,
   size: number,
   options: SlidingWindowsOptions = {},
 ): T[][] {
-  const { step = 1, partial = false } = options;
-
+  const {
+    step = 1,
+    partial = false,
+  } = options;
   if (
     !Number.isInteger(size) || !Number.isInteger(step) || size <= 0 || step <= 0
   ) {
     throw new RangeError("Both size and step must be positive integer.");
   }
+  if (options.maxWindows && options.maxWindows <= 0) {
+    throw new RangeError("maxWindows must be a positive integer");
+  }
 
-  return Array.from(
-    { length: Math.floor((array.length - (partial ? 1 : size)) / step + 1) },
-    (_, i) => array.slice(i * step, i * step + size),
-  );
+  // when the iterable is an array, we can use a more efficient algorithm
+  // this also handles the special case where an array can have empty items [ <10 empty items> ]
+  if (Array.isArray(iterable)) {
+    const maxWindows = options.maxWindows ?? Infinity;
+    return Array.from(
+      {
+        length: Math.min(
+          Math.floor((iterable.length - (partial ? 1 : size)) / step + 1),
+          maxWindows,
+        ),
+      },
+      (_, i) => iterable.slice(i * step, i * step + size),
+    );
+  }
+
+  const result: T[][] = [];
+  const buffer: T[] = [];
+  let currentStep = 0;
+  for (const current of iterable) {
+    buffer.push(current);
+    currentStep++;
+    if (currentStep === size) {
+      result.push([...buffer]);
+      buffer.splice(0, step);
+      currentStep -= step;
+      if (
+        options.maxWindows && result.length === options.maxWindows
+      ) {
+        break;
+      }
+    }
+  }
+  if (partial) {
+    while (buffer.length) {
+      result.push([...buffer]);
+      buffer.splice(0, step);
+    }
+  }
+
+  return result;
 }

--- a/collections/sliding_windows.ts
+++ b/collections/sliding_windows.ts
@@ -86,7 +86,10 @@ export function slidingWindows<T>(
   ) {
     throw new RangeError("Both size and step must be positive integer.");
   }
-  if (options.maxWindows && options.maxWindows <= 0) {
+  if (
+    options.maxWindows &&
+    (Number.isInteger(options.maxWindows) && options.maxWindows <= 0)
+  ) {
     throw new RangeError("maxWindows must be a positive integer");
   }
 

--- a/collections/sliding_windows_test.ts
+++ b/collections/sliding_windows_test.ts
@@ -4,11 +4,7 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { slidingWindows } from "./sliding_windows.ts";
 
 function slidingWindowsTest<T>(
-  input: [
-    collection: T[],
-    size: number,
-    config?: { step?: number; partial?: boolean; maxWindows?: number },
-  ],
+  input: Parameters<typeof slidingWindows>,
   expected: T[][],
   message?: string,
 ) {
@@ -17,11 +13,7 @@ function slidingWindowsTest<T>(
 }
 
 function slidingWindowsThrowsTest<T>(
-  input: [
-    collection: T[],
-    size: number,
-    config?: { step?: number; partial?: boolean; maxWindows?: number },
-  ],
+  input: Parameters<typeof slidingWindows>,
   ErrorClass: ErrorConstructor,
   msgIncludes?: string,
   msg?: string | undefined,
@@ -399,21 +391,21 @@ Deno.test("slidingWindows() handles invalid maxWindows", () => {
     RangeError,
     "maxWindows must be a positive integer",
   );
-  slidingWindowsThrowsTest(
-    [[1, 2, 3, 4, 5], 3, { maxWindows: -1 }],
-    RangeError,
-    "maxWindows must be a positive integer",
-  );
-  slidingWindowsThrowsTest(
-    [[1, 2, 3, 4, 5], 3, { maxWindows: NaN }],
-    RangeError,
-    "maxWindows must be a positive integer",
-  );
-  slidingWindowsThrowsTest(
-    [[1, 2, 3, 4, 5], 3, { maxWindows: 0.5 }],
-    RangeError,
-    "maxWindows must be a positive integer",
-  );
+  // slidingWindowsThrowsTest(
+  //   [[1, 2, 3, 4, 5], 3, { maxWindows: -1 }],
+  //   RangeError,
+  //   "maxWindows must be a positive integer",
+  // );
+  // slidingWindowsThrowsTest(
+  //   [[1, 2, 3, 4, 5], 3, { maxWindows: NaN }],
+  //   RangeError,
+  //   "maxWindows must be a positive integer",
+  // );
+  // slidingWindowsThrowsTest(
+  //   [[1, 2, 3, 4, 5], 3, { maxWindows: 0.5 }],
+  //   RangeError,
+  //   "maxWindows must be a positive integer",
+  // );
 });
 
 Deno.test("slidingWindows() respects handles maxWindows with an array", () => {

--- a/collections/sliding_windows_test.ts
+++ b/collections/sliding_windows_test.ts
@@ -7,7 +7,7 @@ function slidingWindowsTest<T>(
   input: [
     collection: T[],
     size: number,
-    config?: { step?: number; partial?: boolean, maxWindows?: number },
+    config?: { step?: number; partial?: boolean; maxWindows?: number },
   ],
   expected: T[][],
   message?: string,
@@ -20,7 +20,7 @@ function slidingWindowsThrowsTest<T>(
   input: [
     collection: T[],
     size: number,
-    config?: { step?: number; partial?: boolean, maxWindows?: number },
+    config?: { step?: number; partial?: boolean; maxWindows?: number },
   ],
   ErrorClass: ErrorConstructor,
   msgIncludes?: string,
@@ -394,7 +394,6 @@ Deno.test("slidingWindows() respects handles maxWindows with an infinite iterabl
 });
 
 Deno.test("slidingWindows() handles invalid maxWindows", () => {
-
   slidingWindowsThrowsTest(
     [[1, 2, 3, 4, 5], 3, { maxWindows: 0 }],
     RangeError,
@@ -423,5 +422,5 @@ Deno.test("slidingWindows() respects handles maxWindows with an array", () => {
     [1],
     [2],
     [3],
-  ])
-})
+  ]);
+});

--- a/collections/sliding_windows_test.ts
+++ b/collections/sliding_windows_test.ts
@@ -294,3 +294,101 @@ Deno.test({
     ]);
   },
 });
+
+Deno.test("slidingWindows() handles a generator", () => {
+  function* gen() {
+    yield 1;
+    yield 2;
+    yield 3;
+    yield 4;
+    yield 5;
+  }
+  const result = slidingWindows(gen(), 3);
+  assertEquals(result, [
+    [1, 2, 3],
+    [2, 3, 4],
+    [3, 4, 5],
+  ]);
+});
+
+Deno.test("slidingWindows() handles a generator with step", () => {
+  function* gen() {
+    yield 1;
+    yield 2;
+    yield 3;
+    yield 4;
+    yield 5;
+  }
+  const result = slidingWindows(gen(), 5, { step: 2 });
+  assertEquals(result, [
+    [1, 2, 3, 4, 5],
+  ]);
+});
+
+Deno.test("slidingWindows() handles a generator with partial", () => {
+  function* gen() {
+    yield 1;
+    yield 2;
+    yield 3;
+    yield 4;
+    yield 5;
+  }
+  const result = slidingWindows(gen(), 3, { partial: true });
+  assertEquals(result, [
+    [1, 2, 3],
+    [2, 3, 4],
+    [3, 4, 5],
+    [4, 5],
+    [5],
+  ]);
+});
+
+Deno.test("slidingWindows() handles a Set", () => {
+  const set = new Set([1, 2, 3, 4, 5]);
+  const result = slidingWindows(set, 3);
+  assertEquals(result, [
+    [1, 2, 3],
+    [2, 3, 4],
+    [3, 4, 5],
+  ]);
+});
+
+Deno.test("slidingWindows() handles a Map", () => {
+  const map = new Map([
+    ["a", 1],
+    ["b", 2],
+    ["c", 3],
+    ["d", 4],
+    ["e", 5],
+  ]);
+  const result = slidingWindows(map, 3);
+  assertEquals(result, [
+    [["a", 1], ["b", 2], ["c", 3]],
+    [["b", 2], ["c", 3], ["d", 4]],
+    [["c", 3], ["d", 4], ["e", 5]],
+  ]);
+});
+
+Deno.test("slidingWindows() handles a string", () => {
+  const result = slidingWindows("abcde", 3);
+  assertEquals(result, [
+    ["a", "b", "c"],
+    ["b", "c", "d"],
+    ["c", "d", "e"],
+  ]);
+});
+
+Deno.test("slidingWindows() respects handles maxWindows with an infinite iterable", () => {
+  function* gen() {
+    let i = 0;
+    while (true) {
+      yield i++;
+    }
+  }
+  const result = slidingWindows(gen(), 3, { maxWindows: 3 });
+  assertEquals(result, [
+    [0, 1, 2],
+    [1, 2, 3],
+    [2, 3, 4],
+  ]);
+});

--- a/collections/sliding_windows_test.ts
+++ b/collections/sliding_windows_test.ts
@@ -391,21 +391,21 @@ Deno.test("slidingWindows() handles invalid maxWindows", () => {
     RangeError,
     "maxWindows must be a positive integer",
   );
-  // slidingWindowsThrowsTest(
-  //   [[1, 2, 3, 4, 5], 3, { maxWindows: -1 }],
-  //   RangeError,
-  //   "maxWindows must be a positive integer",
-  // );
-  // slidingWindowsThrowsTest(
-  //   [[1, 2, 3, 4, 5], 3, { maxWindows: NaN }],
-  //   RangeError,
-  //   "maxWindows must be a positive integer",
-  // );
-  // slidingWindowsThrowsTest(
-  //   [[1, 2, 3, 4, 5], 3, { maxWindows: 0.5 }],
-  //   RangeError,
-  //   "maxWindows must be a positive integer",
-  // );
+  slidingWindowsThrowsTest(
+    [[1, 2, 3, 4, 5], 3, { maxWindows: -1 }],
+    RangeError,
+    "maxWindows must be a positive integer",
+  );
+  slidingWindowsThrowsTest(
+    [[1, 2, 3, 4, 5], 3, { maxWindows: NaN }],
+    RangeError,
+    "maxWindows must be a positive integer",
+  );
+  slidingWindowsThrowsTest(
+    [[1, 2, 3, 4, 5], 3, { maxWindows: 0.5 }],
+    RangeError,
+    "maxWindows must be a positive integer",
+  );
 });
 
 Deno.test("slidingWindows() respects handles maxWindows with an array", () => {

--- a/collections/sliding_windows_test.ts
+++ b/collections/sliding_windows_test.ts
@@ -7,7 +7,7 @@ function slidingWindowsTest<T>(
   input: [
     collection: T[],
     size: number,
-    config?: { step?: number; partial?: boolean },
+    config?: { step?: number; partial?: boolean, maxWindows?: number },
   ],
   expected: T[][],
   message?: string,
@@ -20,7 +20,7 @@ function slidingWindowsThrowsTest<T>(
   input: [
     collection: T[],
     size: number,
-    config?: { step?: number; partial?: boolean },
+    config?: { step?: number; partial?: boolean, maxWindows?: number },
   ],
   ErrorClass: ErrorConstructor,
   msgIncludes?: string,
@@ -392,3 +392,36 @@ Deno.test("slidingWindows() respects handles maxWindows with an infinite iterabl
     [2, 3, 4],
   ]);
 });
+
+Deno.test("slidingWindows() handles invalid maxWindows", () => {
+
+  slidingWindowsThrowsTest(
+    [[1, 2, 3, 4, 5], 3, { maxWindows: 0 }],
+    RangeError,
+    "maxWindows must be a positive integer",
+  );
+  slidingWindowsThrowsTest(
+    [[1, 2, 3, 4, 5], 3, { maxWindows: -1 }],
+    RangeError,
+    "maxWindows must be a positive integer",
+  );
+  slidingWindowsThrowsTest(
+    [[1, 2, 3, 4, 5], 3, { maxWindows: NaN }],
+    RangeError,
+    "maxWindows must be a positive integer",
+  );
+  slidingWindowsThrowsTest(
+    [[1, 2, 3, 4, 5], 3, { maxWindows: 0.5 }],
+    RangeError,
+    "maxWindows must be a positive integer",
+  );
+});
+
+Deno.test("slidingWindows() respects handles maxWindows with an array", () => {
+  const result = slidingWindows([1, 2, 3, 4, 5], 1, { maxWindows: 3 });
+  assertEquals(result, [
+    [1],
+    [2],
+    [3],
+  ])
+})


### PR DESCRIPTION
Support `Iterable` for collections `slidingWindows`

Maintains the current sliding windows for Arrays for the empty Array case. Using the iterable version would change the output from an empty array causing the case is covered by the "slidingWindows() handles empty Array" test to fail.

Example:
```typescript
slidingWindows(new Array(3), 1)

// The difference is 
// [ [ <1 empty item> ], [ <1 empty item> ], [ <1 empty item> ] ]
// vs
// [ [ undefined ], [ undefined ], [ undefined ] ]
```

If the array specific implementation was removed, this would become a breaking change

With an infinite iterator this function would never return. 
I added a `maxWindows` option that limits the number of windows created which would be useful to prevent that case. (maybe it should throw instead?)

However I can remove if we think a seperate `take` function is better
or the onus is on the user
 e.g
```ts
function* take<T>(iterable: Iterable<T>, count: number): Iterable<T> {
  let i = 0;
  for (const item of iterable) {
    if (i++ >= count) {
      break;
    }
    yield item;
  }
}
function* infiniteNumbers() {
  let i = 0;
  while (true) {
    yield i++;
  }
}

slidingWindows(
  take(infiniteNumbers(), 5),
  3,
); // [ [ 0, 1, 2 ], [ 1, 2, 3 ], [ 2, 3, 4 ] ]
```


#5470