### PR TITLE
fix(http): show hostname as 'localhost' for 0.0.0.0 on windows

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -849,7 +849,10 @@ function main() {
       networkAddress = getNetworkAddress();
     }
     const protocol = useTls ? "https" : "http";
-    let message = `Listening on:\n- Local: ${protocol}://${hostname}:${port}`;
+    const host = (Deno.build.os === "windows" && hostname === "0.0.0.0")
+      ? "localhost"
+      : hostname;
+    let message = `Listening on:\n- Local: ${protocol}://${host}:${port}`;
     if (networkAddress && !DENO_DEPLOYMENT_ID) {
       message += `\n- Network: ${protocol}://${networkAddress}:${port}`;
     }


### PR DESCRIPTION
This PR shows hostname as `localhost` on windows when the server listens at `0.0.0.0`.

This substitution of the hostname used to be done by CLI, but we stopped doing that when `onListen` handler is set in https://github.com/denoland/deno/pull/24777