### PR TITLE
BREAKING(path/unstable): move unstable overload of `dirname` to `unstable-dirname`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -68,6 +68,7 @@ const ENTRY_POINTS = [
   "../net/mod.ts",
   "../net/unstable_get_network_address.ts",
   "../path/mod.ts",
+  "../path/unstable_dirname.ts",
   "../path/posix/mod.ts",
   "../path/windows/mod.ts",
   "../random/mod.ts",

--- a/path/deno.json
+++ b/path/deno.json
@@ -38,11 +38,13 @@
     "./posix/resolve": "./posix/resolve.ts",
     "./posix/to-file-url": "./posix/to_file_url.ts",
     "./posix/to-namespaced-path": "./posix/to_namespaced_path.ts",
+    "./posix/unstable-dirname": "./posix/unstable_dirname.ts",
     "./relative": "./relative.ts",
     "./resolve": "./resolve.ts",
     "./to-file-url": "./to_file_url.ts",
     "./to-namespaced-path": "./to_namespaced_path.ts",
     "./types": "./types.ts",
+    "./unstable-dirname": "./unstable_dirname.ts",
     "./windows": "./windows/mod.ts",
     "./windows/basename": "./windows/basename.ts",
     "./windows/common": "./windows/common.ts",
@@ -62,6 +64,7 @@
     "./windows/relative": "./windows/relative.ts",
     "./windows/resolve": "./windows/resolve.ts",
     "./windows/to-file-url": "./windows/to_file_url.ts",
-    "./windows/to-namespaced-path": "./windows/to_namespaced_path.ts"
+    "./windows/to-namespaced-path": "./windows/to_namespaced_path.ts",
+    "./windows/unstable-dirname": "./windows/unstable_dirname.ts"
   }
 }

--- a/path/dirname.ts
+++ b/path/dirname.ts
@@ -21,7 +21,7 @@ import { dirname as windowsDirname } from "./windows/dirname.ts";
  * ```
  *
  * Note: If you are working with file URLs,
- * use `dirname` from `@std/path/unstable-dirname`.
+ * use the new version of `dirname` from `@std/path/unstable-dirname`.
  *
  * @param path Path to extract the directory from.
  * @returns The directory path.

--- a/path/dirname.ts
+++ b/path/dirname.ts
@@ -20,6 +20,9 @@ import { dirname as windowsDirname } from "./windows/dirname.ts";
  * }
  * ```
  *
+ * Note: If you are working with file URLs,
+ * use `dirname` from `@std/path/unstable-dirname`.
+ *
  * @param path Path to extract the directory from.
  * @returns The directory path.
  */

--- a/path/dirname_test.ts
+++ b/path/dirname_test.ts
@@ -5,6 +5,8 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { dirname } from "./dirname.ts";
 import * as posix from "./posix/mod.ts";
 import * as windows from "./windows/mod.ts";
+import { dirname as windowsUnstableDirname } from "./windows/unstable_dirname.ts";
+import { dirname as posixUnstableDirname } from "./posix/unstable_dirname.ts";
 
 // Test suite from "GNU core utilities"
 // https://github.com/coreutils/coreutils/blob/master/tests/misc/dirname.pl
@@ -89,13 +91,13 @@ Deno.test("posix.dirname()", function () {
 
 Deno.test("posix.dirname() works with file URLs", () => {
   assertEquals(
-    posix.dirname(new URL("file:///home/user/Documents/image.png")),
+    posixUnstableDirname(new URL("file:///home/user/Documents/image.png")),
     "/home/user/Documents",
   );
 
   // throws with non-file URLs
   assertThrows(
-    () => posix.dirname(new URL("https://deno.land/")),
+    () => posixUnstableDirname(new URL("https://deno.land/")),
     TypeError,
     'URL must be a file URL: received "https:"',
   );
@@ -118,13 +120,13 @@ Deno.test("windows.dirname()", function () {
 
 Deno.test("windows.dirname() works with file URLs", () => {
   assertEquals(
-    windows.dirname(new URL("file:///C:/home/user/Documents/image.png")),
+    windowsUnstableDirname(new URL("file:///C:/home/user/Documents/image.png")),
     "C:\\home\\user\\Documents",
   );
 
   // throws with non-file URLs
   assertThrows(
-    () => windows.dirname(new URL("https://deno.land/")),
+    () => windowsUnstableDirname(new URL("https://deno.land/")),
     TypeError,
     'URL must be a file URL: received "https:"',
   );

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -1,10 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { assertArg } from "../_common/dirname.ts";
-import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
-import { isPosixPathSeparator } from "./_util.ts";
-import { fromFileUrl } from "./from_file_url.ts";
+import { dirname as unstableDirname } from "./unstable_dirname.ts";
 
 /**
  * Return the directory path of a `path`.
@@ -21,59 +18,6 @@ import { fromFileUrl } from "./from_file_url.ts";
  * @param path The path to get the directory from.
  * @returns The directory path.
  */
-export function dirname(path: string): string;
-/**
- * Return the directory path of a file URL.
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * @example Usage
- * ```ts
- * import { dirname } from "@std/path/posix/dirname";
- * import { assertEquals } from "@std/assert";
- *
- * assertEquals(dirname("/home/user/Documents/"), "/home/user");
- * assertEquals(dirname("/home/user/Documents/image.png"), "/home/user/Documents");
- * assertEquals(dirname(new URL("file:///home/user/Documents/image.png")), "/home/user/Documents");
- * ```
- *
- * @param path The file url to get the directory from.
- * @returns The directory path.
- */
-export function dirname(path: string | URL): string;
-export function dirname(path: string | URL): string {
-  if (path instanceof URL) {
-    path = fromFileUrl(path);
-  }
-  assertArg(path);
-
-  let end = -1;
-  let matchedNonSeparator = false;
-
-  for (let i = path.length - 1; i >= 1; --i) {
-    if (isPosixPathSeparator(path.charCodeAt(i))) {
-      if (matchedNonSeparator) {
-        end = i;
-        break;
-      }
-    } else {
-      matchedNonSeparator = true;
-    }
-  }
-
-  // No matches. Fallback based on provided path:
-  //
-  // - leading slashes paths
-  //     "/foo" => "/"
-  //     "///foo" => "/"
-  // - no slash path
-  //     "foo" => "."
-  if (end === -1) {
-    return isPosixPathSeparator(path.charCodeAt(0)) ? "/" : ".";
-  }
-
-  return stripTrailingSeparators(
-    path.slice(0, end),
-    isPosixPathSeparator,
-  );
+export function dirname(path: string): string {
+  return unstableDirname(path);
 }

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -18,7 +18,7 @@ import { isPosixPathSeparator } from "./_util.ts";
  * ```
  *
  * Note: If you are working with file URLs,
- * use `dirname` from `@std/path/posix/unstable-dirname`.
+ * use the new version of `dirname` from `@std/path/posix/unstable-dirname`.
  *
  * @param path The path to get the directory from.
  * @returns The directory path.

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -1,7 +1,9 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { dirname as unstableDirname } from "./unstable_dirname.ts";
+import { assertArg } from "../_common/dirname.ts";
+import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
+import { isPosixPathSeparator } from "./_util.ts";
 
 /**
  * Return the directory path of a `path`.
@@ -19,5 +21,35 @@ import { dirname as unstableDirname } from "./unstable_dirname.ts";
  * @returns The directory path.
  */
 export function dirname(path: string): string {
-  return unstableDirname(path);
+  assertArg(path);
+
+  let end = -1;
+  let matchedNonSeparator = false;
+
+  for (let i = path.length - 1; i >= 1; --i) {
+    if (isPosixPathSeparator(path.charCodeAt(i))) {
+      if (matchedNonSeparator) {
+        end = i;
+        break;
+      }
+    } else {
+      matchedNonSeparator = true;
+    }
+  }
+
+  // No matches. Fallback based on provided path:
+  //
+  // - leading slashes paths
+  //     "/foo" => "/"
+  //     "///foo" => "/"
+  // - no slash path
+  //     "foo" => "."
+  if (end === -1) {
+    return isPosixPathSeparator(path.charCodeAt(0)) ? "/" : ".";
+  }
+
+  return stripTrailingSeparators(
+    path.slice(0, end),
+    isPosixPathSeparator,
+  );
 }

--- a/path/posix/dirname.ts
+++ b/path/posix/dirname.ts
@@ -17,6 +17,9 @@ import { isPosixPathSeparator } from "./_util.ts";
  * assertEquals(dirname("/home/user/Documents/image.png"), "/home/user/Documents");
  * ```
  *
+ * Note: If you are working with file URLs,
+ * use `dirname` from `@std/path/posix/unstable-dirname`.
+ *
  * @param path The path to get the directory from.
  * @returns The directory path.
  */

--- a/path/posix/unstable_dirname.ts
+++ b/path/posix/unstable_dirname.ts
@@ -1,0 +1,62 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import { assertArg } from "../_common/dirname.ts";
+import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
+import { isPosixPathSeparator } from "./_util.ts";
+import { fromFileUrl } from "./from_file_url.ts";
+
+/**
+ * Return the directory path of a file URL.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { dirname } from "@std/path/posix/unstable-dirname";
+ * import { assertEquals } from "@std/assert";
+ *
+ * assertEquals(dirname("/home/user/Documents/"), "/home/user");
+ * assertEquals(dirname("/home/user/Documents/image.png"), "/home/user/Documents");
+ * assertEquals(dirname(new URL("file:///home/user/Documents/image.png")), "/home/user/Documents");
+ * ```
+ *
+ * @param path The file url to get the directory from.
+ * @returns The directory path.
+ */
+export function dirname(path: string | URL): string {
+  if (path instanceof URL) {
+    path = fromFileUrl(path);
+  }
+  assertArg(path);
+
+  let end = -1;
+  let matchedNonSeparator = false;
+
+  for (let i = path.length - 1; i >= 1; --i) {
+    if (isPosixPathSeparator(path.charCodeAt(i))) {
+      if (matchedNonSeparator) {
+        end = i;
+        break;
+      }
+    } else {
+      matchedNonSeparator = true;
+    }
+  }
+
+  // No matches. Fallback based on provided path:
+  //
+  // - leading slashes paths
+  //     "/foo" => "/"
+  //     "///foo" => "/"
+  // - no slash path
+  //     "foo" => "."
+  if (end === -1) {
+    return isPosixPathSeparator(path.charCodeAt(0)) ? "/" : ".";
+  }
+
+  return stripTrailingSeparators(
+    path.slice(0, end),
+    isPosixPathSeparator,
+  );
+}

--- a/path/posix/unstable_dirname.ts
+++ b/path/posix/unstable_dirname.ts
@@ -1,9 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { assertArg } from "../_common/dirname.ts";
-import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
-import { isPosixPathSeparator } from "./_util.ts";
+import { dirname as stableDirname } from "./dirname.ts";
 import { fromFileUrl } from "./from_file_url.ts";
 
 /**
@@ -28,35 +26,5 @@ export function dirname(path: string | URL): string {
   if (path instanceof URL) {
     path = fromFileUrl(path);
   }
-  assertArg(path);
-
-  let end = -1;
-  let matchedNonSeparator = false;
-
-  for (let i = path.length - 1; i >= 1; --i) {
-    if (isPosixPathSeparator(path.charCodeAt(i))) {
-      if (matchedNonSeparator) {
-        end = i;
-        break;
-      }
-    } else {
-      matchedNonSeparator = true;
-    }
-  }
-
-  // No matches. Fallback based on provided path:
-  //
-  // - leading slashes paths
-  //     "/foo" => "/"
-  //     "///foo" => "/"
-  // - no slash path
-  //     "foo" => "."
-  if (end === -1) {
-    return isPosixPathSeparator(path.charCodeAt(0)) ? "/" : ".";
-  }
-
-  return stripTrailingSeparators(
-    path.slice(0, end),
-    isPosixPathSeparator,
-  );
+  return stableDirname(path);
 }

--- a/path/unstable_dirname.ts
+++ b/path/unstable_dirname.ts
@@ -2,27 +2,31 @@
 // This module is browser compatible.
 
 import { isWindows } from "./_os.ts";
-import { dirname as posixDirname } from "./posix/dirname.ts";
-import { dirname as windowsDirname } from "./windows/dirname.ts";
+import { dirname as posixDirname } from "./posix/unstable_dirname.ts";
+import { dirname as windowsDirname } from "./windows/unstable_dirname.ts";
 
 /**
- * Return the directory path of a path.
+ * Return the directory path of a file URL.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
  * ```ts
- * import { dirname } from "@std/path/dirname";
+ * import { dirname } from "@std/path/unstable-dirname";
  * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(dirname("C:\\home\\user\\Documents\\image.png"), "C:\\home\\user\\Documents");
+ *   assertEquals(dirname(new URL("file:///C:/home/user/Documents/image.png")), "C:\\home\\user\\Documents");
  * } else {
  *   assertEquals(dirname("/home/user/Documents/image.png"), "/home/user/Documents");
+ *   assertEquals(dirname(new URL("file:///home/user/Documents/image.png")), "/home/user/Documents");
  * }
  * ```
  *
  * @param path Path to extract the directory from.
  * @returns The directory path.
  */
-export function dirname(path: string): string {
+export function dirname(path: string | URL): string {
   return isWindows ? windowsDirname(path) : posixDirname(path);
 }

--- a/path/unstable_dirname.ts
+++ b/path/unstable_dirname.ts
@@ -2,8 +2,8 @@
 // This module is browser compatible.
 
 import { isWindows } from "./_os.ts";
-import { dirname as posixDirname } from "./posix/unstable_dirname.ts";
-import { dirname as windowsDirname } from "./windows/unstable_dirname.ts";
+import { dirname as posixUnstableDirname } from "./posix/unstable_dirname.ts";
+import { dirname as windowsUnstableDirname } from "./windows/unstable_dirname.ts";
 
 /**
  * Return the directory path of a file URL.
@@ -28,5 +28,5 @@ import { dirname as windowsDirname } from "./windows/unstable_dirname.ts";
  * @returns The directory path.
  */
 export function dirname(path: string | URL): string {
-  return isWindows ? windowsDirname(path) : posixDirname(path);
+  return isWindows ? windowsUnstableDirname(path) : posixUnstableDirname(path);
 }

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -22,6 +22,9 @@ import {
  * assertEquals(dir, "C:\\foo\\bar");
  * ```
  *
+ * Note: If you are working with file URLs,
+ * use `dirname` from `@std/path/windows/unstable-dirname`.
+ *
  * @param path The path to get the directory from.
  * @returns The directory path.
  */

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -1,15 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { assertArg } from "../_common/dirname.ts";
-import { CHAR_COLON } from "../_common/constants.ts";
-import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
-import {
-  isPathSeparator,
-  isPosixPathSeparator,
-  isWindowsDeviceRoot,
-} from "./_util.ts";
-import { fromFileUrl } from "./from_file_url.ts";
+import { dirname as unstableDirname } from "./unstable_dirname.ts";
 
 /**
  * Return the directory path of a `path`.
@@ -26,112 +18,6 @@ import { fromFileUrl } from "./from_file_url.ts";
  * @param path The path to get the directory from.
  * @returns The directory path.
  */
-export function dirname(path: string): string;
-/**
- * Return the directory path of a file URL.
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * @example Usage
- * ```ts
- * import { dirname } from "@std/path/windows/dirname";
- * import { assertEquals } from "@std/assert";
- *
- * assertEquals(dirname("C:\\foo\\bar\\baz.ext"), "C:\\foo\\bar");
- * assertEquals(dirname(new URL("file:///C:/foo/bar/baz.ext")), "C:\\foo\\bar");
- * ```
- *
- * @param path The path to get the directory from.
- * @returns The directory path.
- */
-export function dirname(path: string | URL): string;
-export function dirname(path: string | URL): string {
-  if (path instanceof URL) {
-    path = fromFileUrl(path);
-  }
-  assertArg(path);
-
-  const len = path.length;
-  let rootEnd = -1;
-  let end = -1;
-  let matchedSlash = true;
-  let offset = 0;
-  const code = path.charCodeAt(0);
-
-  // Try to match a root
-  if (len > 1) {
-    if (isPathSeparator(code)) {
-      // Possible UNC root
-
-      rootEnd = offset = 1;
-
-      if (isPathSeparator(path.charCodeAt(1))) {
-        // Matched double path separator at beginning
-        let j = 2;
-        let last = j;
-        // Match 1 or more non-path separators
-        for (; j < len; ++j) {
-          if (isPathSeparator(path.charCodeAt(j))) break;
-        }
-        if (j < len && j !== last) {
-          // Matched!
-          last = j;
-          // Match 1 or more path separators
-          for (; j < len; ++j) {
-            if (!isPathSeparator(path.charCodeAt(j))) break;
-          }
-          if (j < len && j !== last) {
-            // Matched!
-            last = j;
-            // Match 1 or more non-path separators
-            for (; j < len; ++j) {
-              if (isPathSeparator(path.charCodeAt(j))) break;
-            }
-            if (j === len) {
-              // We matched a UNC root only
-              return path;
-            }
-            if (j !== last) {
-              // We matched a UNC root with leftovers
-
-              // Offset by 1 to include the separator after the UNC root to
-              // treat it as a "normal root" on top of a (UNC) root
-              rootEnd = offset = j + 1;
-            }
-          }
-        }
-      }
-    } else if (isWindowsDeviceRoot(code)) {
-      // Possible device root
-
-      if (path.charCodeAt(1) === CHAR_COLON) {
-        rootEnd = offset = 2;
-        if (len > 2) {
-          if (isPathSeparator(path.charCodeAt(2))) rootEnd = offset = 3;
-        }
-      }
-    }
-  } else if (isPathSeparator(code)) {
-    // `path` contains just a path separator, exit early to avoid
-    // unnecessary work
-    return path;
-  }
-
-  for (let i = len - 1; i >= offset; --i) {
-    if (isPathSeparator(path.charCodeAt(i))) {
-      if (!matchedSlash) {
-        end = i;
-        break;
-      }
-    } else {
-      // We saw the first non-path separator
-      matchedSlash = false;
-    }
-  }
-
-  if (end === -1) {
-    if (rootEnd === -1) return ".";
-    else end = rootEnd;
-  }
-  return stripTrailingSeparators(path.slice(0, end), isPosixPathSeparator);
+export function dirname(path: string): string {
+  return unstableDirname(path);
 }

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -1,7 +1,14 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { dirname as unstableDirname } from "./unstable_dirname.ts";
+import { assertArg } from "../_common/dirname.ts";
+import { CHAR_COLON } from "../_common/constants.ts";
+import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
+import {
+  isPathSeparator,
+  isPosixPathSeparator,
+  isWindowsDeviceRoot,
+} from "./_util.ts";
 
 /**
  * Return the directory path of a `path`.
@@ -19,5 +26,89 @@ import { dirname as unstableDirname } from "./unstable_dirname.ts";
  * @returns The directory path.
  */
 export function dirname(path: string): string {
-  return unstableDirname(path);
+  assertArg(path);
+
+  const len = path.length;
+  let rootEnd = -1;
+  let end = -1;
+  let matchedSlash = true;
+  let offset = 0;
+  const code = path.charCodeAt(0);
+
+  // Try to match a root
+  if (len > 1) {
+    if (isPathSeparator(code)) {
+      // Possible UNC root
+
+      rootEnd = offset = 1;
+
+      if (isPathSeparator(path.charCodeAt(1))) {
+        // Matched double path separator at beginning
+        let j = 2;
+        let last = j;
+        // Match 1 or more non-path separators
+        for (; j < len; ++j) {
+          if (isPathSeparator(path.charCodeAt(j))) break;
+        }
+        if (j < len && j !== last) {
+          // Matched!
+          last = j;
+          // Match 1 or more path separators
+          for (; j < len; ++j) {
+            if (!isPathSeparator(path.charCodeAt(j))) break;
+          }
+          if (j < len && j !== last) {
+            // Matched!
+            last = j;
+            // Match 1 or more non-path separators
+            for (; j < len; ++j) {
+              if (isPathSeparator(path.charCodeAt(j))) break;
+            }
+            if (j === len) {
+              // We matched a UNC root only
+              return path;
+            }
+            if (j !== last) {
+              // We matched a UNC root with leftovers
+
+              // Offset by 1 to include the separator after the UNC root to
+              // treat it as a "normal root" on top of a (UNC) root
+              rootEnd = offset = j + 1;
+            }
+          }
+        }
+      }
+    } else if (isWindowsDeviceRoot(code)) {
+      // Possible device root
+
+      if (path.charCodeAt(1) === CHAR_COLON) {
+        rootEnd = offset = 2;
+        if (len > 2) {
+          if (isPathSeparator(path.charCodeAt(2))) rootEnd = offset = 3;
+        }
+      }
+    }
+  } else if (isPathSeparator(code)) {
+    // `path` contains just a path separator, exit early to avoid
+    // unnecessary work
+    return path;
+  }
+
+  for (let i = len - 1; i >= offset; --i) {
+    if (isPathSeparator(path.charCodeAt(i))) {
+      if (!matchedSlash) {
+        end = i;
+        break;
+      }
+    } else {
+      // We saw the first non-path separator
+      matchedSlash = false;
+    }
+  }
+
+  if (end === -1) {
+    if (rootEnd === -1) return ".";
+    else end = rootEnd;
+  }
+  return stripTrailingSeparators(path.slice(0, end), isPosixPathSeparator);
 }

--- a/path/windows/dirname.ts
+++ b/path/windows/dirname.ts
@@ -23,7 +23,7 @@ import {
  * ```
  *
  * Note: If you are working with file URLs,
- * use `dirname` from `@std/path/windows/unstable-dirname`.
+ * use the new version of `dirname` from `@std/path/windows/unstable-dirname`.
  *
  * @param path The path to get the directory from.
  * @returns The directory path.

--- a/path/windows/unstable_dirname.ts
+++ b/path/windows/unstable_dirname.ts
@@ -1,14 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import { assertArg } from "../_common/dirname.ts";
-import { CHAR_COLON } from "../_common/constants.ts";
-import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
-import {
-  isPathSeparator,
-  isPosixPathSeparator,
-  isWindowsDeviceRoot,
-} from "./_util.ts";
+import { dirname as stableDirname } from "./dirname.ts";
 import { fromFileUrl } from "./from_file_url.ts";
 
 /**
@@ -32,89 +25,5 @@ export function dirname(path: string | URL): string {
   if (path instanceof URL) {
     path = fromFileUrl(path);
   }
-  assertArg(path);
-
-  const len = path.length;
-  let rootEnd = -1;
-  let end = -1;
-  let matchedSlash = true;
-  let offset = 0;
-  const code = path.charCodeAt(0);
-
-  // Try to match a root
-  if (len > 1) {
-    if (isPathSeparator(code)) {
-      // Possible UNC root
-
-      rootEnd = offset = 1;
-
-      if (isPathSeparator(path.charCodeAt(1))) {
-        // Matched double path separator at beginning
-        let j = 2;
-        let last = j;
-        // Match 1 or more non-path separators
-        for (; j < len; ++j) {
-          if (isPathSeparator(path.charCodeAt(j))) break;
-        }
-        if (j < len && j !== last) {
-          // Matched!
-          last = j;
-          // Match 1 or more path separators
-          for (; j < len; ++j) {
-            if (!isPathSeparator(path.charCodeAt(j))) break;
-          }
-          if (j < len && j !== last) {
-            // Matched!
-            last = j;
-            // Match 1 or more non-path separators
-            for (; j < len; ++j) {
-              if (isPathSeparator(path.charCodeAt(j))) break;
-            }
-            if (j === len) {
-              // We matched a UNC root only
-              return path;
-            }
-            if (j !== last) {
-              // We matched a UNC root with leftovers
-
-              // Offset by 1 to include the separator after the UNC root to
-              // treat it as a "normal root" on top of a (UNC) root
-              rootEnd = offset = j + 1;
-            }
-          }
-        }
-      }
-    } else if (isWindowsDeviceRoot(code)) {
-      // Possible device root
-
-      if (path.charCodeAt(1) === CHAR_COLON) {
-        rootEnd = offset = 2;
-        if (len > 2) {
-          if (isPathSeparator(path.charCodeAt(2))) rootEnd = offset = 3;
-        }
-      }
-    }
-  } else if (isPathSeparator(code)) {
-    // `path` contains just a path separator, exit early to avoid
-    // unnecessary work
-    return path;
-  }
-
-  for (let i = len - 1; i >= offset; --i) {
-    if (isPathSeparator(path.charCodeAt(i))) {
-      if (!matchedSlash) {
-        end = i;
-        break;
-      }
-    } else {
-      // We saw the first non-path separator
-      matchedSlash = false;
-    }
-  }
-
-  if (end === -1) {
-    if (rootEnd === -1) return ".";
-    else end = rootEnd;
-  }
-  return stripTrailingSeparators(path.slice(0, end), isPosixPathSeparator);
+  return stableDirname(path);
 }

--- a/path/windows/unstable_dirname.ts
+++ b/path/windows/unstable_dirname.ts
@@ -1,0 +1,120 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import { assertArg } from "../_common/dirname.ts";
+import { CHAR_COLON } from "../_common/constants.ts";
+import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
+import {
+  isPathSeparator,
+  isPosixPathSeparator,
+  isWindowsDeviceRoot,
+} from "./_util.ts";
+import { fromFileUrl } from "./from_file_url.ts";
+
+/**
+ * Return the directory path of a file URL.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { dirname } from "@std/path/windows/unstable-dirname";
+ * import { assertEquals } from "@std/assert";
+ *
+ * assertEquals(dirname("C:\\foo\\bar\\baz.ext"), "C:\\foo\\bar");
+ * assertEquals(dirname(new URL("file:///C:/foo/bar/baz.ext")), "C:\\foo\\bar");
+ * ```
+ *
+ * @param path The path to get the directory from.
+ * @returns The directory path.
+ */
+export function dirname(path: string | URL): string {
+  if (path instanceof URL) {
+    path = fromFileUrl(path);
+  }
+  assertArg(path);
+
+  const len = path.length;
+  let rootEnd = -1;
+  let end = -1;
+  let matchedSlash = true;
+  let offset = 0;
+  const code = path.charCodeAt(0);
+
+  // Try to match a root
+  if (len > 1) {
+    if (isPathSeparator(code)) {
+      // Possible UNC root
+
+      rootEnd = offset = 1;
+
+      if (isPathSeparator(path.charCodeAt(1))) {
+        // Matched double path separator at beginning
+        let j = 2;
+        let last = j;
+        // Match 1 or more non-path separators
+        for (; j < len; ++j) {
+          if (isPathSeparator(path.charCodeAt(j))) break;
+        }
+        if (j < len && j !== last) {
+          // Matched!
+          last = j;
+          // Match 1 or more path separators
+          for (; j < len; ++j) {
+            if (!isPathSeparator(path.charCodeAt(j))) break;
+          }
+          if (j < len && j !== last) {
+            // Matched!
+            last = j;
+            // Match 1 or more non-path separators
+            for (; j < len; ++j) {
+              if (isPathSeparator(path.charCodeAt(j))) break;
+            }
+            if (j === len) {
+              // We matched a UNC root only
+              return path;
+            }
+            if (j !== last) {
+              // We matched a UNC root with leftovers
+
+              // Offset by 1 to include the separator after the UNC root to
+              // treat it as a "normal root" on top of a (UNC) root
+              rootEnd = offset = j + 1;
+            }
+          }
+        }
+      }
+    } else if (isWindowsDeviceRoot(code)) {
+      // Possible device root
+
+      if (path.charCodeAt(1) === CHAR_COLON) {
+        rootEnd = offset = 2;
+        if (len > 2) {
+          if (isPathSeparator(path.charCodeAt(2))) rootEnd = offset = 3;
+        }
+      }
+    }
+  } else if (isPathSeparator(code)) {
+    // `path` contains just a path separator, exit early to avoid
+    // unnecessary work
+    return path;
+  }
+
+  for (let i = len - 1; i >= offset; --i) {
+    if (isPathSeparator(path.charCodeAt(i))) {
+      if (!matchedSlash) {
+        end = i;
+        break;
+      }
+    } else {
+      // We saw the first non-path separator
+      matchedSlash = false;
+    }
+  }
+
+  if (end === -1) {
+    if (rootEnd === -1) return ".";
+    else end = rootEnd;
+  }
+  return stripTrailingSeparators(path.slice(0, end), isPosixPathSeparator);
+}


### PR DESCRIPTION
part of #5920 

This PR moves the 2nd overload of `dirname` functions to `./unstable-dirname`.

Unstable versions of `dirname` functions are only available from `unstable-dirname`, `posix/unstable-dirname`, or `windows/unstable-dirname`.

If this looks fine, I'll work on the rest of items in `@std/path`