### PR TITLE
refactor(assert): move unstable `assertNever` under `@std/assert/unstable-never`

### DIFF
--- a/_tools/check_mod_exports.ts
+++ b/_tools/check_mod_exports.ts
@@ -39,6 +39,7 @@ for await (
       includeDirs: false,
       maxDepth: 1,
       skip: [
+        /unstable/,
         /dotenv(\/|\\)load\.ts$/,
         /front_matter(\/|\\)yaml\.ts$/,
         /front_matter(\/|\\)json\.ts$/,

--- a/assert/deno.json
+++ b/assert/deno.json
@@ -16,7 +16,7 @@
     "./less": "./less.ts",
     "./less-or-equal": "./less_or_equal.ts",
     "./match": "./match.ts",
-    "./never": "./never.ts",
+    "./unstable-never": "./unstable_never.ts",
     "./not-equals": "./not_equals.ts",
     "./not-instance-of": "./not_instance_of.ts",
     "./not-match": "./not_match.ts",

--- a/assert/mod.ts
+++ b/assert/mod.ts
@@ -30,7 +30,6 @@ export * from "./is_error.ts";
 export * from "./less_or_equal.ts";
 export * from "./less.ts";
 export * from "./match.ts";
-export * from "./never.ts";
 export * from "./not_equals.ts";
 export * from "./not_instance_of.ts";
 export * from "./not_match.ts";

--- a/assert/unstable_never.ts
+++ b/assert/unstable_never.ts
@@ -34,7 +34,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Exhaustivenss check
  * ```ts
- * import { assertNever } from "@std/assert/never";
+ * import { assertNever } from "@std/assert/unstable-never";
  *
  * type Kinds = "A" | "B";
  *
@@ -62,7 +62,7 @@ import { AssertionError } from "./assertion_error.ts";
  *
  * @example Compile-time error when there is a missing case
  * ```ts expect-error ignore
- * import { assertNever } from "@std/assert/never";
+ * import { assertNever } from "@std/assert/unstable-never";
  *
  * type Kinds = "A" | "B" | "C";
  *

--- a/assert/unstable_never_test.ts
+++ b/assert/unstable_never_test.ts
@@ -1,5 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { AssertionError, assertNever, assertThrows } from "./mod.ts";
+import { AssertionError, assertThrows } from "./mod.ts";
+import { assertNever } from "./unstable_never.ts";
 
 Deno.test("assertNever: exhaustiveness check", () => {
   type Kinds = "A" | "B";


### PR DESCRIPTION
part of #5920

This PR moves `assertNever` under the export path `assert/unstable-never`