### PR TITLE
fix(http): have `getCookies()` return `Record<string, string | undefined>`

### DIFF
--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -251,10 +251,12 @@ function validateDomain(domain: string) {
  * @param headers The headers instance to get cookies from
  * @return Object with cookie names as keys
  */
-export function getCookies(headers: Headers): Record<string, string> {
+export function getCookies(
+  headers: Headers,
+): Record<string, string | undefined> {
   const cookie = headers.get("Cookie");
   if (cookie !== null) {
-    const out: Record<string, string> = {};
+    const out: Record<string, string | undefined> = {};
     const c = cookie.split(";");
     for (const kv of c) {
       const [cookieKey, ...cookieVal] = kv.split("=");


### PR DESCRIPTION
Make the return type of `getCookies` `Record<string, string | undefined>` so that TypeScript will force you to check that the cookie is actually present before using it.

Note that this is not a breaking code change, but it is a breaking type change, i.e. code that used to type check successfully may not anymore after updating to a version that includes this change.

Fixes #5979