### PR TITLE
deprecation(io/unstable): deprecate `sliceLongToBytes()`

### DIFF
--- a/io/slice_long_to_bytes.ts
+++ b/io/slice_long_to_bytes.ts
@@ -17,7 +17,7 @@
  * @param dest The array to store the sliced bytes
  * @returns The sliced bytes
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated This will be removed in the future.
  */
 export function sliceLongToBytes(
   d: number,


### PR DESCRIPTION
This will be removed without replacement.

Towards #5989