### PR TITLE
deprecation(io/unstable): deprecate `readLines()`

### DIFF
--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -26,7 +26,7 @@ import { concat } from "@std/bytes/concat";
  *
  * @deprecated Use
  * {@linkcode https://jsr.io/@std/streams/doc/unstable-to-lines/~/toLines | toLines}
- * instead. This will be removed in the future.
+ * on the readable stream instead. This will be removed in the future.
  */
 export async function* readLines(
   reader: Reader,

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -24,7 +24,9 @@ import { concat } from "@std/bytes/concat";
  * @param decoderOpts The options
  * @returns The async iterator of strings
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Use
+ * {@linkcode https://jsr.io/@std/streams/doc/unstable-to-lines/~/toLines | toLines}
+ * instead. This will be removed in the future.
  */
 export async function* readLines(
   reader: Reader,


### PR DESCRIPTION
Towards #5989