### PR TITLE
fix(tar): update to `0.1.1`

### DIFF
--- a/import_map.json
+++ b/import_map.json
@@ -39,7 +39,7 @@
     "@std/random": "jsr:@std/random@^0.1.0",
     "@std/semver": "jsr:@std/semver@^1.0.3",
     "@std/streams": "jsr:@std/streams@^1.0.5",
-    "@std/tar": "jsr:@std/tar@^0.1.0",
+    "@std/tar": "jsr:@std/tar@^0.1.1",
     "@std/testing": "jsr:@std/testing@^1.0.2",
     "@std/text": "jsr:@std/text@^1.0.6",
     "@std/toml": "jsr:@std/toml@^1.0.1",

--- a/tar/deno.json
+++ b/tar/deno.json
@@ -1,6 +1,6 @@
 {
   "name": "@std/tar",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "exports": {
     ".": "./mod.ts",
     "./tar-stream": "./tar_stream.ts",


### PR DESCRIPTION
We recently moved `@std/streams/fixed-chunk-stream` to `@std/streams/unstable-fixed-chunk-stream` in #5951. However, we forgot to update `@std/tar` accordingly. So now, `UntarStream` is unusable on the latest release. This PR fixes that. I'm sure there are other packages with the same issue.