### PR TITLE
chore(net): add back `get-network-address` module to fix `http@1.0.5/file-server`

### DIFF
--- a/net/deno.json
+++ b/net/deno.json
@@ -4,6 +4,7 @@
   "exports": {
     ".": "./mod.ts",
     "./get-available-port": "./get_available_port.ts",
+    "./get-network-address": "./unstable_get_network_address.ts",
     "./unstable-get-network-address": "./unstable_get_network_address.ts"
   }
 }


### PR DESCRIPTION
`http@1.0.5/file-server` is now broken because it depends on `net@^1.0.2/get-network-address` which now resolves to `net@1.0.3/get-network-address`, but that path doesn't exist in `net@1.0.3`. This PR fixes it.