### PR TITLE
BREAKING(path/unstable): move unstable overload of `join` to `unstable-join`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -75,6 +75,7 @@ const ENTRY_POINTS = [
   "../path/unstable_basename.ts",
   "../path/unstable_dirname.ts",
   "../path/unstable_extname.ts",
+  "../path/unstable_join.ts",
   "../path/posix/mod.ts",
   "../path/windows/mod.ts",
   "../random/mod.ts",

--- a/path/deno.json
+++ b/path/deno.json
@@ -41,6 +41,7 @@
     "./posix/unstable-basename": "./posix/unstable_basename.ts",
     "./posix/unstable-dirname": "./posix/unstable_dirname.ts",
     "./posix/unstable-extname": "./posix/unstable_extname.ts",
+    "./posix/unstable-join": "./posix/unstable_join.ts",
     "./relative": "./relative.ts",
     "./resolve": "./resolve.ts",
     "./to-file-url": "./to_file_url.ts",
@@ -49,6 +50,7 @@
     "./unstable-basename": "./unstable_basename.ts",
     "./unstable-dirname": "./unstable_dirname.ts",
     "./unstable-extname": "./unstable_extname.ts",
+    "./unstable-join": "./unstable_join.ts",
     "./windows": "./windows/mod.ts",
     "./windows/basename": "./windows/basename.ts",
     "./windows/common": "./windows/common.ts",
@@ -71,6 +73,7 @@
     "./windows/to-namespaced-path": "./windows/to_namespaced_path.ts",
     "./windows/unstable-basename": "./windows/unstable_basename.ts",
     "./windows/unstable-dirname": "./windows/unstable_dirname.ts",
-    "./windows/unstable-extname": "./windows/unstable_extname.ts"
+    "./windows/unstable-extname": "./windows/unstable_extname.ts",
+    "./windows/unstable-join": "./windows/unstable_join.ts"
   }
 }

--- a/path/join.ts
+++ b/path/join.ts
@@ -23,26 +23,6 @@ import { join as windowsJoin } from "./windows/join.ts";
  * @param paths Paths to be joined and normalized.
  * @returns The joined and normalized path.
  */
-export function join(...paths: string[]): string;
-/**
- * Join all given a sequence of `paths`, then normalizes the resulting path.
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * @example Usage
- * ```ts
- * import { join } from "@std/path/posix/join";
- * import { assertEquals } from "@std/assert";
- *
- * const path = join(new URL("file:///foo"), "bar", "baz/asdf", "quux", "..");
- * assertEquals(path, "/foo/bar/baz/asdf");
- * ```
- *
- * @param path The path to join. This can be string or file URL.
- * @param paths The paths to join.
- * @returns The joined path.
- */
-export function join(path?: URL | string, ...paths: string[]): string;
-export function join(path?: URL | string, ...paths: string[]): string {
-  return isWindows ? windowsJoin(path, ...paths) : posixJoin(path, ...paths);
+export function join(...paths: string[]): string {
+  return isWindows ? windowsJoin(...paths) : posixJoin(...paths);
 }

--- a/path/posix/join.ts
+++ b/path/posix/join.ts
@@ -3,7 +3,6 @@
 
 import { assertPath } from "../_common/assert_path.ts";
 import { normalize } from "./normalize.ts";
-import { fromFileUrl } from "./from_file_url.ts";
 
 /**
  * Join all given a sequence of `paths`,then normalizes the resulting path.
@@ -20,30 +19,8 @@ import { fromFileUrl } from "./from_file_url.ts";
  * @param paths The paths to join.
  * @returns The joined path.
  */
-export function join(...paths: string[]): string;
-/**
- * Join all given a sequence of `paths`, then normalizes the resulting path.
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * @example Usage
- * ```ts
- * import { join } from "@std/path/posix/join";
- * import { assertEquals } from "@std/assert";
- *
- * assertEquals(join("/foo", "bar", "baz/asdf", "quux", ".."), "/foo/bar/baz/asdf");
- * assertEquals(join(new URL("file:///foo"), "bar", "baz/asdf", "quux", ".."), "/foo/bar/baz/asdf");
- * ```
- *
- * @param path The path to join. This can be string or file URL.
- * @param paths The paths to join.
- * @returns The joined path.
- */
-export function join(path?: URL | string, ...paths: string[]): string;
-export function join(path?: URL | string, ...paths: string[]): string {
-  if (path === undefined) return ".";
-  path = path instanceof URL ? fromFileUrl(path) : path;
-  paths = path ? [path, ...paths] : paths;
+export function join(...paths: string[]): string {
+  if (paths.length === 0) return ".";
   paths.forEach((path) => assertPath(path));
   const joined = paths.filter((path) => path.length > 0).join("/");
   return joined === "" ? "." : normalize(joined);

--- a/path/posix/unstable_join.ts
+++ b/path/posix/unstable_join.ts
@@ -1,0 +1,30 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import { join as stableJoin } from "./join.ts";
+import { fromFileUrl } from "./from_file_url.ts";
+
+/**
+ * Join all given a sequence of `paths`, then normalizes the resulting path.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { join } from "@std/path/posix/unstable-join";
+ * import { assertEquals } from "@std/assert";
+ *
+ * assertEquals(join("/foo", "bar", "baz/asdf", "quux", ".."), "/foo/bar/baz/asdf");
+ * assertEquals(join(new URL("file:///foo"), "bar", "baz/asdf", "quux", ".."), "/foo/bar/baz/asdf");
+ * ```
+ *
+ * @param path The path to join. This can be string or file URL.
+ * @param paths The paths to join.
+ * @returns The joined path.
+ */
+export function join(path?: URL | string, ...paths: string[]): string {
+  if (path === undefined) return ".";
+  path = path instanceof URL ? fromFileUrl(path) : path;
+  paths = path ? [path, ...paths] : paths;
+  return stableJoin(...paths);
+}

--- a/path/unstable_join.ts
+++ b/path/unstable_join.ts
@@ -1,0 +1,35 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import { isWindows } from "./_os.ts";
+import { join as posixUnstableJoin } from "./posix/unstable_join.ts";
+import { join as windowsUnstableJoin } from "./windows/unstable_join.ts";
+
+/**
+ * Join all given a sequence of `paths`, then normalizes the resulting path.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { join } from "@std/path/unstable-join";
+ * import { assertEquals } from "@std/assert";
+ *
+ * if (Deno.build.os === "windows") {
+ *   const path = join(new URL("file:///C:/foo"), "bar", "baz/asdf", "quux", "..");
+ *   assertEquals(path, "C:\\foo\\bar\\baz\\asdf");
+ * } else {
+ *   const path = join(new URL("file:///foo"), "bar", "baz/asdf", "quux", "..");
+ *   assertEquals(path, "/foo/bar/baz/asdf");
+ * }
+ * ```
+ *
+ * @param path The path to join. This can be string or file URL.
+ * @param paths The paths to join.
+ * @returns The joined path.
+ */
+export function join(path?: URL | string, ...paths: string[]): string {
+  return isWindows
+    ? windowsUnstableJoin(path, ...paths)
+    : posixUnstableJoin(path, ...paths);
+}

--- a/path/windows/join.ts
+++ b/path/windows/join.ts
@@ -4,7 +4,6 @@
 import { assertPath } from "../_common/assert_path.ts";
 import { isPathSeparator } from "./_util.ts";
 import { normalize } from "./normalize.ts";
-import { fromFileUrl } from "./from_file_url.ts";
 
 /**
  * Join all given a sequence of `paths`,then normalizes the resulting path.
@@ -21,29 +20,7 @@ import { fromFileUrl } from "./from_file_url.ts";
  * @param paths The paths to join.
  * @returns The joined path.
  */
-export function join(...paths: string[]): string;
-/**
- * Join all given a sequence of `paths`, then normalizes the resulting path.
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * @example Usage
- * ```ts
- * import { join } from "@std/path/windows/join";
- * import { assertEquals } from "@std/assert";
- *
- * assertEquals(join("C:\\foo", "bar", "baz\\.."), "C:\\foo\\bar");
- * assertEquals(join(new URL("file:///C:/foo"), "bar", "baz\\.."), "C:\\foo\\bar");
- * ```
- *
- * @param path The path to join. This can be string or file URL.
- * @param paths The paths to join.
- * @returns The joined path.
- */
-export function join(path?: URL | string, ...paths: string[]): string;
-export function join(path?: URL | string, ...paths: string[]): string {
-  path = path instanceof URL ? fromFileUrl(path) : path;
-  paths = path ? [path, ...paths] : paths;
+export function join(...paths: string[]): string {
   paths.forEach((path) => assertPath(path));
   paths = paths.filter((path) => path.length > 0);
   if (paths.length === 0) return ".";

--- a/path/windows/unstable_join.ts
+++ b/path/windows/unstable_join.ts
@@ -1,0 +1,29 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import { join as stableJoin } from "./join.ts";
+import { fromFileUrl } from "./from_file_url.ts";
+
+/**
+ * Join all given a sequence of `paths`, then normalizes the resulting path.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @example Usage
+ * ```ts
+ * import { join } from "@std/path/windows/unstable-join";
+ * import { assertEquals } from "@std/assert";
+ *
+ * assertEquals(join("C:\\foo", "bar", "baz\\.."), "C:\\foo\\bar");
+ * assertEquals(join(new URL("file:///C:/foo"), "bar", "baz\\.."), "C:\\foo\\bar");
+ * ```
+ *
+ * @param path The path to join. This can be string or file URL.
+ * @param paths The paths to join.
+ * @returns The joined path.
+ */
+export function join(path?: URL | string, ...paths: string[]): string {
+  path = path instanceof URL ? fromFileUrl(path) : path;
+  paths = path ? [path, ...paths] : paths;
+  return stableJoin(...paths);
+}


### PR DESCRIPTION
part of #5920 

This PR moves the unstable overload of `join` function to `unstable-join` module.