### PR TITLE
docs(fs): clarify permissions requirements for `exists[Sync]()`

### DIFF
--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -36,7 +36,8 @@ export interface ExistsOptions {
  * @see {@link https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use} for
  * more information on the time-of-check to time-of-use bug.
  *
- * Requires `--allow-read` and `--allow-sys` permissions.
+ * Requires `--allow-read` permissions, and in some cases, `--allow-sys`
+ * permissions if `options.isReadable` is `true`.
  *
  * @see {@link https://docs.deno.com/runtime/manual/basics/permissions#file-system-access}
  * for more information on Deno's permissions system.
@@ -166,7 +167,8 @@ export async function exists(
  * @see {@link https://en.wikipedia.org/wiki/Time-of-check_to_time-of-use} for
  * more information on the time-of-check to time-of-use bug.
  *
- * Requires `--allow-read` and `--allow-sys` permissions.
+ * Requires `--allow-read` permissions, and in some cases, `--allow-sys`
+ * permissions if `options.isReadable` is `true`.
  *
  * @see {@link https://docs.deno.com/runtime/manual/basics/permissions#file-system-access}
  * for more information on Deno's permissions system.

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -73,6 +73,9 @@ export interface ExistsOptions {
  * ```
  *
  * @example Check if a path is readable
+ *
+ * Requires `--allow-sys` permissions in some cases.
+ *
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -97,6 +100,9 @@ export interface ExistsOptions {
  * ```
  *
  * @example Check if a path is a readable directory
+ *
+ * Requires `--allow-sys` permissions in some cases.
+ *
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -105,6 +111,9 @@ export interface ExistsOptions {
  * ```
  *
  * @example Check if a path is a readable file
+ *
+ * Requires `--allow-sys` permissions in some cases.
+ *
  * ```ts no-eval
  * import { exists } from "@std/fs/exists";
  *
@@ -203,6 +212,9 @@ export async function exists(
  * ```
  *
  * @example Check if a path is readable
+ *
+ * Requires `--allow-sys` permissions in some cases.
+ *
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *
@@ -227,6 +239,9 @@ export async function exists(
  * ```
  *
  * @example Check if a path is a readable directory
+ *
+ * Requires `--allow-sys` permissions in some cases.
+ *
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *
@@ -235,6 +250,9 @@ export async function exists(
  * ```
  *
  * @example Check if a path is a readable file
+ *
+ * Requires `--allow-sys` permissions in some cases.
+ *
  * ```ts no-eval
  * import { existsSync } from "@std/fs/exists";
  *


### PR DESCRIPTION
`--allow-sys` is required as [`Deno.uid()`](https://docs.deno.com/api/deno/~/Deno.uid) and [`Deno.gid()`](https://docs.deno.com/api/deno/~/Deno.gid) are called when `options.isReadable = true`, which both require `--allow-sys` permissions.

Closes #5977