### PR TITLE
BREAKING(encoding/unstable): move `hex-stream` module to `unstable-hex-stream`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -48,6 +48,7 @@ const ENTRY_POINTS = [
   "../encoding/unstable_base64_stream.ts",
   "../encoding/unstable_base32hex_stream.ts",
   "../encoding/unstable_base32_stream.ts",
+  "../encoding/unstable_hex_stream.ts",
   "../expect/mod.ts",
   "../fmt/bytes.ts",
   "../fmt/colors.ts",

--- a/encoding/deno.json
+++ b/encoding/deno.json
@@ -14,7 +14,7 @@
     "./base64url": "./base64url.ts",
     "./base64url-stream": "./base64url_stream.ts",
     "./hex": "./hex.ts",
-    "./hex-stream": "./hex_stream.ts",
+    "./unstable-hex-stream": "./unstable_hex_stream.ts",
     "./varint": "./varint.ts"
   }
 }

--- a/encoding/mod.ts
+++ b/encoding/mod.ts
@@ -23,5 +23,4 @@ export * from "./base64.ts";
 export * from "./base64url.ts";
 export * from "./base64url_stream.ts";
 export * from "./hex.ts";
-export * from "./hex_stream.ts";
 export * from "./varint.ts";

--- a/encoding/unstable_hex_stream.ts
+++ b/encoding/unstable_hex_stream.ts
@@ -4,6 +4,18 @@
 /**
  * Utilities for encoding and decoding to and from hex in a streaming manner.
  *
+ * ```ts
+ * import { assertEquals } from "@std/assert";
+ * import { HexDecoderStream } from "@std/encoding/unstable-hex-stream";
+ * import { toText } from "@std/streams/to-text";
+ *
+ * const stream = ReadableStream.from(["48656c6c6f2c", "20776f726c6421"])
+ *   .pipeThrough(new HexDecoderStream())
+ *   .pipeThrough(new TextDecoderStream());
+ *
+ * assertEquals(await toText(stream), "Hello, world!");
+ * ```
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @module
@@ -22,7 +34,7 @@ import { decodeHex, encodeHex } from "./hex.ts";
  * ```ts
  * import { assertEquals } from "@std/assert";
  * import { encodeHex } from "@std/encoding/hex";
- * import { HexEncoderStream } from "@std/encoding/hex-stream";
+ * import { HexEncoderStream } from "@std/encoding/unstable-hex-stream";
  * import { toText } from "@std/streams/to-text";
  *
  * const stream = ReadableStream.from(["Hello,", " world!"])
@@ -52,7 +64,7 @@ export class HexEncoderStream extends TransformStream<Uint8Array, string> {
  * @example Usage
  * ```ts
  * import { assertEquals } from "@std/assert";
- * import { HexDecoderStream } from "@std/encoding/hex-stream";
+ * import { HexDecoderStream } from "@std/encoding/unstable-hex-stream";
  * import { toText } from "@std/streams/to-text";
  *
  * const stream = ReadableStream.from(["48656c6c6f2c", "20776f726c6421"])

--- a/encoding/unstable_hex_stream_test.ts
+++ b/encoding/unstable_hex_stream_test.ts
@@ -2,7 +2,7 @@
 
 import { assertEquals } from "@std/assert";
 import { encodeHex } from "./hex.ts";
-import { HexDecoderStream, HexEncoderStream } from "./hex_stream.ts";
+import { HexDecoderStream, HexEncoderStream } from "./unstable_hex_stream.ts";
 import { toText } from "@std/streams/to-text";
 import { concat } from "@std/bytes/concat";
 import { RandomSliceStream } from "./_random_slice_stream.ts";


### PR DESCRIPTION
Towards #5920