### PR TITLE
deprecation(archive/unstable): deprecate `@std/archive`

### DIFF
--- a/archive/_common.ts
+++ b/archive/_common.ts
@@ -6,6 +6,9 @@ import type { Reader } from "@std/io/types";
 /**
  * Base interface for {@linkcode TarMeta}.
  *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
 export interface TarInfo {
@@ -43,6 +46,9 @@ export interface TarInfo {
 
 /**
  * Base interface for {@linkcode TarMetaWithLinkName}.
+ *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */

--- a/archive/mod.ts
+++ b/archive/mod.ts
@@ -34,9 +34,6 @@
  * archive file, while untar is the inverse utility to extract the files from an
  * archive. Files are not compressed, only collected into the archive.
  *
- * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
- *
  * ```ts no-eval
  * import { Tar } from "@std/archive/tar";
  * import { Buffer } from "@std/io/buffer";
@@ -64,6 +61,9 @@
  * await copy(tar.getReader(), writer);
  * writer.close();
  * ```
+ *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *

--- a/archive/mod.ts
+++ b/archive/mod.ts
@@ -34,6 +34,9 @@
  * archive file, while untar is the inverse utility to extract the files from an
  * archive. Files are not compressed, only collected into the archive.
  *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
+ *
  * ```ts no-eval
  * import { Tar } from "@std/archive/tar";
  * import { Buffer } from "@std/io/buffer";

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -44,6 +44,9 @@ export type { TarInfo, TarMeta };
 /**
  * Options for {@linkcode Tar.append}.
  *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
 export interface TarOptions extends TarInfo {
@@ -122,6 +125,9 @@ function formatHeader(data: TarData): Uint8Array {
 /**
  * Base interface for {@linkcode TarDataWithSource}.
  *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
 export interface TarData {
@@ -173,6 +179,9 @@ export interface TarData {
 /**
  * Tar data interface for {@linkcode Tar.data}.
  *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
 export interface TarDataWithSource extends TarData {
@@ -191,6 +200,9 @@ export interface TarDataWithSource extends TarData {
  * A class to create a tar archive.  Tar archives allow for storing multiple files in a
  * single file (called an archive, or sometimes a tarball).  These archives typically
  * have the '.tar' extension.
+ *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
  *
  * ### Usage
  * The workflow is to create a Tar instance, append files to it, and then write the

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -46,6 +46,9 @@ export type { Reader, Seeker };
  * Extend TarMeta with the `linkName` property so that readers can access
  * symbolic link values without polluting the world of archive writers.
  *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
 export interface TarMetaWithLinkName extends TarMeta {
@@ -55,6 +58,9 @@ export interface TarMetaWithLinkName extends TarMeta {
 
 /**
  * Tar header with raw, unprocessed bytes as values.
+ *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -96,6 +102,9 @@ function parseHeader(buffer: Uint8Array): TarHeader {
 /**
  * Tar entry
  *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
+ *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
@@ -123,6 +132,9 @@ export interface TarEntry extends TarMetaWithLinkName {}
 
 /**
  * Contains tar header metadata and a reader to the entry's body.
+ *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
@@ -324,6 +336,9 @@ export class TarEntry implements Reader {
  * A class to extract from a tar archive.  Tar archives allow for storing multiple
  * files in a single file (called an archive, or sometimes a tarball).  These
  * archives typically have the '.tar' extension.
+ *
+ * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
+ * `@std/archive` will be removed in the future.
  *
  * ### Supported file formats
  * Only the ustar file format is supported.  This is the most common format. The


### PR DESCRIPTION
This package is being superceded by `@std/tar`.

Towards #5986