### PR TITLE
deprecation(io/unstable): deprecate `StringWriter`

### DIFF
--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -28,7 +28,9 @@ const decoder = new TextDecoder();
  * assertEquals(w.toString(), "base0123456789");
  * ```
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Write to a
+ * {@linkcode https://jsr.io/@std/streams/doc/buffer/~/Buffer | Buffer}'s
+ * `writable` property instead. This will be removed in 0.226.0.
  */
 export class StringWriter implements Writer, WriterSync {
   #chunks: Uint8Array[] = [];

--- a/io/string_writer.ts
+++ b/io/string_writer.ts
@@ -30,7 +30,7 @@ const decoder = new TextDecoder();
  *
  * @deprecated Write to a
  * {@linkcode https://jsr.io/@std/streams/doc/buffer/~/Buffer | Buffer}'s
- * `writable` property instead. This will be removed in 0.226.0.
+ * `writable` property instead. This will be removed in 0.225.0.
  */
 export class StringWriter implements Writer, WriterSync {
   #chunks: Uint8Array[] = [];


### PR DESCRIPTION
Towards #5898