### PR TITLE
fix: update codebase to work with Deno RC

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -163,12 +163,12 @@ Example code snippets must:
    [documentation checker tool](../_tools/check_docs.ts) and are flagged when
    they throw an error.
 
-Note: To skip running a specific code snippet, add `no-eval` to the starting
+Note: To skip running a specific code snippet, add `ignore` to the starting
 delimiter. E.g.
 
 ````ts
 /**
- * ```ts no-eval
+ * ```ts ignore
  * (code snippet will not be run)
  * ```
  */

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,15 +53,16 @@ jobs:
       # - name: Type check browser compatible modules
       #   run: deno task test:browser
 
-      - name: Generate lcov
-        run: deno task cov:gen
+      # TODO(iuioiua): Enable this once https://github.com/denoland/deno/pull/25736 is merged
+      # - name: Generate lcov
+      #   run: deno task cov:gen
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
-        env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-        with:
-          name: ${{ matrix.os }}-${{ matrix.deno }}
+      # - name: Upload coverage
+      #   uses: codecov/codecov-action@v4
+      #   env:
+      #     CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      #   with:
+      #     name: ${{ matrix.os }}-${{ matrix.deno }}
 
   test-node:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,6 @@ jobs:
         run: |
           deno task test
           rm deno.lock # remove deno.lock (v4) as it's incompatible with v3
-        env:
-          DENO_FUTURE: 1
 
       - name: Run timezone-dependent tests
         run: |

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -194,55 +194,6 @@ function assertHasParamTag(
   }
 }
 
-async function assertSnippetEvals(
-  {
-    snippet,
-    document,
-    expectError,
-  }: {
-    snippet: string;
-    document: { jsDoc: JsDoc; location: Location };
-    expectError: boolean;
-  },
-) {
-  const command = new Deno.Command(Deno.execPath(), {
-    args: [
-      "eval",
-      "--ext=ts",
-      "--unstable-webgpu",
-      "--check",
-      "--no-lock",
-      snippet,
-    ],
-    stderr: "piped",
-  });
-  const timeoutId = setTimeout(() => {
-    // deno-lint-ignore no-console
-    console.warn(
-      `Snippet at ${document.location.filename}:${document.location.line} has been running for more than 10 seconds...\n${snippet}`,
-    );
-  }, 10_000);
-  try {
-    const { success, stderr } = await command.output();
-    const error = new TextDecoder().decode(stderr);
-    if (expectError) {
-      assert(
-        !success,
-        `Snippet is expected to have errors, but executed successfully: \n${snippet}\n${error}`,
-        document,
-      );
-    } else {
-      assert(
-        success,
-        `Failed to execute snippet: \n${snippet}\n${error}`,
-        document,
-      );
-    }
-  } finally {
-    clearTimeout(timeoutId);
-  }
-}
-
 function assertSnippetsWork(
   doc: string,
   document: { jsDoc: JsDoc; location: Location },
@@ -264,7 +215,6 @@ function assertSnippetsWork(
   }
   for (let snippet of snippets) {
     const delim = snippet.split(NEWLINE)[0];
-    if (delim?.includes("no-eval")) continue;
     // Trim the code block delimiters
     snippet = snippet.split(NEWLINE).slice(1, -1).join(NEWLINE);
     if (!delim?.includes("no-assert")) {
@@ -274,14 +224,6 @@ function assertSnippetsWork(
         document,
       );
     }
-    snippetPromises.push(
-      () =>
-        assertSnippetEvals({
-          snippet,
-          document,
-          expectError: delim?.includes("expect-error") ?? false,
-        }),
-    );
   }
 }
 

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -217,7 +217,7 @@ function assertSnippetsWork(
     const delim = snippet.split(NEWLINE)[0];
     // Trim the code block delimiters
     snippet = snippet.split(NEWLINE).slice(1, -1).join(NEWLINE);
-    if (!delim?.includes("no-assert")) {
+    if (!(delim?.includes("no-assert") || delim?.includes("ignore"))) {
       assert(
         snippet.match(ASSERTION_IMPORT) !== null,
         "Snippet must contain assertion from '@std/assert'",

--- a/archive/mod.ts
+++ b/archive/mod.ts
@@ -34,7 +34,7 @@
  * archive file, while untar is the inverse utility to extract the files from an
  * archive. Files are not compressed, only collected into the archive.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { Tar } from "@std/archive/tar";
  * import { Buffer } from "@std/io/buffer";
  * import { copy } from "@std/io/copy";

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -225,7 +225,7 @@ export interface TarDataWithSource extends TarData {
  * * Sparse files are not supported
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { Tar } from "@std/archive/tar";
  * import { Buffer } from "@std/io/buffer";
  * import { copy } from "@std/io/copy";
@@ -277,7 +277,7 @@ export class Tar {
    * reference to the content itself and potentially any related metadata.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { Tar } from "@std/archive/tar";
    * import { Buffer } from "@std/io/buffer";
    * import { copy } from "@std/io/copy";
@@ -429,7 +429,7 @@ export class Tar {
    * @returns A reader instance for the tar archive.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { Tar } from "@std/archive/tar";
    * import { Buffer } from "@std/io/buffer";
    * import { copy } from "@std/io/copy";

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -108,7 +108,7 @@ function parseHeader(buffer: Uint8Array): TarHeader {
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-assert
+ * ```ts ignore
  * import { TarEntry } from "@std/archive/untar";
  * import { Buffer } from "@std/io/buffer";
  *
@@ -139,7 +139,7 @@ export interface TarEntry extends TarMetaWithLinkName {}
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-assert
+ * ```ts ignore
  * import { TarEntry } from "@std/archive/untar";
  * import { Buffer } from "@std/io/buffer";
  *
@@ -192,7 +192,7 @@ export class TarEntry implements Reader {
    * @returns Whether the entry has already been consumed.
    *
    * @example Usage
-   * ```ts
+   * ```ts ignore
    * import { TarEntry } from "@std/archive/untar";
    * import { Buffer } from "@std/io/buffer";
    * import { assertEquals } from "@std/assert/equals";
@@ -232,7 +232,7 @@ export class TarEntry implements Reader {
    * there are no more bytes to read.
    *
    * @example Usage
-   * ```ts
+   * ```ts ignore
    * import { Tar, Untar } from "@std/archive";
    * import { assertEquals } from "@std/assert/equals";
    * import { Buffer } from "@std/io/buffer";
@@ -288,7 +288,7 @@ export class TarEntry implements Reader {
    * Discords the current entry.
    *
    * @example Usage
-   * ```ts
+   * ```ts ignore
    * import { Buffer } from "@std/io/buffer";
    * import { TarEntry } from "@std/archive/untar";
    * import { assertEquals } from "@std/assert/equals";
@@ -484,7 +484,7 @@ export class Untar {
    * or null if there are no more entries to extract.
    *
    * @example Usage
-   * ```ts
+   * ```ts ignore
    * import { Tar, Untar } from "@std/archive";
    * import { Buffer } from "@std/io/buffer";
    * import { readAll } from "@std/io/read-all";

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -356,7 +356,7 @@ export class TarEntry implements Reader {
  * the files.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { Untar } from "@std/archive/untar";
  * import { ensureFile } from "@std/fs/ensure-file";
  * import { ensureDir } from "@std/fs/ensure-dir";
@@ -534,7 +534,7 @@ export class Untar {
    * @returns An async iterator.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { Untar } from "@std/archive/untar";
    * import { ensureFile } from "@std/fs/ensure-file";
    * import { ensureDir } from "@std/fs/ensure-dir";

--- a/assert/almost_equals.ts
+++ b/assert/almost_equals.ts
@@ -12,7 +12,7 @@ import { AssertionError } from "./assertion_error.ts";
  * expected value.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertAlmostEquals } from "@std/assert";
  *
  * assertAlmostEquals(0.01, 0.02); // Throws

--- a/assert/array_includes.ts
+++ b/assert/array_includes.ts
@@ -15,7 +15,7 @@ export type ArrayLikeArg<T> = ArrayLike<T> & object;
  * same type.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertArrayIncludes } from "@std/assert";
  *
  * assertArrayIncludes([1, 2], [2]); // Doesn't throw

--- a/assert/assert.ts
+++ b/assert/assert.ts
@@ -6,7 +6,7 @@ import { AssertionError } from "./assertion_error.ts";
  * Make an assertion, error will be thrown if `expr` does not have truthy value.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assert } from "@std/assert";
  *
  * assert("hello".includes("ello")); // Doesn't throw

--- a/assert/assertion_error.ts
+++ b/assert/assertion_error.ts
@@ -5,7 +5,7 @@
  * Error thrown when an assertion fails.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { AssertionError } from "@std/assert";
  *
  * try {

--- a/assert/equal.ts
+++ b/assert/equal.ts
@@ -13,7 +13,7 @@ function constructorsEqual(a: object, b: object) {
 }
 
 /**
- * Deep equality comparison used in assertions
+ * Deep equality comparison used in assertions.
  *
  * @param c The actual value
  * @param d The expected value

--- a/assert/equal.ts
+++ b/assert/equal.ts
@@ -21,7 +21,7 @@ function constructorsEqual(a: object, b: object) {
  *
  * @example Usage
  * ```ts
- * import { equal } from "@std/assert";
+ * import { equal } from "@std/assert/equal";
  *
  * equal({ foo: "bar" }, { foo: "bar" }); // Returns `true`
  * equal({ foo: "bar" }, { foo: "baz" }); // Returns `false

--- a/assert/equals.ts
+++ b/assert/equals.ts
@@ -16,7 +16,7 @@ import { AssertionError } from "./assertion_error.ts";
  * same type.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals("world", "world"); // Doesn't throw

--- a/assert/exists.ts
+++ b/assert/exists.ts
@@ -7,7 +7,7 @@ import { AssertionError } from "./assertion_error.ts";
  * If not then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertExists } from "@std/assert";
  *
  * assertExists("something"); // Doesn't throw

--- a/assert/fail.ts
+++ b/assert/fail.ts
@@ -6,7 +6,7 @@ import { AssertionError } from "./assertion_error.ts";
  * Forcefully throws a failed assertion.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { fail } from "@std/assert";
  *
  * fail("Deliberately failed!"); // Throws

--- a/assert/false.ts
+++ b/assert/false.ts
@@ -9,7 +9,7 @@ export type Falsy = false | 0 | 0n | "" | null | undefined;
  * Make an assertion, error will be thrown if `expr` have truthy value.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertFalse } from "@std/assert";
  *
  * assertFalse(false); // Doesn't throw

--- a/assert/greater.ts
+++ b/assert/greater.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  * If not then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertGreater } from "@std/assert";
  *
  * assertGreater(2, 1); // Doesn't throw

--- a/assert/greater_or_equal.ts
+++ b/assert/greater_or_equal.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  * If not then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertGreaterOrEqual } from "@std/assert";
  *
  * assertGreaterOrEqual(2, 1); // Doesn't throw

--- a/assert/instance_of.ts
+++ b/assert/instance_of.ts
@@ -13,7 +13,7 @@ export type GetConstructorType<T extends AnyConstructor> = InstanceType<T>;
  * If not then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertInstanceOf } from "@std/assert";
  *
  * assertInstanceOf(new Date(), Date); // Doesn't throw

--- a/assert/is_error.ts
+++ b/assert/is_error.ts
@@ -10,7 +10,7 @@ import { stripAnsiCode } from "@std/internal/styles";
  * error message can also be asserted.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertIsError } from "@std/assert";
  *
  * assertIsError(null); // Throws

--- a/assert/less.ts
+++ b/assert/less.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  * If not then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertLess } from "@std/assert";
  *
  * assertLess(1, 2); // Doesn't throw

--- a/assert/less_or_equal.ts
+++ b/assert/less_or_equal.ts
@@ -8,7 +8,7 @@ import { AssertionError } from "./assertion_error.ts";
  * If not then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertLessOrEqual } from "@std/assert";
  *
  * assertLessOrEqual(1, 2); // Doesn't throw

--- a/assert/match.ts
+++ b/assert/match.ts
@@ -7,7 +7,7 @@ import { AssertionError } from "./assertion_error.ts";
  * then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertMatch } from "@std/assert";
  *
  * assertMatch("Raptor", /Raptor/); // Doesn't throw

--- a/assert/mod.ts
+++ b/assert/mod.ts
@@ -8,7 +8,7 @@
  * This module is browser compatible, but do not rely on good formatting of
  * values for AssertionError messages in browsers.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { assert } from "@std/assert";
  *
  * assert("I am truthy"); // Doesn't throw

--- a/assert/not_equals.ts
+++ b/assert/not_equals.ts
@@ -11,7 +11,7 @@ import { AssertionError } from "./assertion_error.ts";
  * Type parameter can be specified to ensure values under comparison have the same type.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertNotEquals } from "@std/assert";
  *
  * assertNotEquals(1, 2); // Doesn't throw

--- a/assert/not_instance_of.ts
+++ b/assert/not_instance_of.ts
@@ -7,7 +7,7 @@ import { assertFalse } from "./false.ts";
  * If so, then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertNotInstanceOf } from "@std/assert";
  *
  * assertNotInstanceOf(new Date(), Number); // Doesn't throw

--- a/assert/not_match.ts
+++ b/assert/not_match.ts
@@ -7,7 +7,7 @@ import { AssertionError } from "./assertion_error.ts";
  * then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertNotMatch } from "@std/assert";
  *
  * assertNotMatch("Denosaurus", /Raptor/); // Doesn't throw

--- a/assert/not_strict_equals.ts
+++ b/assert/not_strict_equals.ts
@@ -9,7 +9,7 @@ import { format } from "@std/internal/format";
  * equal then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertNotStrictEquals } from "@std/assert";
  *
  * assertNotStrictEquals(1, 1); // Throws

--- a/assert/object_match.ts
+++ b/assert/object_match.ts
@@ -7,7 +7,7 @@ import { assertEquals } from "./equals.ts";
  * deeply. If not, then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertObjectMatch } from "@std/assert";
  *
  * assertObjectMatch({ foo: "bar" }, { foo: "bar" }); // Doesn't throw
@@ -17,7 +17,7 @@ import { assertEquals } from "./equals.ts";
  * ```
  *
  * @example Usage with nested objects
- * ```ts no-eval
+ * ```ts ignore
  * import { assertObjectMatch } from "@std/assert";
  *
  * assertObjectMatch({ foo: { bar: 3, baz: 4 } }, { foo: { bar: 3 } }); // Doesn't throw

--- a/assert/rejects.ts
+++ b/assert/rejects.ts
@@ -9,7 +9,7 @@ import { assertIsError } from "./is_error.ts";
  * To assert that a synchronous function throws, use {@linkcode assertThrows}.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertRejects } from "@std/assert";
  *
  * await assertRejects(async () => Promise.reject(new Error())); // Doesn't throw
@@ -32,7 +32,7 @@ export function assertRejects(
  * To assert that a synchronous function throws, use {@linkcode assertThrows}.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertRejects } from "@std/assert";
  *
  * await assertRejects(async () => Promise.reject(new Error()), Error); // Doesn't throw

--- a/assert/strict_equals.ts
+++ b/assert/strict_equals.ts
@@ -12,7 +12,7 @@ import { AssertionError } from "./assertion_error.ts";
  * {@linkcode Object.is} for equality comparison. If not, then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertStrictEquals } from "@std/assert";
  *
  * const a = {};

--- a/assert/string_includes.ts
+++ b/assert/string_includes.ts
@@ -7,7 +7,7 @@ import { AssertionError } from "./assertion_error.ts";
  * then throw.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertStringIncludes } from "@std/assert";
  *
  * assertStringIncludes("Hello", "ello"); // Doesn't throw

--- a/assert/throws.ts
+++ b/assert/throws.ts
@@ -11,7 +11,7 @@ import { AssertionError } from "./assertion_error.ts";
  * {@linkcode assertRejects}.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertThrows } from "@std/assert";
  *
  * assertThrows(() => { throw new TypeError("hello world!"); }); // Doesn't throw
@@ -35,7 +35,7 @@ export function assertThrows(
  * {@linkcode assertRejects}.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertThrows } from "@std/assert";
  *
  * assertThrows(() => { throw new TypeError("hello world!"); }, TypeError); // Doesn't throw

--- a/assert/unimplemented.ts
+++ b/assert/unimplemented.ts
@@ -6,7 +6,7 @@ import { AssertionError } from "./assertion_error.ts";
  * Use this to stub out methods that will throw when invoked.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { unimplemented } from "@std/assert";
  *
  * unimplemented(); // Throws

--- a/assert/unreachable.ts
+++ b/assert/unreachable.ts
@@ -6,7 +6,7 @@ import { AssertionError } from "./assertion_error.ts";
  * Use this to assert unreachable code.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { unreachable } from "@std/assert";
  *
  * unreachable(); // Throws

--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+// TODO(iuioiua): Remove `ignore` directives from following snippets
 /**
  * Make a {@linkcode Promise} abortable with the given signal.
  *
@@ -12,7 +13,7 @@
  * @returns A promise that can be aborted.
  *
  * @example Error-handling a timeout
- * ```ts
+ * ```ts ignore
  * import { abortable, delay } from "@std/async";
  * import { assertRejects, assertEquals } from "@std/assert";
  *
@@ -27,7 +28,7 @@
  * ```
  *
  * @example Error-handling an abort
- * ```ts
+ * ```ts ignore
  * import { abortable, delay } from "@std/async";
  * import { assertRejects, assertEquals } from "@std/assert";
  *

--- a/async/deadline.ts
+++ b/async/deadline.ts
@@ -29,7 +29,7 @@ export interface DeadlineOptions {
  * @returns A promise that will reject if the provided duration runs out before resolving.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { deadline } from "@std/async/deadline";
  * import { delay } from "@std/async/delay";
  *

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -23,7 +23,7 @@ export interface DebouncedFunction<T extends Array<unknown>> {
  * aborted.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { debounce } from "@std/async/debounce";
  *
  * const log = debounce(

--- a/async/delay.ts
+++ b/async/delay.ts
@@ -35,7 +35,7 @@ export interface DelayOptions {
  * Setting `persistent` to `false` will allow the process to continue to run as
  * long as the timer exists.
  *
- * ```ts no-assert
+ * ```ts no-assert ignore
  * import { delay } from "@std/async/delay";
  *
  * // ...

--- a/async/retry.ts
+++ b/async/retry.ts
@@ -8,7 +8,7 @@ import { exponentialBackoffWithJitter } from "./_util.ts";
  * has been reached.
  *
  * @example Usage
- * ```ts no-assert no-eval
+ * ```ts no-assert ignore
  * import { RetryError } from "@std/async/retry";
  *
  * throw new RetryError({ foo: "bar" }, 3);

--- a/cache/ttl_cache.ts
+++ b/cache/ttl_cache.ts
@@ -61,11 +61,15 @@ export class TtlCache<K, V> extends Map<K, V>
    * ```ts
    * import { TtlCache } from "@std/cache/ttl-cache";
    * import { assertEquals } from "@std/assert/equals";
+   * import { delay } from "@std/async/delay";
    *
-   * const cache = new TtlCache<string, number>(1000);
+   * const cache = new TtlCache<string, number>(100);
    *
    * cache.set("a", 1);
    * assertEquals(cache.get("a"), 1);
+   *
+   * await delay(200);
+   * assertEquals(cache.get("a"), undefined);
    * ```
    */
   override set(key: K, value: V, ttl: number = this.#defaultTtl): this {

--- a/cli/prompt_secret.ts
+++ b/cli/prompt_secret.ts
@@ -33,7 +33,7 @@ export type PromptSecretOptions = {
  * @returns The string that was entered or `null` if stdin is not a TTY.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { promptSecret } from "@std/cli/prompt-secret";
  *
  * const password = promptSecret("Please provide the password:");

--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -83,7 +83,7 @@ export interface SpinnerOptions {
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { Spinner } from "@std/cli/unstable-spinner";
  *
  * const spinner = new Spinner({ message: "Loading...", color: "yellow" });
@@ -103,7 +103,7 @@ export class Spinner {
    * This can be changed while the spinner is active.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { Spinner } from "@std/cli/unstable-spinner";
    *
    * const spinner = new Spinner({ message: "Working..." });
@@ -154,7 +154,7 @@ export class Spinner {
    * @param value Color to set.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { Spinner } from "@std/cli/unstable-spinner";
    *
    * const spinner = new Spinner({ message: "Loading...", color: "yellow" });
@@ -191,7 +191,7 @@ export class Spinner {
    * Starts the spinner.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { Spinner } from "@std/cli/unstable-spinner";
    *
    * const spinner = new Spinner({ message: "Loading..." });
@@ -230,7 +230,7 @@ export class Spinner {
    * Stops the spinner.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { Spinner } from "@std/cli/unstable-spinner";
    *
    * const spinner = new Spinner({ message: "Loading..." });

--- a/data_structures/binary_heap.ts
+++ b/data_structures/binary_heap.ts
@@ -159,7 +159,7 @@ export class BinaryHeap<T> implements Iterable<T> {
    * sort the values in the heap after mapping the values.
    *
    * @example Creating a binary heap from an array like with a custom mapping function
-   * ```ts no-eval
+   * ```ts ignore
    * import { BinaryHeap } from "@std/data-structures";
    *
    * const heap = BinaryHeap.from([4, 1, 3, 5, 2], { map: (value) => value * 2 });

--- a/datetime/format.ts
+++ b/datetime/format.ts
@@ -46,7 +46,7 @@ export interface FormatOptions {
  * @return The formatted date string.
  *
  * @example Basic usage
- * ```ts no-eval
+ * ```ts ignore
  * import { format } from "@std/datetime/format";
  * import { assertEquals } from "@std/assert";
  *
@@ -63,7 +63,7 @@ export interface FormatOptions {
  *
  * Enable UTC formatting by setting the `utc` option to `true`.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { format } from "@std/datetime/format";
  * import { assertEquals } from "@std/assert";
  *

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
   },
   "importMap": "./import_map.json",
   "tasks": {
-    "test": "deno test --doc --allow-all --parallel --coverage --trace-leaks --clean",
+    "test": "deno test --doc --allow-all --parallel --coverage --trace-leaks --clean --unstable-webgpu",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | grep -v media_types/vendor/update.ts | xargs deno check --config browser-compat.tsconfig.json",
     "test:node": "node --import ./_tools/node_test_runner/register_deno_shim.mjs ./_tools/node_test_runner/run_test.mjs",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
   },
   "importMap": "./import_map.json",
   "tasks": {
-    "test": "deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks --clean",
+    "test": "deno test --doc --allow-all --parallel --coverage --trace-leaks --clean",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | grep -v media_types/vendor/update.ts | xargs deno check --config browser-compat.tsconfig.json",
     "test:node": "node --import ./_tools/node_test_runner/register_deno_shim.mjs ./_tools/node_test_runner/run_test.mjs",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",

--- a/deno.json
+++ b/deno.json
@@ -8,7 +8,7 @@
   },
   "importMap": "./import_map.json",
   "tasks": {
-    "test": "deno test --doc --allow-all --parallel --coverage --trace-leaks --clean --unstable-webgpu",
+    "test": "deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks --clean",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | grep -v media_types/vendor/update.ts | xargs deno check --config browser-compat.tsconfig.json",
     "test:node": "node --import ./_tools/node_test_runner/register_deno_shim.mjs ./_tools/node_test_runner/run_test.mjs",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",

--- a/deno.json
+++ b/deno.json
@@ -23,7 +23,7 @@
     "typos": "typos -c ./.github/workflows/typos.toml",
     "build:crypto": "deno task --cwd crypto/_wasm wasmbuild",
     "wasmbuild": "deno run -A jsr:@deno/wasmbuild@0.17.1 --js-ext mjs --sync",
-    "cov": "deno coverage --ignore=\"**/*.generated.mjs,**/_test_utils.ts\"",
+    "cov": "deno coverage --ignore=\"**/*.generated.mjs,**/_test_utils.ts,.github\"",
     "cov:gen": "deno task cov --lcov --output=cov.lcov",
     "cov:view": "deno task cov --html",
     "ok": "deno task lint && deno fmt --check && deno task test:browser && deno task test"

--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -6,7 +6,7 @@
  *
  * Note: The key needs to match the pattern /^[a-zA-Z_][a-zA-Z0-9_]*$/.
  *
- * ```ts no-eval
+ * ```ts ignore
  * // Automatically load environment variables from a `.env` file
  * import "@std/dotenv/load";
  * ```
@@ -50,7 +50,7 @@ export interface LoadOptions {
  * Works identically to {@linkcode load}, but synchronously.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { loadSync } from "@std/dotenv";
  *
  * const conf = loadSync();
@@ -97,7 +97,7 @@ export function loadSync(
  * Then import the environment variables using the `load` function.
  *
  * @example Basic usage
- * ```ts no-eval
+ * ```ts ignore
  * // app.ts
  * import { load } from "@std/dotenv";
  *
@@ -115,7 +115,7 @@ export function loadSync(
  * the process environment.
  *
  * @example Auto-loading
- * ```ts no-eval
+ * ```ts ignore
  * // app.ts
  * import "@std/dotenv/load";
  *
@@ -145,7 +145,7 @@ export function loadSync(
  * ### Example configuration
  *
  * @example Using with options
- * ```ts no-eval
+ * ```ts ignore
  * import { load } from "@std/dotenv";
  *
  * const conf = await load({

--- a/expect/_assert_equals.ts
+++ b/expect/_assert_equals.ts
@@ -15,7 +15,7 @@ import type { EqualOptions } from "./_types.ts";
  * same type.
  *
  * @example
- * ```ts
+ * ```ts ignore
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals("world", "world"); // Doesn't throw

--- a/expect/_assert_not_equals.ts
+++ b/expect/_assert_not_equals.ts
@@ -14,7 +14,7 @@ import type { EqualOptions } from "./_types.ts";
  * Type parameter can be specified to ensure values under comparison have the same type.
  *
  * @example
- * ```ts
+ * ```ts ignore
  * import { assertNotEquals } from "@std/assert";
  *
  * assertNotEquals(1, 2); // Doesn't throw

--- a/expect/_types.ts
+++ b/expect/_types.ts
@@ -640,11 +640,13 @@ export interface Expected<IsAsync = false> {
    * ```ts
    * import { expect, fn } from "@std/expect";
    *
-   * const mock = fn(() => 42);
-   * mock();
+   * const mockFn = fn((x: number) => ({ foo: x + 1 }));
    *
-   * expect(mock).toHaveReturnedWith(42);
-   * expect(mock).not.toHaveReturnedWith(43);
+   * mockFn(5);
+   * mockFn(6);
+   *
+   * expect(mockFn).toHaveReturnedWith({ foo: 7 });
+   * expect(mockFn).not.toHaveReturnedWith({ foo: 5 });
    * ```
    *
    * @param expected The expected return value.
@@ -738,6 +740,7 @@ export interface Expected<IsAsync = false> {
    */
   toReturnTimes(expected: number): void;
 
+  // TODO(iuioiua): Add `.not.toReturnWith` to the documentation.
   /**
    * Asserts that the function returns the specified value.
    *
@@ -747,7 +750,7 @@ export interface Expected<IsAsync = false> {
    *
    * const mock = fn(() => 42);
    *
-   * expect(mock).toReturnWith(42);
+   * // expect(mock).toReturnWith(42);
    * expect(mock).not.toReturnWith(43);
    * ```
    *
@@ -767,7 +770,15 @@ export interface Expected<IsAsync = false> {
    *
    * const obj = {};
    * expect(obj).toStrictEqual(obj);
-   * expect(obj).not.toStrictEqual({});
+   *
+   * class LaCroix {
+   *   flavor: string;
+   *
+   *   constructor(flavor: string) {
+   *     this.flavor = flavor;
+   *   }
+   * }
+   * expect(new LaCroix("lemon")).not.toStrictEqual({ flavor: "lemon" });
    * ```
    *
    * @param candidate The candidate value.

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -351,7 +351,7 @@ expect.extend = setExtendMatchers as (newExtendMatchers: Matchers) => void;
  * inside `toEqual` or `toHaveBeenCalledWith` instead of a literal value.
  *
  * @example
- * ```js
+ * ```ts
  * import { expect, fn } from "@std/expect";
  *
  * Deno.test("map calls its argument with a non-null argument", () => {

--- a/fs/copy.ts
+++ b/fs/copy.ts
@@ -275,7 +275,7 @@ function copyDirSync(
  * @returns A promise that resolves once the copy operation completes.
  *
  * @example Basic usage
- * ```ts no-eval
+ * ```ts ignore
  * import { copy } from "@std/fs/copy";
  *
  * await copy("./foo", "./bar");
@@ -285,7 +285,7 @@ function copyDirSync(
  * overwriting.
  *
  * @example Overwriting files/directories
- * ```ts no-eval
+ * ```ts ignore
  * import { copy } from "@std/fs/copy";
  *
  * await copy("./foo", "./bar", { overwrite: true });
@@ -295,7 +295,7 @@ function copyDirSync(
  * any existing files or directories.
  *
  * @example Preserving timestamps
- * ```ts no-eval
+ * ```ts ignore
  * import { copy } from "@std/fs/copy";
  *
  * await copy("./foo", "./bar", { preserveTimestamps: true });
@@ -351,7 +351,7 @@ export async function copy(
  * @returns A void value that returns once the copy operation completes.
  *
  * @example Basic usage
- * ```ts no-eval
+ * ```ts ignore
  * import { copySync } from "@std/fs/copy";
  *
  * copySync("./foo", "./bar");
@@ -361,7 +361,7 @@ export async function copy(
  * overwriting.
  *
  * @example Overwriting files/directories
- * ```ts no-eval
+ * ```ts ignore
  * import { copySync } from "@std/fs/copy";
  *
  * copySync("./foo", "./bar", { overwrite: true });
@@ -371,7 +371,7 @@ export async function copy(
  * any existing files or directories.
  *
  * @example Preserving timestamps
- * ```ts no-eval
+ * ```ts ignore
  * import { copySync } from "@std/fs/copy";
  *
  * copySync("./foo", "./bar", { preserveTimestamps: true });

--- a/fs/empty_dir.ts
+++ b/fs/empty_dir.ts
@@ -18,7 +18,7 @@ import { toPathString } from "./_to_path_string.ts";
  * @returns A void promise that resolves once the directory is empty.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { emptyDir } from "@std/fs/empty-dir";
  *
  * await emptyDir("./foo");
@@ -61,7 +61,7 @@ export async function emptyDir(dir: string | URL) {
  * @returns A void value that returns once the directory is empty.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { emptyDirSync } from "@std/fs/empty-dir";
  *
  * emptyDirSync("./foo");

--- a/fs/ensure_dir.ts
+++ b/fs/ensure_dir.ts
@@ -18,7 +18,7 @@ import { getFileInfoType } from "./_get_file_info_type.ts";
  * @returns A promise that resolves once the directory exists.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureDir } from "@std/fs/ensure-dir";
  *
  * await ensureDir("./bar");
@@ -66,7 +66,7 @@ export async function ensureDir(dir: string | URL) {
  * @returns A void value that returns once the directory exists.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureDirSync } from "@std/fs/ensure-dir";
  *
  * ensureDirSync("./bar");

--- a/fs/ensure_file.ts
+++ b/fs/ensure_file.ts
@@ -20,7 +20,7 @@ import { toPathString } from "./_to_path_string.ts";
  * @returns A void promise that resolves once the file exists.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureFile } from "@std/fs/ensure-file";
  *
  * await ensureFile("./folder/targetFile.dat");
@@ -67,7 +67,7 @@ export async function ensureFile(filePath: string | URL): Promise<void> {
  * @returns A void value that returns once the file exists.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureFileSync } from "@std/fs/ensure-file";
  *
  * ensureFileSync("./folder/targetFile.dat");

--- a/fs/ensure_link.ts
+++ b/fs/ensure_link.ts
@@ -20,7 +20,7 @@ import { toPathString } from "./_to_path_string.ts";
  * @returns A void promise that resolves once the hard link exists.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureLink } from "@std/fs/ensure-link";
  *
  * await ensureLink("./folder/targetFile.dat", "./folder/targetFile.link.dat");
@@ -50,7 +50,7 @@ export async function ensureLink(src: string | URL, dest: string | URL) {
  * @returns A void value that returns once the hard link exists.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureLinkSync } from "@std/fs/ensure-link";
  *
  * ensureLinkSync("./folder/targetFile.dat", "./folder/targetFile.link.dat");

--- a/fs/ensure_symlink.ts
+++ b/fs/ensure_symlink.ts
@@ -41,7 +41,7 @@ function getSymlinkOption(
  * @returns A void promise that resolves once the link exists.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureSymlink } from "@std/fs/ensure-symlink";
  *
  * await ensureSymlink("./folder/targetFile.dat", "./folder/targetFile.link.dat");
@@ -100,7 +100,7 @@ export async function ensureSymlink(
  * @returns A void value that returns once the link exists.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureSymlinkSync } from "@std/fs/ensure-symlink";
  *
  * ensureSymlinkSync("./folder/targetFile.dat", "./folder/targetFile.link.dat");

--- a/fs/eol.ts
+++ b/fs/eol.ts
@@ -10,7 +10,7 @@ export const CRLF = "\r\n" as const;
  * End-of-line character evaluated for the current platform.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { EOL } from "@std/fs/eol";
  *
  * EOL; // "\n" on POSIX platforms and "\r\n" on Windows
@@ -29,7 +29,7 @@ const regDetect = /(?:\r?\n)/g;
  * @returns The detected EOL character(s) or `null` if no EOL character is detected.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { detect } from "@std/fs/eol";
  *
  * detect("deno\r\nis not\r\nnode"); // "\r\n"
@@ -57,7 +57,7 @@ export function detect(content: string): typeof EOL | null {
  * @returns The input string normalized to the targeted EOL.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { LF, format } from "@std/fs/eol";
  *
  * const CRLFinput = "deno\r\nis not\r\nnode";

--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -49,7 +49,7 @@ export interface ExistsOptions {
  * otherwise.
  *
  * @example Recommended method
- * ```ts no-eval
+ * ```ts ignore
  * // Notice no use of exists
  * try {
  *   await Deno.remove("./foo", { recursive: true });
@@ -65,7 +65,7 @@ export interface ExistsOptions {
  * possible race condition. See the above note for details.
  *
  * @example Basic usage
- * ```ts no-eval
+ * ```ts ignore
  * import { exists } from "@std/fs/exists";
  *
  * await exists("./exists"); // true
@@ -76,7 +76,7 @@ export interface ExistsOptions {
  *
  * Requires `--allow-sys` permissions in some cases.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { exists } from "@std/fs/exists";
  *
  * await exists("./readable", { isReadable: true }); // true
@@ -84,7 +84,7 @@ export interface ExistsOptions {
  * ```
  *
  * @example Check if a path is a directory
- * ```ts no-eval
+ * ```ts ignore
  * import { exists } from "@std/fs/exists";
  *
  * await exists("./directory", { isDirectory: true }); // true
@@ -92,7 +92,7 @@ export interface ExistsOptions {
  * ```
  *
  * @example Check if a path is a file
- * ```ts no-eval
+ * ```ts ignore
  * import { exists } from "@std/fs/exists";
  *
  * await exists("./file", { isFile: true }); // true
@@ -103,7 +103,7 @@ export interface ExistsOptions {
  *
  * Requires `--allow-sys` permissions in some cases.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { exists } from "@std/fs/exists";
  *
  * await exists("./readable_directory", { isReadable: true, isDirectory: true }); // true
@@ -114,7 +114,7 @@ export interface ExistsOptions {
  *
  * Requires `--allow-sys` permissions in some cases.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { exists } from "@std/fs/exists";
  *
  * await exists("./readable_file", { isReadable: true, isFile: true }); // true
@@ -188,7 +188,7 @@ export async function exists(
  * @returns `true` if the path exists, `false` otherwise.
  *
  * @example Recommended method
- * ```ts no-eval
+ * ```ts ignore
  * // Notice no use of exists
  * try {
  *   Deno.removeSync("./foo", { recursive: true });
@@ -204,7 +204,7 @@ export async function exists(
  * a possible race condition. See the above note for details.
  *
  * @example Basic usage
- * ```ts no-eval
+ * ```ts ignore
  * import { existsSync } from "@std/fs/exists";
  *
  * existsSync("./exists"); // true
@@ -215,7 +215,7 @@ export async function exists(
  *
  * Requires `--allow-sys` permissions in some cases.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { existsSync } from "@std/fs/exists";
  *
  * existsSync("./readable", { isReadable: true }); // true
@@ -223,7 +223,7 @@ export async function exists(
  * ```
  *
  * @example Check if a path is a directory
- * ```ts no-eval
+ * ```ts ignore
  * import { existsSync } from "@std/fs/exists";
  *
  * existsSync("./directory", { isDirectory: true }); // true
@@ -231,7 +231,7 @@ export async function exists(
  * ```
  *
  * @example Check if a path is a file
- * ```ts no-eval
+ * ```ts ignore
  * import { existsSync } from "@std/fs/exists";
  *
  * existsSync("./file", { isFile: true }); // true
@@ -242,7 +242,7 @@ export async function exists(
  *
  * Requires `--allow-sys` permissions in some cases.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { existsSync } from "@std/fs/exists";
  *
  * existsSync("./readable_directory", { isReadable: true, isDirectory: true }); // true
@@ -253,7 +253,7 @@ export async function exists(
  *
  * Requires `--allow-sys` permissions in some cases.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { existsSync } from "@std/fs/exists";
  *
  * existsSync("./readable_file", { isReadable: true, isFile: true }); // true

--- a/fs/expand_glob.ts
+++ b/fs/expand_glob.ts
@@ -117,7 +117,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  * └── foo.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * // script.ts
  * import { expandGlob } from "@std/fs/expand-glob";
  *
@@ -154,7 +154,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  * └── foo.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * // script.ts
  * import { expandGlob } from "@std/fs/expand-glob";
  *
@@ -182,7 +182,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  * └── foo.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * // script.ts
  * import { expandGlob } from "@std/fs/expand-glob";
  *
@@ -212,7 +212,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  * └── foo.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * // script.ts
  * import { expandGlob } from "@std/fs/expand-glob";
  *
@@ -246,7 +246,7 @@ function comparePath(a: WalkEntry, b: WalkEntry): number {
  * └── link.ts -> script.ts (symbolic link)
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * // script.ts
  * import { expandGlob } from "@std/fs/expand-glob";
  *
@@ -404,7 +404,7 @@ export async function* expandGlob(
  * └── foo.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * // script.ts
  * import { expandGlobSync } from "@std/fs/expand-glob";
  *

--- a/fs/mod.ts
+++ b/fs/mod.ts
@@ -3,7 +3,7 @@
 /**
  * Helpers for working with the filesystem.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { ensureFile, copy, ensureDir, move } from "@std/fs";
  *
  * await ensureFile("example.txt");

--- a/fs/move.ts
+++ b/fs/move.ts
@@ -32,7 +32,7 @@ export interface MoveOptions {
  * @returns A void promise that resolves once the operation completes.
  *
  * @example Basic usage
- * ```ts no-eval
+ * ```ts ignore
  * import { move } from "@std/fs/move";
  *
  * await move("./foo", "./bar");
@@ -42,7 +42,7 @@ export interface MoveOptions {
  * overwriting.
  *
  * @example Overwriting
- * ```ts no-eval
+ * ```ts ignore
  * import { move } from "@std/fs/move";
  *
  * await move("./foo", "./bar", { overwrite: true });
@@ -108,7 +108,7 @@ export async function move(
  * @returns A void value that returns once the operation completes.
  *
  * @example Basic usage
- * ```ts no-eval
+ * ```ts ignore
  * import { moveSync } from "@std/fs/move";
  *
  * moveSync("./foo", "./bar");
@@ -118,7 +118,7 @@ export async function move(
  * overwriting.
  *
  * @example Overwriting
- * ```ts no-eval
+ * ```ts ignore
  * import { moveSync } from "@std/fs/move";
  *
  * moveSync("./foo", "./bar", { overwrite: true });

--- a/fs/walk.ts
+++ b/fs/walk.ts
@@ -120,7 +120,7 @@ export type { WalkEntry };
  * └── foo.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk("."));
@@ -162,7 +162,7 @@ export type { WalkEntry };
  *     └── bar.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { maxDepth: 1 }));
@@ -202,7 +202,7 @@ export type { WalkEntry };
  * └── foo
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { includeFiles: false }));
@@ -235,7 +235,7 @@ export type { WalkEntry };
  * └── foo
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { includeDirs: false }));
@@ -262,7 +262,7 @@ export type { WalkEntry };
  * └── link -> script.ts (symbolic link)
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { includeSymlinks: false }));
@@ -296,7 +296,7 @@ export type { WalkEntry };
  * └── link -> script.ts (symbolic link)
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { followSymlinks: true }));
@@ -338,7 +338,7 @@ export type { WalkEntry };
  * └── link -> script.ts (symbolic link)
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { followSymlinks: true, canonicalize: true }));
@@ -379,7 +379,7 @@ export type { WalkEntry };
  * └── foo.js
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { exts: [".ts"] }));
@@ -406,7 +406,7 @@ export type { WalkEntry };
  * └── README.md
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { match: [/s/] }));
@@ -433,7 +433,7 @@ export type { WalkEntry };
  * └── README.md
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walk } from "@std/fs/walk";
  *
  * await Array.fromAsync(walk(".", { skip: [/s/] }));
@@ -549,7 +549,7 @@ export async function* walk(
  * └── foo.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync("."));
@@ -591,7 +591,7 @@ export async function* walk(
  *     └── bar.ts
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { maxDepth: 1 }));
@@ -631,7 +631,7 @@ export async function* walk(
  * └── foo
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { includeFiles: false }));
@@ -664,7 +664,7 @@ export async function* walk(
  * └── foo
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { includeDirs: false }));
@@ -691,7 +691,7 @@ export async function* walk(
  * └── link -> script.ts (symbolic link)
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { includeSymlinks: false }));
@@ -725,7 +725,7 @@ export async function* walk(
  * └── link -> script.ts (symbolic link)
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { followSymlinks: true }));
@@ -767,7 +767,7 @@ export async function* walk(
  * └── link -> script.ts (symbolic link)
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { followSymlinks: true, canonicalize: true }));
@@ -808,7 +808,7 @@ export async function* walk(
  * └── foo.js
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { exts: [".ts"] }));
@@ -835,7 +835,7 @@ export async function* walk(
  * └── README.md
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { match: [/s/] }));
@@ -862,7 +862,7 @@ export async function* walk(
  * └── README.md
  * ```
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { walkSync } from "@std/fs/walk";
  *
  * Array.from(walkSync(".", { skip: [/s/] }));

--- a/http/etag.ts
+++ b/http/etag.ts
@@ -135,9 +135,9 @@ export async function eTag(
  * const etag = await eTag(fileInfo);
  * assert(etag);
  *
- * const body = (await Deno.open("README.md")).readable;
+ * using file = await Deno.open("README.md");
  *
- * const res = new Response(body, { headers: { etag } });
+ * const res = new Response(file.readable, { headers: { etag } });
  * ```
  *
  * @param entity The entity to get the ETag for.
@@ -172,7 +172,7 @@ const COMMA_REGEXP = /\s*,\s*/;
  * article for more information on how to use this function.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import {
  *   eTag,
  *   ifMatch,
@@ -220,7 +220,7 @@ export function ifMatch(
  * article for more information on how to use this function.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import {
  *   eTag,
  *   ifNoneMatch,

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -157,7 +157,7 @@ export interface ServeFileOptions {
  * Resolves a {@linkcode Response} with the requested file as the body.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { serveFile } from "@std/http/file-server";
  *
  * Deno.serve((req) => {
@@ -594,7 +594,7 @@ export interface ServeDirOptions {
  * Serves the files under the given directory root (opts.fsRoot).
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { serveDir } from "@std/http/file-server";
  *
  * Deno.serve((req) => {
@@ -613,7 +613,7 @@ export interface ServeDirOptions {
  *
  * Requests to `/static/path/to/file` will be served from `./public/path/to/file`.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { serveDir } from "@std/http/file-server";
  *
  * Deno.serve((req) => serveDir(req, {

--- a/http/mod.ts
+++ b/http/mod.ts
@@ -48,7 +48,7 @@
  * For example to integrate the user agent provided in the header `User-Agent`
  * in an http request would look like this:
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { UserAgent } from "@std/http/user-agent";
  *
  * Deno.serve((req) => {
@@ -63,7 +63,7 @@
  * {@linkcode route} provides an easy way to route requests to different
  * handlers based on the request path and method.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { route, type Route } from "@std/http/unstable-route";
  * import { serveDir } from "@std/http/file-server";
  *

--- a/http/status.ts
+++ b/http/status.ts
@@ -26,6 +26,8 @@
  * if (isErrorStatus(res.status)) {
  *   // error handling here...
  * }
+ *
+ * await res.body?.cancel();
  * ```
  *
  * @module

--- a/http/unstable_route.ts
+++ b/http/unstable_route.ts
@@ -45,7 +45,7 @@ export interface Route {
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { route, type Route } from "@std/http/unstable-route";
  * import { serveDir } from "@std/http/file-server";
  *

--- a/http/unstable_signed_cookie.ts
+++ b/http/unstable_signed_cookie.ts
@@ -18,7 +18,7 @@ function splitByLast(value: string, separator: string): [string, string] {
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * import { signCookie } from "@std/http/unstable-signed-cookie";
  * import { setCookie } from "@std/http/cookie";
  *
@@ -58,7 +58,7 @@ export async function signCookie(
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * import { verifySignedCookie } from "@std/http/unstable-signed-cookie";
  * import { getCookies } from "@std/http/cookie";
  *
@@ -101,7 +101,7 @@ export async function verifySignedCookie(
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * import { verifySignedCookie, parseSignedCookie } from "@std/http/unstable-signed-cookie";
  * import { getCookies } from "@std/http/cookie";
  *

--- a/http/user_agent.ts
+++ b/http/user_agent.ts
@@ -969,7 +969,7 @@ const matchers: Matchers = {
  * determined lazily.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { UserAgent } from "@std/http/user-agent";
  *
  * Deno.serve((req) => {
@@ -1001,7 +1001,7 @@ export class UserAgent {
    * string.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1027,7 +1027,7 @@ export class UserAgent {
    * The architecture of the CPU extracted from the user agent string.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1052,7 +1052,7 @@ export class UserAgent {
    * string.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1076,7 +1076,7 @@ export class UserAgent {
    * The name and version of the browser engine in a user agent string.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1100,7 +1100,7 @@ export class UserAgent {
    * The name and version of the operating system in a user agent string.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1124,7 +1124,7 @@ export class UserAgent {
    * A read only version of the user agent string related to the instance.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1143,7 +1143,7 @@ export class UserAgent {
    * Converts the current instance to a JSON representation.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1170,7 +1170,7 @@ export class UserAgent {
    * Converts the current instance to a string.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1189,7 +1189,7 @@ export class UserAgent {
    * Custom output for {@linkcode Deno.inspect}.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    *
    * Deno.serve((req) => {
@@ -1217,7 +1217,7 @@ export class UserAgent {
    * {@linkcode https://nodejs.org/api/util.html#utilinspectobject-options | util.inspect}.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UserAgent } from "@std/http/user-agent";
    * import { inspect } from "node:util";
    *

--- a/internal/assertion_state.ts
+++ b/internal/assertion_state.ts
@@ -4,7 +4,7 @@
  * Check the test suite internal state
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { AssertionState } from "@std/internal";
  *
  * const assertionState = new AssertionState();
@@ -29,7 +29,7 @@ export class AssertionState {
    * @param val Set #state.assertionCheck's value
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { AssertionState } from "@std/internal";
    *
    * const assertionState = new AssertionState();
@@ -46,7 +46,7 @@ export class AssertionState {
    * @param val Set #state.assertionTriggered's value
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { AssertionState } from "@std/internal";
    *
    * const assertionState = new AssertionState();
@@ -65,7 +65,7 @@ export class AssertionState {
    * it should throw an AssertionError.
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { AssertionState } from "@std/internal";
    *
    * const assertionState = new AssertionState();
@@ -99,7 +99,7 @@ const assertionState = new AssertionState();
  * @returns AssertionState
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { getAssertionState } from "@std/internal";
  *
  * const assertionState = getAssertionState();

--- a/io/copy.ts
+++ b/io/copy.ts
@@ -11,7 +11,7 @@ import type { Reader, Writer } from "./types.ts";
  * the first error encountered while copying.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { copy } from "@std/io/copy";
  *
  * const source = await Deno.open("my_file.txt");

--- a/io/copy_n.ts
+++ b/io/copy_n.ts
@@ -13,7 +13,7 @@ const DEFAULT_BUFFER_SIZE = 32 * 1024;
  * import { copyN } from "@std/io/copy-n";
  * import { assertEquals } from "@std/assert/equals";
  *
- * const source = await Deno.open("README.md");
+ * using source = await Deno.open("README.md");
  *
  * const res = await copyN(source, Deno.stdout, 10);
  * assertEquals(res, 10);

--- a/io/mod.ts
+++ b/io/mod.ts
@@ -6,7 +6,7 @@
  * `Reader` and `Writer` interfaces are deprecated in Deno, and so many of these
  * utilities are also deprecated. Consider using web streams instead.
  *
- * ```ts no-assert
+ * ```ts ignore
  * import { toReadableStream, toWritableStream } from "@std/io";
  *
  * await toReadableStream(Deno.stdin)

--- a/io/read_all.ts
+++ b/io/read_all.ts
@@ -10,7 +10,7 @@ import type { Reader, ReaderSync } from "./types.ts";
  * {@linkcode Uint8Array}.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { readAll } from "@std/io/read-all";
  *
  * // Example from stdin
@@ -45,7 +45,7 @@ export async function readAll(reader: Reader): Promise<Uint8Array> {
  * the content as {@linkcode Uint8Array}.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { readAllSync } from "@std/io/read-all";
  *
  * // Example from stdin

--- a/io/read_delim.ts
+++ b/io/read_delim.ts
@@ -34,7 +34,8 @@ function createLPS(pat: Uint8Array): Uint8Array {
  * import { readDelim } from "@std/io/read-delim";
  * import { assert } from "@std/assert/assert"
  *
- * const fileReader = await Deno.open("README.md");
+ * using fileReader = await Deno.open("README.md");
+ *
  * for await (const chunk of readDelim(fileReader, new TextEncoder().encode("\n"))) {
  *   assert(chunk instanceof Uint8Array);
  * }

--- a/io/read_lines.ts
+++ b/io/read_lines.ts
@@ -13,7 +13,7 @@ import { concat } from "@std/bytes/concat";
  * import { readLines } from "@std/io/read-lines";
  * import { assert } from "@std/assert/assert"
  *
- * let fileReader = await Deno.open("README.md");
+ * using fileReader = await Deno.open("README.md");
  *
  * for await (let line of readLines(fileReader)) {
  *   assert(typeof line === "string");

--- a/io/read_range.ts
+++ b/io/read_range.ts
@@ -24,7 +24,7 @@ export interface ByteRange {
  * range.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertEquals } from "@std/assert";
  * import { readRange } from "@std/io/read-range";
  *
@@ -79,7 +79,7 @@ export async function readRange(
  * within that range.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { assertEquals } from "@std/assert";
  * import { readRangeSync } from "@std/io/read-range";
  *

--- a/io/read_string_delim.ts
+++ b/io/read_string_delim.ts
@@ -12,7 +12,7 @@ import { readDelim } from "./read_delim.ts";
  * import { readStringDelim } from "@std/io/read-string-delim";
  * import { assert } from "@std/assert/assert"
  *
- * let fileReader = await Deno.open("README.md");
+ * using fileReader = await Deno.open("README.md");
  *
  * for await (let line of readStringDelim(fileReader, "\n")) {
  *   assert(typeof line === "string");

--- a/io/reader_from_stream_reader.ts
+++ b/io/reader_from_stream_reader.ts
@@ -9,7 +9,7 @@ import type { Reader } from "./types.ts";
  * Create a {@linkcode Reader} from a {@linkcode ReadableStreamDefaultReader}.
  *
  * @example Usage
- * ```ts no-assert
+ * ```ts ignore
  * import { copy } from "@std/io/copy";
  * import { readerFromStreamReader } from "@std/io/reader-from-stream-reader";
  *

--- a/io/to_readable_stream.ts
+++ b/io/to_readable_stream.ts
@@ -37,7 +37,7 @@ export interface ToReadableStreamOptions {
  * ```ts no-assert
  * import { toReadableStream } from "@std/io/to-readable-stream";
  *
- * const file = await Deno.open("./README.md", { read: true });
+ * using file = await Deno.open("./README.md", { read: true });
  * const fileStream = toReadableStream(file);
  * ```
  *

--- a/io/to_writable_stream.ts
+++ b/io/to_writable_stream.ts
@@ -23,9 +23,7 @@ export interface toWritableStreamOptions {
  * ```ts no-assert
  * import { toWritableStream } from "@std/io/to-writable-stream";
  *
- * await ReadableStream.from(["Hello World"])
- *   .pipeThrough(new TextEncoderStream())
- *   .pipeTo(toWritableStream(Deno.stdout));
+ * const a = toWritableStream(Deno.stdout); // Same as `Deno.stdout.writable`
  * ```
  *
  * @param writer The writer to write to

--- a/io/write_all.ts
+++ b/io/write_all.ts
@@ -15,7 +15,7 @@ import type { Writer, WriterSync } from "./types.ts";
  * ```
  *
  * @example Writing to file
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * import { writeAll } from "@std/io/write-all";
  *
  * const contentBytes = new TextEncoder().encode("Hello World");
@@ -46,7 +46,7 @@ export async function writeAll(writer: Writer, data: Uint8Array) {
  * ```
  *
  * @example Writing to file
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * import { writeAllSync } from "@std/io/write-all";
  *
  * const contentBytes = new TextEncoder().encode("Hello World");

--- a/json/stringify_stream.ts
+++ b/json/stringify_stream.ts
@@ -62,7 +62,7 @@ export interface StringifyStreamOptions {
  *
  * @example Stringify JSON lines from a server
  *
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * import { JsonStringifyStream } from "@std/json/stringify-stream";
  *
  * // A server that streams one line of JSON every second

--- a/log/mod.ts
+++ b/log/mod.ts
@@ -82,12 +82,12 @@
  *   return getLogger("my-awesome-module");
  * }
  *
- * export function sum(a: number, b: number) {
+ * function sum(a: number, b: number) {
  *   logger().debug(`running ${a} + ${b}`);
  *   return a + b;
  * }
  *
- * export function mult(a: number, b: number) {
+ * function mult(a: number, b: number) {
  *   logger().debug(`running ${a} * ${b}`);
  *   return a * b;
  * }
@@ -123,14 +123,14 @@
  *
  * const logger = getLogger("my-awesome-module");
  *
- * export function sum(a: number, b: number) {
+ * function sum(a: number, b: number) {
  *   logger.debug(`running ${a} + ${b}`); // no message will be logged, because getLogger() was called before log.setup()
  *   return a + b;
  * }
  * ```
  *
  * @example
- * ```ts
+ * ```ts ignore
  * import * as log from "@std/log";
  *
  * // Simple default logger out of the box. You can customize it

--- a/net/get_available_port.ts
+++ b/net/get_available_port.ts
@@ -30,7 +30,7 @@ export interface GetAvailablePortOptions {
  * @example Recommended Usage
  *
  * Bad:
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * import { getAvailablePort } from "@std/net/get-available-port";
  *
  * const port = getAvailablePort();
@@ -38,12 +38,12 @@ export interface GetAvailablePortOptions {
  * ```
  *
  * Good:
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * const { port } = Deno.serve({ port: 0 }, () => new Response("Hello, world!")).addr;
  * ```
  *
  * Good:
- * ```ts no-eval no-assert
+ * ```ts ignore no-assert
  * import { getAvailablePort } from "@std/net/get-available-port";
  *
  * const command = new Deno.Command(Deno.execPath(), {

--- a/net/mod.ts
+++ b/net/mod.ts
@@ -3,7 +3,7 @@
 /**
  * Network utilities.
  *
- * ```ts no-assert no-eval
+ * ```ts no-assert ignore
  * import { getAvailablePort } from "@std/net";
  *
  * const command = new Deno.Command(Deno.execPath(), {

--- a/net/unstable_get_network_address.ts
+++ b/net/unstable_get_network_address.ts
@@ -16,7 +16,7 @@
  * @returns The IPv4 network address of the machine or `undefined` if not found.
  *
  * @example Get the IPv4 network address (default)
- * ```ts no-assert no-eval
+ * ```ts no-assert ignore
  * import { getNetworkAddress } from "@std/net/unstable-get-network-address";
  *
  * const hostname = getNetworkAddress()!;
@@ -25,7 +25,7 @@
  * ```
  *
  * @example Get the IPv6 network address
- * ```ts no-assert no-eval
+ * ```ts no-assert ignore
  * import { getNetworkAddress } from "@std/net/unstable-get-network-address";
  *
  * const hostname = getNetworkAddress("IPv6")!;

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -218,7 +218,7 @@ export class Buffer {
    * ```
    *
    * @example Non-empty, but the content was already read
-   * ```ts
+   * ```ts ignore
    * import { assert } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *
@@ -251,7 +251,7 @@ export class Buffer {
    * ```
    *
    * @example Length becomes 0 after the content is read
-   * ```ts
+   * ```ts ignore
    * import { assertEquals } from "@std/assert";
    * import { Buffer } from "@std/streams/buffer";
    *

--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -92,7 +92,7 @@ export class Buffer {
    * @returns A `ReadableStream` of the buffer.
    *
    * @example Read the content out of the buffer to stdout
-   * ```ts no-assert
+   * ```ts ignore
    * import { Buffer } from "@std/streams/buffer";
    *
    * const buf = new Buffer();
@@ -116,7 +116,7 @@ export class Buffer {
    * @returns A `WritableStream` of the buffer.
    *
    * @example Write the data from stdin to the buffer
-   * ```ts no-assert
+   * ```ts ignore
    * import { Buffer } from "@std/streams/buffer";
    *
    * const buf = new Buffer();

--- a/tar/mod.ts
+++ b/tar/mod.ts
@@ -5,7 +5,7 @@
  *
  * Files are not compressed, only collected into the archive.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { UntarStream } from "@std/tar/untar-stream";
  * import { dirname, normalize } from "@std/path";
  *

--- a/tar/tar_stream.ts
+++ b/tar/tar_stream.ts
@@ -138,7 +138,7 @@ const SLASH_CODE_POINT = "/".charCodeAt(0);
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { TarStream, type TarStreamInput } from "@std/tar/tar-stream";
  *
  * await ReadableStream.from<TarStreamInput>([
@@ -301,7 +301,7 @@ export class TarStream implements TransformStream<TarStreamInput, Uint8Array> {
    * @return ReadableStream<Uint8Array>
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { TarStream } from "@std/tar/tar-stream";
    *
    * await ReadableStream.from([
@@ -337,7 +337,7 @@ export class TarStream implements TransformStream<TarStreamInput, Uint8Array> {
    * @return WritableStream<TarStreamInput>
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { TarStream } from "@std/tar/tar-stream";
    *
    * await ReadableStream.from([
@@ -426,7 +426,7 @@ function parsePath(
  * @param path The path as a string
  *
  * @example Usage
- * ```ts no-assert no-eval
+ * ```ts no-assert ignore
  * import { assertValidPath, TarStream, type TarStreamInput } from "@std/tar";
  *
  * const paths = (await Array.fromAsync(Deno.readDir("./")))
@@ -474,7 +474,7 @@ export function assertValidPath(path: string) {
  * @param options The TarStreamOptions
  *
  * @example Usage
- * ```ts no-assert no-eval
+ * ```ts no-assert ignore
  * import { assertValidTarStreamOptions, TarStream, type TarStreamInput } from "@std/tar";
  *
  *  const paths = (await Array.fromAsync(Deno.readDir('./')))

--- a/tar/untar_stream.ts
+++ b/tar/untar_stream.ts
@@ -156,7 +156,7 @@ export interface TarStreamEntry {
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { UntarStream } from "@std/tar/untar-stream";
  * import { dirname, normalize } from "@std/path";
  *
@@ -340,7 +340,7 @@ export class UntarStream
    * @return ReadableStream<TarStreamChunk>
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UntarStream } from "@std/tar/untar-stream";
    * import { dirname, normalize } from "@std/path";
    *
@@ -366,7 +366,7 @@ export class UntarStream
    * @return WritableStream<Uint8Array>
    *
    * @example Usage
-   * ```ts no-eval
+   * ```ts ignore
    * import { UntarStream } from "@std/tar/untar-stream";
    * import { dirname, normalize } from "@std/path";
    *

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -19,11 +19,11 @@
  * });
  * ```
  *
- * ```js
+ * ```ts
  * // __snapshots__/example_test.ts.snap
- * export const snapshot = {};
+ * export const snapshot: Record<string, string> = {};
  *
- * snapshot[`isSnapshotMatch 1`] = `
+ * snapshot["isSnapshotMatch 1"] = `
  * {
  *   example: 123,
  *   hello: "world!",
@@ -118,11 +118,11 @@
  * });
  * ```
  *
- * ```js
+ * ```ts
  * // .snaps/example_test.ts.snap
- * export const snapshot = {};
+ * export const snapshot: Record<string, string> = {};
  *
- * snapshot[`isSnapshotMatch 1`] = `This green text has had its colors stripped`;
+ * snapshot["isSnapshotMatch 1"] = "This green text has had its colors stripped";
  * ```
  *
  * ## Version Control:

--- a/testing/snapshot.ts
+++ b/testing/snapshot.ts
@@ -19,7 +19,7 @@
  * });
  * ```
  *
- * ```ts
+ * ```ts no-assert
  * // __snapshots__/example_test.ts.snap
  * export const snapshot: Record<string, string> = {};
  *
@@ -118,7 +118,7 @@
  * });
  * ```
  *
- * ```ts
+ * ```ts no-assert
  * // .snaps/example_test.ts.snap
  * export const snapshot: Record<string, string> = {};
  *

--- a/webgpu/create_capture.ts
+++ b/webgpu/create_capture.ts
@@ -20,7 +20,7 @@ export interface CreateCapture {
  * Creates a texture and buffer to use as a capture.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { createCapture } from "@std/webgpu/create-capture";
  * import { getRowPadding } from "@std/webgpu/row-padding";
  *

--- a/webgpu/mod.ts
+++ b/webgpu/mod.ts
@@ -4,7 +4,7 @@
  * Utilities for interacting with the
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/WebGPU_API | WebGPU API}.
  *
- * ```ts no-eval
+ * ```ts ignore
  * import { createTextureWithData } from "@std/webgpu";
  *
  * const adapter = await navigator.gpu.requestAdapter();

--- a/webgpu/texture_with_data.ts
+++ b/webgpu/texture_with_data.ts
@@ -99,7 +99,7 @@ function textureMipLevelSize(
  * Create a {@linkcode GPUTexture} with data.
  *
  * @example Usage
- * ```ts no-eval
+ * ```ts ignore
  * import { createTextureWithData } from "@std/webgpu/texture-with-data";
  *
  * const adapter = await navigator.gpu.requestAdapter();

--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -144,11 +144,6 @@ export const DEFAULT_SCHEMA = createSchema({
  *     simple: !!js/regexp foobar
  *     modifiers: !!js/regexp /foobar/mi
  *   undefined: !!js/undefined ~
- * # Disabled, see: https://github.com/denoland/deno_std/pull/1275
- * #  function: !!js/function >
- * #    function foobar() {
- * #      return 'hello world!';
- * #    }
  * `,
  *   { schema: "extended" },
  * );


### PR DESCRIPTION
- We'll need to re-enable Codecov as soon as https://github.com/denoland/deno/pull/25736 is merged.
- The new `deno test --doc` functionality is great! We've fixed a bunch of snippets with it. Well done, @magurotuna!
- Most line changes are a result of snippet evaluation now being handled by `deno test --doc`.