### PR TITLE
deprecation(io/unstable): deprecate `LimitedReader`

### DIFF
--- a/io/limited_reader.ts
+++ b/io/limited_reader.ts
@@ -23,7 +23,9 @@ import type { Reader } from "./types.ts";
  * assertEquals(new TextDecoder().decode(res), "hello");
  * ```
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Pipe the readable through a
+ * {@linkcode https://jsr.io/@std/streams/doc/limited-bytes-transform-stream/~/LimitedBytesTransformStream | LimitedBytesTransformStream}
+ * instead. This will be removed in 0.226.0.
  */
 export class LimitedReader implements Reader {
   /**


### PR DESCRIPTION
Towards #5989