### PR TITLE
deprecation(io/unstable): deprecate `readInt()`

### DIFF
--- a/io/read_int.ts
+++ b/io/read_int.ts
@@ -21,7 +21,7 @@ import { readShort } from "./read_short.ts";
  * @param buf The buffer reader to read from
  * @returns The 32bit integer
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated This will be removed in 0.226.0.
  */
 export async function readInt(buf: BufReader): Promise<number | null> {
   const high = await readShort(buf);


### PR DESCRIPTION
This will be removed without replacement.

Towards #5989.