### PR TITLE
deprecation(io/unstable): deprecate `copyN()`

### DIFF
--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -24,7 +24,9 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * @param size Read size
  * @returns Number of bytes copied
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Pipe through
+ * {@linkcode https://jsr.io/@std/streams/doc/~/ByteSliceStream | ByteSliceStream}
+ * instead. This will be removed in the future.
  */
 export async function copyN(
   r: Reader,

--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -24,7 +24,7 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * @param size Read size
  * @returns Number of bytes copied
  *
- * @deprecated Pipe through
+ * @deprecated Pipe the readable stream through a new
  * {@linkcode https://jsr.io/@std/streams/doc/~/ByteSliceStream | ByteSliceStream}
  * instead. This will be removed in the future.
  */


### PR DESCRIPTION
Towards #5989