### PR TITLE
deprecation(io/unstable): deprecate `MultiReader`

### DIFF
--- a/io/multi_reader.ts
+++ b/io/multi_reader.ts
@@ -24,7 +24,7 @@ import type { Reader } from "./types.ts";
  *
  * @deprecated Use
  * {@linkcode https://jsr.io/@std/streams/doc/merge-readable-streams/~/mergeReadableStreams | mergeReadableStreams}
- * on readable streams instead. This will be removed in 0.226.0.
+ * on readable streams instead. This will be removed in 0.225.0.
  */
 export class MultiReader implements Reader {
   readonly #readers: Reader[];

--- a/io/multi_reader.ts
+++ b/io/multi_reader.ts
@@ -22,7 +22,9 @@ import type { Reader } from "./types.ts";
  * assertEquals(new TextDecoder().decode(res), "helloworld");
  * ```
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Use
+ * {@linkcode https://jsr.io/@std/streams/doc/merge-readable-streams/~/mergeReadableStreams | mergeReadableStreams}
+ * on readable streams instead. This will be removed in 0.226.0.
  */
 export class MultiReader implements Reader {
   readonly #readers: Reader[];


### PR DESCRIPTION
Towards #5989