### PR TITLE
refactor(archive,io): use `Seeker[Sync]` from `@std/io/types`

### DIFF
--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -38,9 +38,9 @@ import {
   type UstarFields,
 } from "./_common.ts";
 import { readAll } from "@std/io/read-all";
-import type { Reader } from "@std/io/types";
+import type { Reader, Seeker } from "@std/io/types";
 
-export type { Reader };
+export type { Reader, Seeker };
 
 /**
  * Extend TarMeta with the `linkName` property so that readers can access
@@ -148,7 +148,7 @@ export interface TarEntry extends TarMetaWithLinkName {}
  * ```
  */
 export class TarEntry implements Reader {
-  #reader: Reader | (Reader & Deno.Seeker);
+  #reader: Reader | (Reader & Seeker);
   #size: number;
   #read = 0;
   #consumed = false;
@@ -162,7 +162,7 @@ export class TarEntry implements Reader {
    */
   constructor(
     meta: TarMetaWithLinkName,
-    reader: Reader | (Reader & Deno.Seeker),
+    reader: Reader | (Reader & Seeker),
   ) {
     Object.assign(this, meta);
     this.#reader = reader;
@@ -307,8 +307,8 @@ export class TarEntry implements Reader {
     if (this.#consumed) return;
     this.#consumed = true;
 
-    if (typeof (this.#reader as Deno.Seeker).seek === "function") {
-      await (this.#reader as Deno.Seeker).seek(
+    if (typeof (this.#reader as Seeker).seek === "function") {
+      await (this.#reader as Seeker).seek(
         this.#entrySize - this.#read,
         Deno.SeekMode.Current,
       );

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { copy as copyBytes } from "@std/bytes/copy";
-import type { Reader, ReaderSync } from "./types.ts";
+import type { Reader, ReaderSync, Seeker, SeekerSync } from "./types.ts";
 
 const DEFAULT_BUFFER_SIZE = 32 * 1024;
 
@@ -41,7 +41,7 @@ export interface ByteRange {
  * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export async function readRange(
-  r: Reader & Deno.Seeker,
+  r: Reader & Seeker,
   range: ByteRange,
 ): Promise<Uint8Array> {
   // byte ranges are inclusive, so we have to add one to the end
@@ -94,7 +94,7 @@ export async function readRange(
  * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
  */
 export function readRangeSync(
-  r: ReaderSync & Deno.SeekerSync,
+  r: ReaderSync & SeekerSync,
   range: ByteRange,
 ): Uint8Array {
   // byte ranges are inclusive, so we have to add one to the end

--- a/io/read_range_test.ts
+++ b/io/read_range_test.ts
@@ -3,7 +3,13 @@
 import { copy } from "@std/bytes/copy";
 import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
 import { readRange, readRangeSync } from "./read_range.ts";
-import type { Closer, Reader, ReaderSync } from "./types.ts";
+import type {
+  Closer,
+  Reader,
+  ReaderSync,
+  Seeker,
+  SeekerSync,
+} from "./types.ts";
 
 // N controls how many iterations of certain checks are performed.
 const N = 100;
@@ -18,8 +24,7 @@ export function init() {
   }
 }
 
-class MockFile
-  implements Deno.Seeker, Deno.SeekerSync, Reader, ReaderSync, Closer {
+class MockFile implements Seeker, SeekerSync, Reader, ReaderSync, Closer {
   #buf: Uint8Array;
   #closed = false;
   #offset = 0;


### PR DESCRIPTION
Once a new version of `std` is published, unblocks https://github.com/denoland/deno/pull/25551.