### PR TITLE
fix(net): skip empty mac address for `getNetworkAddress()`

### DIFF
--- a/net/get_network_address.ts
+++ b/net/get_network_address.ts
@@ -39,6 +39,7 @@ export function getNetworkAddress(
   return Deno.networkInterfaces()
     .find((i) =>
       i.family === family &&
+      i.mac !== "00:00:00:00:00:00" &&
       (family === "IPv4"
         // Cannot lie within 127.0.0.0/8
         ? !i.address.startsWith("127")


### PR DESCRIPTION
hi

dont know why but on my machine I have a loopback IP starting with `10.`
which is wrongly found as my local IP when using `getNetworkAddress()` 
loopback link usually don't have any physical interface so we can safely skip empty mac address `00:00:00:00:00:00`

Fixes #5933