### PR TITLE
fix(http): invalid ipv6 hostname printed to console

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -842,7 +842,10 @@ function main() {
     const host = (Deno.build.os === "windows" && hostname === "0.0.0.0")
       ? "localhost"
       : hostname;
-    let message = `Listening on:\n- Local: ${protocol}://${host}:${port}`;
+
+    const formattedHost = hostname.includes(":") ? `[${host}]` : host;
+    let message =
+      `Listening on:\n- Local: ${protocol}://${formattedHost}:${port}`;
     if (networkAddress && !DENO_DEPLOYMENT_ID) {
       message += `\n- Network: ${protocol}://${networkAddress}:${port}`;
     }


### PR DESCRIPTION
Before (invalid):

```sh
http://::1:8000
```

After:

```sh
http://[::1]:8000
```