### PR TITLE
docs(archive,log,testing): correct typos

### DIFF
--- a/archive/mod.ts
+++ b/archive/mod.ts
@@ -54,7 +54,7 @@
  *   filePath: "./filename_on_filesystem.txt",
  * });
  *
- * // Now let's write the tar (with it's two files) to the filesystem
+ * // Now let's write the tar (with its two files) to the filesystem
  * // use tar.getReader() to read the contents.
  *
  * const writer = await Deno.open("./out.tar", { write: true, create: true });

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -233,7 +233,7 @@ export interface TarDataWithSource extends TarData {
  *   filePath: "./filename_on_filesystem.txt",
  * });
  *
- * // Now let's write the tar (with it's two files) to the filesystem
+ * // Now let's write the tar (with its two files) to the filesystem
  * // use tar.getReader() to read the contents.
  *
  * const writer = await Deno.open("./out.tar", { write: true, create: true });
@@ -285,7 +285,7 @@ export class Tar {
    *   filePath: "./filename_on_filesystem.txt",
    * });
    *
-   * // Now let's write the tar (with it's two files) to the filesystem
+   * // Now let's write the tar (with its two files) to the filesystem
    * // use tar.getReader() to read the contents.
    *
    * const writer = await Deno.open("./out.tar", { write: true, create: true });
@@ -437,7 +437,7 @@ export class Tar {
    *   filePath: "./filename_on_filesystem.txt",
    * });
    *
-   * // Now let's write the tar (with it's two files) to the filesystem
+   * // Now let's write the tar (with its two files) to the filesystem
    * // use tar.getReader() to read the contents.
    *
    * const writer = await Deno.open("./out.tar", { write: true, create: true });

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -25,7 +25,7 @@
  * `log.formatters.jsonFormatter` or write your own function that takes a
  * {@linkcode LogRecord} and returns a JSON.stringify'd object.
  * If you want the log to go to stdout then use {@linkcode ConsoleHandler} with
- * the configuration `useColors: false` to turn off the ANSI terminal colours.
+ * the configuration `useColors: false` to turn off the ANSI terminal colors.
  *
  * ```ts
  * import * as log from "@std/log";

--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -463,23 +463,23 @@ snapshot[`assertSnapshot() - regression #2144 1`] = `
 
 snapshot[`assertSnapshot() - empty #2245 1`] = ``;
 
-snapshot[`createAssertSnapshot() > no options 1`] = `This green text has had it's colours stripped`;
+snapshot[`createAssertSnapshot() > no options 1`] = `This green text has had it's colors stripped`;
 
-snapshot[`createAssertSnapshot() - options object - custom name 1`] = `This green text has had it's colours stripped`;
+snapshot[`createAssertSnapshot() - options object - custom name 1`] = `This green text has had it's colors stripped`;
 
 snapshot[`createAssertSnapshot() > message 1`] = `"This snapshot has failed as expected"`;
 
-snapshot[`createAssertSnapshot() - composite - custom Name 1`] = `This green text has had it's colours stripped`;
+snapshot[`createAssertSnapshot() - composite - custom Name 1`] = `This green text has had it's colors stripped`;
 
 snapshot[`assertSnapshot() - regression #5155 1`] = `
 "running 1 test from <tempDir>/test.ts
 Snapshot Test ... FAILED (--ms)
 
- ERRORS 
+ ERRORS
 error: PermissionDenied: Missing write access to snapshot file (file://<path>). This is required because assertSnapshot was called in update mode. Please pass the --allow-write flag.
         throw new Deno.errors.PermissionDenied(
               ^
- FAILURES 
+ FAILURES
 
 FAILED | 0 passed | 1 failed (--ms)
 

--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -463,13 +463,13 @@ snapshot[`assertSnapshot() - regression #2144 1`] = `
 
 snapshot[`assertSnapshot() - empty #2245 1`] = ``;
 
-snapshot[`createAssertSnapshot() > no options 1`] = `This green text has had it's colors stripped`;
+snapshot[`createAssertSnapshot() > no options 1`] = `This green text has had its colors stripped`;
 
-snapshot[`createAssertSnapshot() - options object - custom name 1`] = `This green text has had it's colors stripped`;
+snapshot[`createAssertSnapshot() - options object - custom name 1`] = `This green text has had its colors stripped`;
 
 snapshot[`createAssertSnapshot() > message 1`] = `"This snapshot has failed as expected"`;
 
-snapshot[`createAssertSnapshot() - composite - custom Name 1`] = `This green text has had it's colors stripped`;
+snapshot[`createAssertSnapshot() - composite - custom Name 1`] = `This green text has had its colors stripped`;
 
 snapshot[`assertSnapshot() - regression #5155 1`] = `
 "running 1 test from <tempDir>/test.ts

--- a/testing/__snapshots__/snapshot_test.ts.snap
+++ b/testing/__snapshots__/snapshot_test.ts.snap
@@ -475,11 +475,11 @@ snapshot[`assertSnapshot() - regression #5155 1`] = `
 "running 1 test from <tempDir>/test.ts
 Snapshot Test ... FAILED (--ms)
 
- ERRORS
+ ERRORS 
 error: PermissionDenied: Missing write access to snapshot file (file://<path>). This is required because assertSnapshot was called in update mode. Please pass the --allow-write flag.
         throw new Deno.errors.PermissionDenied(
               ^
- FAILURES
+ FAILURES 
 
 FAILED | 0 passed | 1 failed (--ms)
 

--- a/testing/bdd_test.ts
+++ b/testing/bdd_test.ts
@@ -1431,7 +1431,7 @@ Deno.test("describe()", async (t) => {
   await t.step("flat child only", async (t) => {
     /**
      * Asserts that when only is used on a child `describe` or `it` call, it will be the only test case or suite that runs within the top test suite.
-     * This demonstrates the issue where `Deno.test` is called without `only` even though one of it's child steps are focused.
+     * This demonstrates the issue where `Deno.test` is called without `only` even though one of its child steps are focused.
      * This is used to reduce code duplication when testing calling `describe.ignore` with different call signatures.
      */
     async function assertOnly(

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -113,7 +113,7 @@
  * );
  *
  * Deno.test("isSnapshotMatch", async function (t): Promise<void> {
- *   const a = "\x1b[32mThis green text has had it's colours stripped\x1b[39m";
+ *   const a = "\x1b[32mThis green text has had it's colors stripped\x1b[39m";
  *   await assertMonochromeSnapshot(t, a);
  * });
  * ```
@@ -122,7 +122,7 @@
  * // .snaps/example_test.ts.snap
  * export const snapshot = {};
  *
- * snapshot[`isSnapshotMatch 1`] = `This green text has had it's colours stripped`;
+ * snapshot[`isSnapshotMatch 1`] = `This green text has had it's colors stripped`;
  * ```
  *
  * ## Version Control:

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -113,7 +113,7 @@
  * );
  *
  * Deno.test("isSnapshotMatch", async function (t): Promise<void> {
- *   const a = "\x1b[32mThis green text has had it's colors stripped\x1b[39m";
+ *   const a = "\x1b[32mThis green text has had its colors stripped\x1b[39m";
  *   await assertMonochromeSnapshot(t, a);
  * });
  * ```
@@ -122,7 +122,7 @@
  * // .snaps/example_test.ts.snap
  * export const snapshot = {};
  *
- * snapshot[`isSnapshotMatch 1`] = `This green text has had it's colors stripped`;
+ * snapshot[`isSnapshotMatch 1`] = `This green text has had its colors stripped`;
  * ```
  *
  * ## Version Control:

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -785,14 +785,14 @@ Deno.test("createAssertSnapshot()", async (t) => {
   await t.step("no options", async (t) => {
     await assertMonochromeSnapshot(
       t,
-      "\x1b[32mThis green text has had it's colors stripped\x1b[39m",
+      "\x1b[32mThis green text has had its colors stripped\x1b[39m",
     );
   });
 
   await t.step("options object", async (t) => {
     await assertMonochromeSnapshot(
       t,
-      "\x1b[32mThis green text has had it's colors stripped\x1b[39m",
+      "\x1b[32mThis green text has had its colors stripped\x1b[39m",
       {
         name: "createAssertSnapshot() - options object - custom name",
       },
@@ -823,7 +823,7 @@ Deno.test("createAssertSnapshot()", async (t) => {
 
     await assertMonochromeSnapshotComposite(
       t,
-      "\x1b[32mThis green text has had it's colors stripped\x1b[39m",
+      "\x1b[32mThis green text has had its colors stripped\x1b[39m",
     );
   });
 });

--- a/testing/snapshot_test.ts
+++ b/testing/snapshot_test.ts
@@ -785,14 +785,14 @@ Deno.test("createAssertSnapshot()", async (t) => {
   await t.step("no options", async (t) => {
     await assertMonochromeSnapshot(
       t,
-      "\x1b[32mThis green text has had it's colours stripped\x1b[39m",
+      "\x1b[32mThis green text has had it's colors stripped\x1b[39m",
     );
   });
 
   await t.step("options object", async (t) => {
     await assertMonochromeSnapshot(
       t,
-      "\x1b[32mThis green text has had it's colours stripped\x1b[39m",
+      "\x1b[32mThis green text has had it's colors stripped\x1b[39m",
       {
         name: "createAssertSnapshot() - options object - custom name",
       },
@@ -823,7 +823,7 @@ Deno.test("createAssertSnapshot()", async (t) => {
 
     await assertMonochromeSnapshotComposite(
       t,
-      "\x1b[32mThis green text has had it's colours stripped\x1b[39m",
+      "\x1b[32mThis green text has had it's colors stripped\x1b[39m",
     );
   });
 });


### PR DESCRIPTION
* Use the American spelling of colors in docs for consistency with module and option names
* Replace a few incorrect usages of it's