### PR TITLE
BREAKING(path/unstable): move unstable overload of `basename` to `unstable-basename`

### DIFF
--- a/path/basename.ts
+++ b/path/basename.ts
@@ -31,7 +31,7 @@ import { basename as windowsBasename } from "./windows/basename.ts";
  *
  * @returns The basename of the path.
  */
-export function basename(path: string, suffix?: string): string {
+export function basename(path: string, suffix = ""): string {
   return isWindows
     ? windowsBasename(path, suffix)
     : posixBasename(path, suffix);

--- a/path/basename.ts
+++ b/path/basename.ts
@@ -24,7 +24,7 @@ import { basename as windowsBasename } from "./windows/basename.ts";
  * ```
  *
  * Note: If you are working with file URLs,
- * use `basename` from `@std/path/unstable-basename`.
+ * use the new version of `basename` from `@std/path/unstable-basename`.
  *
  * @param path Path to extract the name from.
  * @param suffix Suffix to remove from extracted name.

--- a/path/basename.ts
+++ b/path/basename.ts
@@ -23,6 +23,9 @@ import { basename as windowsBasename } from "./windows/basename.ts";
  * }
  * ```
  *
+ * Note: If you are working with file URLs,
+ * use `basename` from `@std/path/unstable-basename`.
+ *
  * @param path Path to extract the name from.
  * @param suffix Suffix to remove from extracted name.
  *

--- a/path/deno.json
+++ b/path/deno.json
@@ -38,11 +38,13 @@
     "./posix/resolve": "./posix/resolve.ts",
     "./posix/to-file-url": "./posix/to_file_url.ts",
     "./posix/to-namespaced-path": "./posix/to_namespaced_path.ts",
+    "./posix/unstable-basename": "./posix/unstable_basename.ts",
     "./relative": "./relative.ts",
     "./resolve": "./resolve.ts",
     "./to-file-url": "./to_file_url.ts",
     "./to-namespaced-path": "./to_namespaced_path.ts",
     "./types": "./types.ts",
+    "./unstable-basename": "./unstable_basename.ts",
     "./windows": "./windows/mod.ts",
     "./windows/basename": "./windows/basename.ts",
     "./windows/common": "./windows/common.ts",
@@ -62,6 +64,7 @@
     "./windows/relative": "./windows/relative.ts",
     "./windows/resolve": "./windows/resolve.ts",
     "./windows/to-file-url": "./windows/to_file_url.ts",
-    "./windows/to-namespaced-path": "./windows/to_namespaced_path.ts"
+    "./windows/to-namespaced-path": "./windows/to_namespaced_path.ts",
+    "./windows/unstable-basename": "./windows/unstable_basename.ts"
   }
 }

--- a/path/posix/basename.ts
+++ b/path/posix/basename.ts
@@ -30,8 +30,8 @@ import { isPosixPathSeparator } from "./_util.ts";
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
  */
-export function basename(path: string, suffix?: string): string {
-  assertArgs(path, suffix ?? "");
+export function basename(path: string, suffix = ""): string {
+  assertArgs(path, suffix);
 
   const lastSegment = lastPathSegment(path, isPosixPathSeparator);
   const strippedSegment = stripTrailingSeparators(

--- a/path/posix/basename.ts
+++ b/path/posix/basename.ts
@@ -23,6 +23,9 @@ import { isPosixPathSeparator } from "./_util.ts";
  * assertEquals(basename("/home/user/Documents/image.png", ".png"), "image");
  * ```
  *
+ * Note: If you are working with file URLs,
+ * use `basename` from `@std/path/posix/unstable-basename`.
+ *
  * @param path The path to extract the name from.
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.

--- a/path/posix/basename.ts
+++ b/path/posix/basename.ts
@@ -24,7 +24,7 @@ import { isPosixPathSeparator } from "./_util.ts";
  * ```
  *
  * Note: If you are working with file URLs,
- * use `basename` from `@std/path/posix/unstable-basename`.
+ * use the new version of `basename` from `@std/path/posix/unstable-basename`.
  *
  * @param path The path to extract the name from.
  * @param suffix The suffix to remove from extracted name.

--- a/path/posix/unstable_basename.ts
+++ b/path/posix/unstable_basename.ts
@@ -1,39 +1,32 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
-import {
-  assertArgs,
-  lastPathSegment,
-  stripSuffix,
-} from "../_common/basename.ts";
-import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
-import { isPosixPathSeparator } from "./_util.ts";
+import { basename as stableBasename } from "./basename.ts";
+import { fromFileUrl } from "./from_file_url.ts";
 
 /**
  * Return the last portion of a `path`.
  * Trailing directory separators are ignored, and optional suffix is removed.
  *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
  * @example Usage
  * ```ts
- * import { basename } from "@std/path/posix/basename";
+ * import { basename } from "@std/path/posix/unstable-basename";
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals(basename("/home/user/Documents/"), "Documents");
  * assertEquals(basename("/home/user/Documents/image.png"), "image.png");
  * assertEquals(basename("/home/user/Documents/image.png", ".png"), "image");
+ * assertEquals(basename(new URL("file:///home/user/Documents/image.png")), "image.png");
+ * assertEquals(basename(new URL("file:///home/user/Documents/image.png"), ".png"), "image");
  * ```
  *
  * @param path The path to extract the name from.
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
  */
-export function basename(path: string, suffix?: string): string {
-  assertArgs(path, suffix ?? "");
-
-  const lastSegment = lastPathSegment(path, isPosixPathSeparator);
-  const strippedSegment = stripTrailingSeparators(
-    lastSegment,
-    isPosixPathSeparator,
-  );
-  return suffix ? stripSuffix(strippedSegment, suffix) : strippedSegment;
+export function basename(path: string | URL, suffix?: string): string {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+  return stableBasename(path, suffix);
 }

--- a/path/posix/unstable_basename.ts
+++ b/path/posix/unstable_basename.ts
@@ -26,7 +26,7 @@ import { fromFileUrl } from "./from_file_url.ts";
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
  */
-export function basename(path: string | URL, suffix?: string): string {
+export function basename(path: string | URL, suffix = ""): string {
   path = path instanceof URL ? fromFileUrl(path) : path;
   return stableBasename(path, suffix);
 }

--- a/path/unstable_basename.ts
+++ b/path/unstable_basename.ts
@@ -2,24 +2,28 @@
 // This module is browser compatible.
 
 import { isWindows } from "./_os.ts";
-import { basename as posixBasename } from "./posix/basename.ts";
-import { basename as windowsBasename } from "./windows/basename.ts";
+import { basename as posixUnstableBasename } from "./posix/unstable_basename.ts";
+import { basename as windowsUnstableBasename } from "./windows/unstable_basename.ts";
 
 /**
  * Return the last portion of a path.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * The trailing directory separators are ignored, and optional suffix is
  * removed.
  *
  * @example Usage
  * ```ts
- * import { basename } from "@std/path/basename";
+ * import { basename } from "@std/path/unstable-basename";
  * import { assertEquals } from "@std/assert";
  *
  * if (Deno.build.os === "windows") {
  *   assertEquals(basename("C:\\user\\Documents\\image.png"), "image.png");
+ *   assertEquals(basename(new URL("file:///C:/user/Documents/image.png")), "image.png");
  * } else {
  *   assertEquals(basename("/home/user/Documents/image.png"), "image.png");
+ *   assertEquals(basename(new URL("file:///home/user/Documents/image.png")), "image.png");
  * }
  * ```
  *
@@ -28,8 +32,8 @@ import { basename as windowsBasename } from "./windows/basename.ts";
  *
  * @returns The basename of the path.
  */
-export function basename(path: string, suffix?: string): string {
+export function basename(path: string | URL, suffix?: string): string {
   return isWindows
-    ? windowsBasename(path, suffix)
-    : posixBasename(path, suffix);
+    ? windowsUnstableBasename(path, suffix)
+    : posixUnstableBasename(path, suffix);
 }

--- a/path/unstable_basename.ts
+++ b/path/unstable_basename.ts
@@ -32,7 +32,7 @@ import { basename as windowsUnstableBasename } from "./windows/unstable_basename
  *
  * @returns The basename of the path.
  */
-export function basename(path: string | URL, suffix?: string): string {
+export function basename(path: string | URL, suffix = ""): string {
   return isWindows
     ? windowsUnstableBasename(path, suffix)
     : posixUnstableBasename(path, suffix);

--- a/path/windows/basename.ts
+++ b/path/windows/basename.ts
@@ -9,7 +9,6 @@ import {
 import { CHAR_COLON } from "../_common/constants.ts";
 import { stripTrailingSeparators } from "../_common/strip_trailing_separators.ts";
 import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
-import { fromFileUrl } from "./from_file_url.ts";
 
 /**
  * Return the last portion of a `path`.
@@ -29,33 +28,8 @@ import { fromFileUrl } from "./from_file_url.ts";
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
  */
-export function basename(path: string, suffix?: string): string;
-/**
- * Return the last portion of a `path`.
- * Trailing directory separators are ignored, and optional suffix is removed.
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * @example Usage
- * ```ts
- * import { basename } from "@std/path/windows/basename";
- * import { assertEquals } from "@std/assert";
- *
- * assertEquals(basename("C:\\user\\Documents\\"), "Documents");
- * assertEquals(basename("C:\\user\\Documents\\image.png"), "image.png");
- * assertEquals(basename("C:\\user\\Documents\\image.png", ".png"), "image");
- * assertEquals(basename(new URL("file:///C:/user/Documents/image.png")), "image.png");
- * assertEquals(basename(new URL("file:///C:/user/Documents/image.png"), ".png"), "image");
- * ```
- *
- * @param path The path to extract the name from.
- * @param suffix The suffix to remove from extracted name.
- * @returns The extracted name.
- */
-export function basename(path: string | URL, suffix?: string): string;
-export function basename(path: string | URL, suffix = ""): string {
-  path = path instanceof URL ? fromFileUrl(path) : path;
-  assertArgs(path, suffix);
+export function basename(path: string, suffix?: string): string {
+  assertArgs(path, suffix ?? "");
 
   // Check for a drive letter prefix so as not to mistake the following
   // path separator as an extra separator at the end of the path that can be

--- a/path/windows/basename.ts
+++ b/path/windows/basename.ts
@@ -25,7 +25,7 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * ```
  *
  * Note: If you are working with file URLs,
- * use `basename` from `@std/path/windows/unstable-basename`.
+ * use the new version of `basename` from `@std/path/windows/unstable-basename`.
  *
  * @param path The path to extract the name from.
  * @param suffix The suffix to remove from extracted name.

--- a/path/windows/basename.ts
+++ b/path/windows/basename.ts
@@ -31,8 +31,8 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
  */
-export function basename(path: string, suffix?: string): string {
-  assertArgs(path, suffix ?? "");
+export function basename(path: string, suffix = ""): string {
+  assertArgs(path, suffix);
 
   // Check for a drive letter prefix so as not to mistake the following
   // path separator as an extra separator at the end of the path that can be

--- a/path/windows/basename.ts
+++ b/path/windows/basename.ts
@@ -24,6 +24,9 @@ import { isPathSeparator, isWindowsDeviceRoot } from "./_util.ts";
  * assertEquals(basename("C:\\user\\Documents\\image.png", ".png"), "image");
  * ```
  *
+ * Note: If you are working with file URLs,
+ * use `basename` from `@std/path/windows/unstable-basename`.
+ *
  * @param path The path to extract the name from.
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.

--- a/path/windows/unstable_basename.ts
+++ b/path/windows/unstable_basename.ts
@@ -26,7 +26,7 @@ import { fromFileUrl } from "./from_file_url.ts";
  * @param suffix The suffix to remove from extracted name.
  * @returns The extracted name.
  */
-export function basename(path: string | URL, suffix?: string): string {
+export function basename(path: string | URL, suffix = ""): string {
   path = path instanceof URL ? fromFileUrl(path) : path;
   return stableBasename(path, suffix);
 }

--- a/path/windows/unstable_basename.ts
+++ b/path/windows/unstable_basename.ts
@@ -1,0 +1,32 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import { basename as stableBasename } from "./basename.ts";
+import { fromFileUrl } from "./from_file_url.ts";
+
+/**
+ * Return the last portion of a `path`.
+ * Trailing directory separators are ignored, and optional suffix is removed.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { basename } from "@std/path/windows/unstable-basename";
+ * import { assertEquals } from "@std/assert";
+ *
+ * assertEquals(basename("C:\\user\\Documents\\"), "Documents");
+ * assertEquals(basename("C:\\user\\Documents\\image.png"), "image.png");
+ * assertEquals(basename("C:\\user\\Documents\\image.png", ".png"), "image");
+ * assertEquals(basename(new URL("file:///C:/user/Documents/image.png")), "image.png");
+ * assertEquals(basename(new URL("file:///C:/user/Documents/image.png"), ".png"), "image");
+ * ```
+ *
+ * @param path The path to extract the name from.
+ * @param suffix The suffix to remove from extracted name.
+ * @returns The extracted name.
+ */
+export function basename(path: string | URL, suffix?: string): string {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+  return stableBasename(path, suffix);
+}


### PR DESCRIPTION
part of #5920 

This PR moves the unstable overload of `basename` to `unstable-basename`