### PR TITLE
BREAKING(encoding/unstable): move `base32-stream` module to `unstable-base32-stream`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -45,6 +45,7 @@ const ENTRY_POINTS = [
   "../datetime/mod.ts",
   "../dotenv/mod.ts",
   "../encoding/mod.ts",
+  "../encoding/unstable_base32_stream.ts",
   "../expect/mod.ts",
   "../fmt/bytes.ts",
   "../fmt/colors.ts",

--- a/encoding/deno.json
+++ b/encoding/deno.json
@@ -5,7 +5,7 @@
     ".": "./mod.ts",
     "./ascii85": "./ascii85.ts",
     "./base32": "./base32.ts",
-    "./base32-stream": "./base32_stream.ts",
+    "./unstable-base32-stream": "./unstable_base32_stream.ts",
     "./base32hex": "./base32hex.ts",
     "./base32hex-stream": "./base32hex_stream.ts",
     "./base58": "./base58.ts",

--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -17,7 +17,6 @@
 
 export * from "./ascii85.ts";
 export * from "./base32.ts";
-export * from "./base32_stream.ts";
 export * from "./base32hex.ts";
 export * from "./base32hex_stream.ts";
 export * from "./base58.ts";

--- a/encoding/unstable_base32_stream.ts
+++ b/encoding/unstable_base32_stream.ts
@@ -4,6 +4,18 @@
 /**
  * Utilities for encoding and decoding to and from base32 in a streaming manner.
  *
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { Base32DecoderStream } from "@std/encoding/unstable-base32-stream";
+ * import { toText } from "@std/streams/to-text";
+ *
+ * const stream = ReadableStream.from(["JBSWY3DPEBLW64TMMQQQ===="])
+ *   .pipeThrough(new Base32DecoderStream())
+ *   .pipeThrough(new TextDecoderStream());
+ *
+ * assertEquals(await toText(stream), "Hello World!");
+ * ```
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @module
@@ -22,7 +34,7 @@ import { decodeBase32, encodeBase32 } from "./base32.ts";
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import { encodeBase32 } from "@std/encoding/base32";
- * import { Base32EncoderStream } from "@std/encoding/base32-stream";
+ * import { Base32EncoderStream } from "@std/encoding/unstable-base32-stream";
  * import { toText } from "@std/streams/to-text";
  *
  * const stream = ReadableStream.from(["Hello,", " world!"])
@@ -66,7 +78,7 @@ export class Base32EncoderStream extends TransformStream<Uint8Array, string> {
  * @example Usage
  * ```ts
  * import { assertEquals } from "@std/assert";
- * import { Base32DecoderStream } from "@std/encoding/base32-stream";
+ * import { Base32DecoderStream } from "@std/encoding/unstable-base32-stream";
  * import { toText } from "@std/streams/to-text";
  *
  * const stream = ReadableStream.from(["JBSWY3DPEBLW64TMMQQQ===="])

--- a/encoding/unstable_base32_stream_test.ts
+++ b/encoding/unstable_base32_stream_test.ts
@@ -2,7 +2,10 @@
 
 import { assertEquals } from "@std/assert";
 import { encodeBase32 } from "./base32.ts";
-import { Base32DecoderStream, Base32EncoderStream } from "./base32_stream.ts";
+import {
+  Base32DecoderStream,
+  Base32EncoderStream,
+} from "./unstable_base32_stream.ts";
 import { RandomSliceStream } from "./_random_slice_stream.ts";
 import { toText } from "../streams/to_text.ts";
 import { concat } from "@std/bytes/concat";


### PR DESCRIPTION
Towards #5920