### PR TITLE
feat(http/unstable): add support for multiple request methods on route

### DIFF
--- a/http/unstable_route.ts
+++ b/http/unstable_route.ts
@@ -28,11 +28,11 @@ export interface Route {
    */
   pattern: URLPattern;
   /**
-   * Request method.
+   * Request method. This can be a string or an array of strings.
    *
    * @default {"GET"}
    */
-  method?: string;
+  method?: string | string[];
   /**
    * Request handler.
    */
@@ -61,7 +61,12 @@ export interface Route {
  *   {
  *     pattern: new URLPattern({ pathname: "/static/*" }),
  *     handler: (req: Request) => serveDir(req)
- *   }
+ *   },
+ *   {
+ *     pattern: new URLPattern({ pathname: "/api" }),
+ *     method: ["GET", "HEAD"],
+ *     handler: (req: Request) => new Response(req.method === 'HEAD' ? null : 'ok'),
+ *   },
  * ];
  *
  * function defaultHandler(_req: Request) {
@@ -91,7 +96,12 @@ export function route(
   return (request: Request, info?: Deno.ServeHandlerInfo) => {
     for (const route of routes) {
       const match = route.pattern.exec(request.url);
-      if (match && request.method === (route.method ?? "GET")) {
+      if (
+        match &&
+        (Array.isArray(route.method)
+          ? route.method.includes(request.method)
+          : request.method === (route.method ?? "GET"))
+      ) {
         return route.handler(request, info, match);
       }
     }

--- a/http/unstable_route_test.ts
+++ b/http/unstable_route_test.ts
@@ -18,6 +18,12 @@ const routes: Route[] = [
     method: "POST",
     handler: () => new Response("Done"),
   },
+  {
+    pattern: new URLPattern({ pathname: "/resource" }),
+    method: ["GET", "HEAD"],
+    handler: (request: Request) =>
+      new Response(request.method === "HEAD" ? null : "Ok"),
+  },
 ];
 
 function defaultHandler(request: Request) {
@@ -53,5 +59,19 @@ Deno.test("route()", async (t) => {
     const response = await handler(request);
     assertEquals(response?.status, 404);
     assertEquals(await response?.text(), "/not-found");
+  });
+
+  await t.step("handles multiple methods", async () => {
+    const getMethodRequest = new Request("http://example.com/resource");
+    const getMethodResponse = await handler(getMethodRequest);
+    assertEquals(getMethodResponse?.status, 200);
+    assertEquals(await getMethodResponse?.text(), "Ok");
+
+    const headMethodRequest = new Request("http://example.com/resource", {
+      method: "HEAD",
+    });
+    const headMethodResponse = await handler(headMethodRequest);
+    assertEquals(headMethodResponse?.status, 200);
+    assertEquals(await headMethodResponse?.text(), "");
   });
 });


### PR DESCRIPTION
This is an approach for https://github.com/denoland/std/issues/5993#issuecomment-2355224277.

It allows the `method` option to accept a `string | string[]` value type. It's more convenient for some similar handlers.

Here are some examples:

```ts
const route: Route[] = [
	{
		method: ["GET", "HEAD"],
		pattern: new URLPattern({ pathname: '/status' }),
		handler: (req: Request) => new Response(req.method === 'HEAD' ? null : 'ok'),
	},
]
```

```ts
const route: Route[] = [
	{
		method: ["POST", "UPDATE", "DELETE", ...somethingElse],
		pattern: new URLPattern({ pathname: '/users/:id' }),
		handler: (req: Request) => {
			prepareSomething();
			switch (req.method) {
				case "POST":
					createUser();
					break;
				case "UPDATE":
					updateUser();
					break;
				case "DELETE":
					deleteUser();
					break;
				default:
					runSomethingElse();
					break;
			}
			const result = getConclusion();
			return new Response(result);
		},
	},
]
```

Closes #5993