### PR TITLE
BREAKING(streams/unstable): move `to-lines` module to `unstable-to-lines`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -67,6 +67,7 @@ const ENTRY_POINTS = [
   "../regexp/mod.ts",
   "../semver/mod.ts",
   "../streams/mod.ts",
+  "../streams/unstable_to_lines.ts",
   "../tar/mod.ts",
   "../text/mod.ts",
   "../testing/bdd.ts",

--- a/streams/deno.json
+++ b/streams/deno.json
@@ -17,7 +17,7 @@
     "./to-array-buffer": "./to_array_buffer.ts",
     "./to-blob": "./to_blob.ts",
     "./to-json": "./to_json.ts",
-    "./to-lines": "./to_lines.ts",
+    "./unstable-to-lines": "./unstable_to_lines.ts",
     "./to-text": "./to_text.ts",
     "./to-transform-stream": "./to_transform_stream.ts",
     "./zip-readable-streams": "./zip_readable_streams.ts"

--- a/streams/mod.ts
+++ b/streams/mod.ts
@@ -32,7 +32,6 @@ export * from "./text_line_stream.ts";
 export * from "./to_array_buffer.ts";
 export * from "./to_blob.ts";
 export * from "./to_json.ts";
-export * from "./to_lines.ts";
 export * from "./to_text.ts";
 export * from "./to_transform_stream.ts";
 export * from "./zip_readable_streams.ts";

--- a/streams/unstable_to_lines.ts
+++ b/streams/unstable_to_lines.ts
@@ -14,7 +14,7 @@ import { TextLineStream } from "./text_line_stream.ts";
  *
  * @example Usage
  * ```ts
- * import { toLines } from "@std/streams/to-lines";
+ * import { toLines } from "@std/streams/unstable-to-lines";
  * import { assertEquals } from "@std/assert/equals";
  *
  * const readable = ReadableStream.from([

--- a/streams/unstable_to_lines_test.ts
+++ b/streams/unstable_to_lines_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-import { toLines } from "./to_lines.ts";
+import { toLines } from "./unstable_to_lines.ts";
 import { assertEquals } from "@std/assert";
 
 Deno.test("toLines() parses simple input", async () => {


### PR DESCRIPTION
Towards #5920