### PR TITLE
refactor(http): inline `serveFallback()` util

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -638,11 +638,9 @@ export async function serveDir(
     response = await createServeDirResponse(req, opts);
   } catch (error) {
     if (!opts.quiet) logError(error as Error);
-    if (error instanceof Deno.errors.NotFound) {
-      response = createStandardResponse(STATUS_CODE.NotFound);
-    } else {
-      response = createStandardResponse(STATUS_CODE.InternalServerError);
-    }
+    response = error instanceof Deno.errors.NotFound
+      ? createStandardResponse(STATUS_CODE.NotFound)
+      : createStandardResponse(STATUS_CODE.InternalServerError);
   }
 
   // Do not update the header if the response is a 301 redirect.


### PR DESCRIPTION
This PR inlines `serveFallback` util in file_server.

This PR also removes the handling of `URIError`. This error can't happen now because `url` is taken from `request.url` which should be always a valid url.

This prepares for the implementation of #5875