### PR TITLE
BREAKING(text/unstable): move `to-constant-case` module to `unstable-to-constant-case`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -77,6 +77,7 @@ const ENTRY_POINTS = [
   "../streams/unstable_to_lines.ts",
   "../tar/mod.ts",
   "../text/mod.ts",
+  "../text/unstable_to_constant_case.ts",
   "../testing/bdd.ts",
   "../testing/mock.ts",
   "../testing/snapshot.ts",

--- a/text/deno.json
+++ b/text/deno.json
@@ -8,7 +8,7 @@
     "./levenshtein-distance": "./levenshtein_distance.ts",
     "./slugify": "./slugify.ts",
     "./to-camel-case": "./to_camel_case.ts",
-    "./to-constant-case": "./to_constant_case.ts",
+    "./unstable-to-constant-case": "./unstable_to_constant_case.ts",
     "./to-kebab-case": "./to_kebab_case.ts",
     "./to-pascal-case": "./to_pascal_case.ts",
     "./to-snake-case": "./to_snake_case.ts",

--- a/text/mod.ts
+++ b/text/mod.ts
@@ -24,7 +24,6 @@ export * from "./closest_string.ts";
 export * from "./compare_similarity.ts";
 export * from "./word_similarity_sort.ts";
 export * from "./to_camel_case.ts";
-export * from "./to_constant_case.ts";
 export * from "./to_kebab_case.ts";
 export * from "./to_pascal_case.ts";
 export * from "./to_snake_case.ts";

--- a/text/unstable_to_constant_case.ts
+++ b/text/unstable_to_constant_case.ts
@@ -10,7 +10,7 @@ import { splitToWords } from "./_util.ts";
  *
  * @example Usage
  * ```ts
- * import { toConstantCase } from "@std/text/to-constant-case";
+ * import { toConstantCase } from "@std/text/unstable-to-constant-case";
  * import { assertEquals } from "@std/assert/equals";
  *
  * assertEquals(toConstantCase("deno is awesome"), "DENO_IS_AWESOME");

--- a/text/unstable_to_constant_case_test.ts
+++ b/text/unstable_to_constant_case_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { assertEquals } from "@std/assert";
-import { toConstantCase } from "./mod.ts";
+import { toConstantCase } from "./unstable_to_constant_case.ts";
 
 Deno.test("toConstantCase() converts a single word", () => {
   const input = "shruberry";


### PR DESCRIPTION
Towards #5920