### PR TITLE
fix(assert): accept abstract classes

### DIFF
--- a/assert/instance_of.ts
+++ b/assert/instance_of.ts
@@ -6,9 +6,7 @@ import { AssertionError } from "./assertion_error.ts";
 // deno-lint-ignore no-explicit-any
 export type AnyConstructor = new (...args: any[]) => any;
 /** Gets constructor type */
-export type GetConstructorType<T extends AnyConstructor> = T extends // deno-lint-ignore no-explicit-any
-new (...args: any) => infer C ? C
-  : never;
+export type GetConstructorType<T extends AnyConstructor> = InstanceType<T>;
 
 /**
  * Make an assertion that `obj` is an instance of `type`.
@@ -27,11 +25,14 @@ new (...args: any) => infer C ? C
  * @param expectedType The expected class constructor.
  * @param msg The optional message to display if the assertion fails.
  */
-export function assertInstanceOf<T extends AnyConstructor>(
+export function assertInstanceOf<
+  // deno-lint-ignore no-explicit-any
+  T extends abstract new (...args: any[]) => any,
+>(
   actual: unknown,
   expectedType: T,
   msg = "",
-): asserts actual is GetConstructorType<T> {
+): asserts actual is InstanceType<T> {
   if (actual instanceof expectedType) return;
 
   const msgSuffix = msg ? `: ${msg}` : ".";

--- a/assert/instance_of_test.ts
+++ b/assert/instance_of_test.ts
@@ -7,12 +7,15 @@ Deno.test({
     class TestClass1 {}
     class TestClass2 {}
     class TestClass3 {}
+    abstract class AbstractTestClass {}
+    class ConcreteTestClass extends AbstractTestClass {}
 
     // Regular types
     assertInstanceOf(new Date(), Date);
     assertInstanceOf(new Number(), Number);
     assertInstanceOf(Promise.resolve(), Promise);
     assertInstanceOf(new TestClass1(), TestClass1);
+    assertInstanceOf(new ConcreteTestClass(), AbstractTestClass);
 
     // Throwing cases
     assertThrows(

--- a/assert/instance_of_test.ts
+++ b/assert/instance_of_test.ts
@@ -7,15 +7,12 @@ Deno.test({
     class TestClass1 {}
     class TestClass2 {}
     class TestClass3 {}
-    abstract class AbstractTestClass {}
-    class ConcreteTestClass extends AbstractTestClass {}
 
     // Regular types
     assertInstanceOf(new Date(), Date);
     assertInstanceOf(new Number(), Number);
     assertInstanceOf(Promise.resolve(), Promise);
     assertInstanceOf(new TestClass1(), TestClass1);
-    assertInstanceOf(new ConcreteTestClass(), AbstractTestClass);
 
     // Throwing cases
     assertThrows(
@@ -115,5 +112,15 @@ Deno.test({
       // @ts-expect-error: `x` is now `Number` rather than `number`, so this should still give a type error.
       x += 5;
     }
+  },
+});
+
+Deno.test({
+  name: "assertInstanceOf() accepts abstract class",
+  fn() {
+    abstract class AbstractClass {}
+    class ConcreteClass extends AbstractClass {}
+
+    assertInstanceOf(new ConcreteClass(), AbstractClass);
   },
 });

--- a/assert/is_error.ts
+++ b/assert/is_error.ts
@@ -29,7 +29,7 @@ import { stripAnsiCode } from "@std/internal/styles";
 export function assertIsError<E extends Error = Error>(
   error: unknown,
   // deno-lint-ignore no-explicit-any
-  ErrorClass?: new (...args: any[]) => E,
+  ErrorClass?: abstract new (...args: any[]) => E,
   msgMatches?: string | RegExp,
   msg?: string,
 ): asserts error is E {

--- a/assert/is_error_test.ts
+++ b/assert/is_error_test.ts
@@ -37,6 +37,13 @@ Deno.test("assertIsError() allows custom error", () => {
   );
 });
 
+Deno.test("assertIsError() accepts abstract class", () => {
+  abstract class AbstractError extends Error {}
+  class ConcreteError extends AbstractError {}
+
+  assertIsError(new ConcreteError("failed"), AbstractError, "fail");
+});
+
 Deno.test("assertIsError() throws with message diff containing double quotes", () => {
   assertThrows(
     () =>

--- a/assert/not_instance_of.ts
+++ b/assert/not_instance_of.ts
@@ -23,7 +23,7 @@ import { assertFalse } from "./false.ts";
 export function assertNotInstanceOf<A, T>(
   actual: A,
   // deno-lint-ignore no-explicit-any
-  unexpectedType: new (...args: any[]) => T,
+  unexpectedType: abstract new (...args: any[]) => T,
   msg?: string,
 ): asserts actual is Exclude<A, T> {
   const msgSuffix = msg ? `: ${msg}` : ".";

--- a/assert/not_instance_of_test.ts
+++ b/assert/not_instance_of_test.ts
@@ -11,6 +11,15 @@ Deno.test({
 });
 
 Deno.test({
+  name: "assertNotInstanceOf() accepts abstract class",
+  fn() {
+    abstract class AbstractClass {}
+
+    assertNotInstanceOf(AbstractClass, AbstractClass);
+  },
+});
+
+Deno.test({
   name: "assertNotInstanceOf() throws",
   fn() {
     assertThrows(

--- a/assert/rejects.ts
+++ b/assert/rejects.ts
@@ -49,7 +49,7 @@ export function assertRejects(
 export function assertRejects<E extends Error = Error>(
   fn: () => PromiseLike<unknown>,
   // deno-lint-ignore no-explicit-any
-  ErrorClass: new (...args: any[]) => E,
+  ErrorClass: abstract new (...args: any[]) => E,
   msgIncludes?: string,
   msg?: string,
 ): Promise<E>;
@@ -57,14 +57,14 @@ export async function assertRejects<E extends Error = Error>(
   fn: () => PromiseLike<unknown>,
   errorClassOrMsg?:
     // deno-lint-ignore no-explicit-any
-    | (new (...args: any[]) => E)
+    | (abstract new (...args: any[]) => E)
     | string,
   msgIncludesOrMsg?: string,
   msg?: string,
 ): Promise<E | Error | unknown> {
   // deno-lint-ignore no-explicit-any
-  let ErrorClass: (new (...args: any[]) => E) | undefined = undefined;
-  let msgIncludes: string | undefined = undefined;
+  let ErrorClass: (abstract new (...args: any[]) => E) | undefined;
+  let msgIncludes: string | undefined;
   let err;
 
   if (typeof errorClassOrMsg !== "string") {
@@ -73,8 +73,7 @@ export async function assertRejects<E extends Error = Error>(
       errorClassOrMsg.prototype instanceof Error ||
       errorClassOrMsg.prototype === Error.prototype
     ) {
-      // deno-lint-ignore no-explicit-any
-      ErrorClass = errorClassOrMsg as new (...args: any[]) => E;
+      ErrorClass = errorClassOrMsg;
       msgIncludes = msgIncludesOrMsg;
     }
   } else {

--- a/assert/rejects_test.ts
+++ b/assert/rejects_test.ts
@@ -90,6 +90,17 @@ Deno.test("assertRejects() throws async parent error ", async () => {
   );
 });
 
+Deno.test("assertRejects() accepts abstract class", () => {
+  abstract class AbstractError extends Error {}
+  class ConcreteError extends AbstractError {}
+
+  assertRejects(
+    () => Promise.reject(new ConcreteError("failed")),
+    AbstractError,
+    "fail",
+  );
+});
+
 Deno.test(
   "assertRejects() throws with custom Error",
   async () => {

--- a/assert/throws.ts
+++ b/assert/throws.ts
@@ -52,7 +52,7 @@ export function assertThrows(
 export function assertThrows<E extends Error = Error>(
   fn: () => unknown,
   // deno-lint-ignore no-explicit-any
-  ErrorClass: new (...args: any[]) => E,
+  ErrorClass: abstract new (...args: any[]) => E,
   msgIncludes?: string,
   msg?: string,
 ): E;
@@ -60,14 +60,14 @@ export function assertThrows<E extends Error = Error>(
   fn: () => unknown,
   errorClassOrMsg?:
     // deno-lint-ignore no-explicit-any
-    | (new (...args: any[]) => E)
+    | (abstract new (...args: any[]) => E)
     | string,
   msgIncludesOrMsg?: string,
   msg?: string,
 ): E | Error | unknown {
   // deno-lint-ignore no-explicit-any
-  let ErrorClass: (new (...args: any[]) => E) | undefined = undefined;
-  let msgIncludes: string | undefined = undefined;
+  let ErrorClass: (abstract new (...args: any[]) => E) | undefined;
+  let msgIncludes: string | undefined;
   let err;
 
   if (typeof errorClassOrMsg !== "string") {
@@ -76,8 +76,7 @@ export function assertThrows<E extends Error = Error>(
       errorClassOrMsg?.prototype instanceof Error ||
       errorClassOrMsg?.prototype === Error.prototype
     ) {
-      // deno-lint-ignore no-explicit-any
-      ErrorClass = errorClassOrMsg as new (...args: any[]) => E;
+      ErrorClass = errorClassOrMsg;
       msgIncludes = msgIncludesOrMsg;
     } else {
       msg = msgIncludesOrMsg;

--- a/assert/throws_test.ts
+++ b/assert/throws_test.ts
@@ -128,6 +128,19 @@ Deno.test("assertThrows() matches subclass of expected error", () => {
   );
 });
 
+Deno.test("assertThrows() accepts abstract class", () => {
+  abstract class AbstractError extends Error {}
+  class ConcreteError extends AbstractError {}
+
+  assertThrows(
+    () => {
+      throw new ConcreteError("failed");
+    },
+    AbstractError,
+    "fail",
+  );
+});
+
 Deno.test("assertThrows() throws when input function does not throw", () => {
   assertThrows(
     () => {


### PR DESCRIPTION
Makes this work:

```ts
import { assertInstanceOf } from "jsr:@std/assert/instance-of";

assertInstanceOf([].values(), Iterator);
```
