### PR TITLE
BREAKING(net/unstable): move `get-network-address` module to `unstable-get-network-address`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -59,6 +59,7 @@ const ENTRY_POINTS = [
   "../media_types/mod.ts",
   "../msgpack/mod.ts",
   "../net/mod.ts",
+  "../net/unstable_get_network_address.ts",
   "../path/mod.ts",
   "../path/posix/mod.ts",
   "../path/windows/mod.ts",

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -51,7 +51,7 @@ import { ByteSliceStream } from "@std/streams/byte-slice-stream";
 import { parseArgs } from "@std/cli/parse-args";
 import denoConfig from "./deno.json" with { type: "json" };
 import { format as formatBytes } from "@std/fmt/bytes";
-import { getNetworkAddress } from "@std/net/get-network-address";
+import { getNetworkAddress } from "../net/unstable_get_network_address.ts";
 import { HEADER } from "./unstable_header.ts";
 import { METHOD } from "./unstable_method.ts";
 

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -51,7 +51,7 @@ import { ByteSliceStream } from "@std/streams/byte-slice-stream";
 import { parseArgs } from "@std/cli/parse-args";
 import denoConfig from "./deno.json" with { type: "json" };
 import { format as formatBytes } from "@std/fmt/bytes";
-import { getNetworkAddress } from "../net/unstable_get_network_address.ts";
+import { getNetworkAddress } from "@std/net/unstable-get-network-address";
 import { HEADER } from "./unstable_header.ts";
 import { METHOD } from "./unstable_method.ts";
 

--- a/net/deno.json
+++ b/net/deno.json
@@ -4,6 +4,6 @@
   "exports": {
     ".": "./mod.ts",
     "./get-available-port": "./get_available_port.ts",
-    "./get-network-address": "./get_network_address.ts"
+    "./unstable-get-network-address": "./unstable_get_network_address.ts"
   }
 }

--- a/net/mod.ts
+++ b/net/mod.ts
@@ -5,7 +5,7 @@
  *
  * ```ts no-assert no-eval
  * import { getAvailablePort } from "@std/net";
- * *
+ *
  * const command = new Deno.Command(Deno.execPath(), {
  *  args: ["test.ts", "--port", getAvailablePort().toString()],
  * });

--- a/net/mod.ts
+++ b/net/mod.ts
@@ -4,10 +4,8 @@
  * Network utilities.
  *
  * ```ts no-assert no-eval
- * import { getNetworkAddress, getAvailablePort } from "@std/net";
- *
- * console.log(`My network IP address is ${getNetworkAddress()}`);
- *
+ * import { getAvailablePort } from "@std/net";
+ * *
  * const command = new Deno.Command(Deno.execPath(), {
  *  args: ["test.ts", "--port", getAvailablePort().toString()],
  * });
@@ -19,4 +17,3 @@
  */
 
 export * from "./get_available_port.ts";
-export * from "./get_network_address.ts";

--- a/net/unstable_get_network_address.ts
+++ b/net/unstable_get_network_address.ts
@@ -17,7 +17,7 @@
  *
  * @example Get the IPv4 network address (default)
  * ```ts no-assert no-eval
- * import { getNetworkAddress } from "@std/net/get-network-address";
+ * import { getNetworkAddress } from "@std/net/unstable-get-network-address";
  *
  * const hostname = getNetworkAddress()!;
  *
@@ -26,7 +26,7 @@
  *
  * @example Get the IPv6 network address
  * ```ts no-assert no-eval
- * import { getNetworkAddress } from "@std/net/get-network-address";
+ * import { getNetworkAddress } from "@std/net/unstable-get-network-address";
  *
  * const hostname = getNetworkAddress("IPv6")!;
  *

--- a/net/unstable_get_network_address_test.ts
+++ b/net/unstable_get_network_address_test.ts
@@ -1,5 +1,5 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-import { getNetworkAddress } from "./get_network_address.ts";
+import { getNetworkAddress } from "./unstable_get_network_address.ts";
 import { stub } from "@std/testing/mock";
 import { assertEquals } from "@std/assert";
 


### PR DESCRIPTION
Towards #5920