### PR TITLE
refactor(assert,expect): import internal APIs from more specific paths

### DIFF
--- a/assert/equals.ts
+++ b/assert/equals.ts
@@ -1,7 +1,11 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 import { equal } from "./equal.ts";
-import { buildMessage, diff, diffStr, format } from "@std/internal";
+import { buildMessage } from "@std/internal/build-message";
+import { diff } from "@std/internal/diff";
+import { diffStr } from "@std/internal/diff-str";
+import { format } from "@std/internal/format";
+
 import { AssertionError } from "./assertion_error.ts";
 
 /**

--- a/assert/strict_equals.ts
+++ b/assert/strict_equals.ts
@@ -1,6 +1,10 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
-import { buildMessage, diff, diffStr, format, red } from "@std/internal";
+import { buildMessage } from "@std/internal/build-message";
+import { diff } from "@std/internal/diff";
+import { diffStr } from "@std/internal/diff-str";
+import { format } from "@std/internal/format";
+import { red } from "@std/internal/styles";
 import { AssertionError } from "./assertion_error.ts";
 
 /**

--- a/expect/_build_message.ts
+++ b/expect/_build_message.ts
@@ -1,6 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { buildMessage, diff, diffStr, format } from "@std/internal";
+import { buildMessage } from "@std/internal/build-message";
+import { diff } from "@std/internal/diff";
+import { diffStr } from "@std/internal/diff-str";
+import { format } from "@std/internal/format";
 import type { EqualOptions } from "./_types.ts";
 
 type EqualErrorMessageOptions = Pick<


### PR DESCRIPTION
This PR changes import specifiers for `@std/internal` more specific to avoid unnecessary dependencies included after #5901 landed.

#5901 introduces a new `@std/internal` API which are not necessary for these APIs.