### PR TITLE
BREAKING(html/unstable): move `is-valid-custom-element-name` module to `unstable-is-valid-custom-element-name`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -50,6 +50,7 @@ const ENTRY_POINTS = [
   "../front_matter/mod.ts",
   "../fs/mod.ts",
   "../html/mod.ts",
+  "../html/unstable_is_valid_custom_element_name.ts",
   "../http/mod.ts",
   "../ini/mod.ts",
   "../internal/mod.ts",

--- a/html/deno.json
+++ b/html/deno.json
@@ -4,7 +4,7 @@
   "exports": {
     ".": "./mod.ts",
     "./entities": "./entities.ts",
-    "./is-valid-custom-element-name": "./is_valid_custom_element_name.ts",
+    "./unstable-is-valid-custom-element-name": "./unstable_is_valid_custom_element_name.ts",
     "./named-entity-list.json": "./named_entity_list.json"
   }
 }

--- a/html/mod.ts
+++ b/html/mod.ts
@@ -16,4 +16,3 @@
  */
 
 export * from "./entities.ts";
-export * from "./is_valid_custom_element_name.ts";

--- a/html/unstable_is_valid_custom_element_name.ts
+++ b/html/unstable_is_valid_custom_element_name.ts
@@ -37,7 +37,7 @@ const CUSTOM_ELEMENT_NAME_CHARS =
  * Using a valid custom element name
  *
  * ```ts
- * import { isValidCustomElementName } from "@std/html/is-valid-custom-element-name";
+ * import { isValidCustomElementName } from "@std/html/unstable-is-valid-custom-element-name";
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals(isValidCustomElementName("custom-element"), true);

--- a/html/unstable_is_valid_custom_element_name_test.ts
+++ b/html/unstable_is_valid_custom_element_name_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals } from "@std/assert/equals";
-import { isValidCustomElementName } from "./is_valid_custom_element_name.ts";
+import { isValidCustomElementName } from "./unstable_is_valid_custom_element_name.ts";
 
 const forbiddenCustomElementNames: string[] = [
   "annotation-xml",


### PR DESCRIPTION
Towards #5920