### PR TITLE
chore: cleanup `IS_DENO_2` constant

### DIFF
--- a/internal/_is_deno_2.ts
+++ b/internal/_is_deno_2.ts
@@ -1,4 +1,3 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // TODO(iuioiua): Remove this file when Deno 2 is released.
-// deno-lint-ignore no-explicit-any
-export const IS_DENO_2 = (globalThis as any).window === undefined;
+export const IS_DENO_2 = Deno.version.deno.startsWith("2.");


### PR DESCRIPTION
I'd previously forgot about `Deno.version`.