### PR TITLE
BREAKING(data-structures/unstable): move `bidirectional-map` module to `unstable-bidirectional-map`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -39,6 +39,7 @@ const ENTRY_POINTS = [
   "../collections/mod.ts",
   "../csv/mod.ts",
   "../data_structures/mod.ts",
+  "../data_structures/unstable_bidirectional_map.ts",
   "../datetime/mod.ts",
   "../dotenv/mod.ts",
   "../encoding/mod.ts",

--- a/data_structures/deno.json
+++ b/data_structures/deno.json
@@ -3,7 +3,7 @@
   "version": "1.0.2",
   "exports": {
     ".": "./mod.ts",
-    "./bidirectional-map": "./bidirectional_map.ts",
+    "./unstable-bidirectional-map": "./unstable_bidirectional_map.ts",
     "./binary-heap": "./binary_heap.ts",
     "./binary-search-tree": "./binary_search_tree.ts",
     "./comparators": "./comparators.ts",

--- a/data_structures/mod.ts
+++ b/data_structures/mod.ts
@@ -25,7 +25,6 @@
  * @module
  */
 
-export * from "./bidirectional_map.ts";
 export * from "./binary_heap.ts";
 export * from "./binary_search_tree.ts";
 export * from "./comparators.ts";

--- a/data_structures/unstable_bidirectional_map.ts
+++ b/data_structures/unstable_bidirectional_map.ts
@@ -14,7 +14,7 @@
  *
  * @example Usage
  * ```ts
- * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+ * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
  * import { assertEquals } from "@std/assert";
  *
  * const map = new BidirectionalMap([["one", 1]]);
@@ -25,7 +25,7 @@
  *
  * @example Inserting a value that already exists
  * ```ts
- * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+ * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
  * import { assertEquals } from "@std/assert";
  *
  * const map = new BidirectionalMap();
@@ -60,7 +60,7 @@ export class BidirectionalMap<K, V> extends Map<K, V> {
    *
    * @example Usage
    * ```ts
-   * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+   * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
    * import { assertEquals } from "@std/assert";
    *
    * const map = new BidirectionalMap([["one", 1]]);
@@ -84,7 +84,7 @@ export class BidirectionalMap<K, V> extends Map<K, V> {
    *
    * @example Usage
    * ```ts
-   * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+   * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
    * import { assertEquals } from "@std/assert";
    *
    * const map = new BidirectionalMap();
@@ -118,7 +118,7 @@ export class BidirectionalMap<K, V> extends Map<K, V> {
    *
    * @example Usage
    * ```ts
-   * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+   * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
    * import { assertEquals } from "@std/assert";
    *
    * const map = new BidirectionalMap([["one", 1]]);
@@ -141,7 +141,7 @@ export class BidirectionalMap<K, V> extends Map<K, V> {
    *
    * @example Usage
    * ```ts
-   * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+   * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
    * import { assertEquals } from "@std/assert";
    *
    * const map = new BidirectionalMap([["one", 1]]);
@@ -166,7 +166,7 @@ export class BidirectionalMap<K, V> extends Map<K, V> {
    *
    * @example Usage
    * ```ts
-   * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+   * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
    * import { assertEquals } from "@std/assert";
    *
    * const map = new BidirectionalMap([["one", 1]]);
@@ -194,7 +194,7 @@ export class BidirectionalMap<K, V> extends Map<K, V> {
    *
    * @example Usage
    * ```ts
-   * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+   * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
    * import { assertEquals } from "@std/assert";
    *
    * const map = new BidirectionalMap([["one", 1]]);
@@ -212,7 +212,7 @@ export class BidirectionalMap<K, V> extends Map<K, V> {
    *
    * @example Usage
    * ```ts
-   * import { BidirectionalMap } from "@std/data-structures/bidirectional-map";
+   * import { BidirectionalMap } from "@std/data-structures/unstable-bidirectional-map";
    * import { assertEquals } from "@std/assert";
    *
    * const map = new BidirectionalMap();

--- a/data_structures/unstable_bidirectional_map_test.ts
+++ b/data_structures/unstable_bidirectional_map_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assert, assertEquals } from "@std/assert";
-import { BidirectionalMap } from "./bidirectional_map.ts";
+import { BidirectionalMap } from "./unstable_bidirectional_map.ts";
 
 Deno.test("BidirectionalMap is an instance of Map", () => {
   const biMap = new BidirectionalMap();


### PR DESCRIPTION
Towards #5920