### PR TITLE
deprecation(io/unstable): deprecate `BufReader`

### DIFF
--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -133,7 +133,9 @@ export interface ReadLineResult {
  * assertEquals(decoder.decode(buf), "hello world");
  * ```
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Use
+ * {@linkcode https://jsr.io/@std/streams/doc/buffer/~/Buffer | Buffer} instead.
+ * This will be removed in 0.226.0.
  */
 export class BufReader implements Reader {
   #buf!: Uint8Array;

--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -34,7 +34,7 @@ const LF = "\n".charCodeAt(0);
  *
  * @deprecated Use
  * {@linkcode https://jsr.io/@std/streams/doc/buffer/~/Buffer | Buffer} instead.
- * This will be removed in 0.226.0.
+ * This will be removed in 0.225.0.
  */
 export class BufferFullError extends Error {
   /**

--- a/io/buf_reader.ts
+++ b/io/buf_reader.ts
@@ -32,7 +32,9 @@ const LF = "\n".charCodeAt(0);
  * }
  * ```
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Use
+ * {@linkcode https://jsr.io/@std/streams/doc/buffer/~/Buffer | Buffer} instead.
+ * This will be removed in 0.226.0.
  */
 export class BufferFullError extends Error {
   /**
@@ -75,7 +77,9 @@ export class BufferFullError extends Error {
  *
  * ```
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Use
+ * {@linkcode https://jsr.io/@std/streams/doc/buffer/~/Buffer | Buffer} instead.
+ * This will be removed in 0.226.0.
  */
 export class PartialReadError extends Error {
   /**
@@ -107,7 +111,9 @@ export class PartialReadError extends Error {
 /**
  * Result type returned by of {@linkcode BufReader.readLine}.
  *
- * @deprecated This will be removed in 1.0.0. Use the {@link https://developer.mozilla.org/en-US/docs/Web/API/Streams_API | Web Streams API} instead.
+ * @deprecated Use
+ * {@linkcode https://jsr.io/@std/streams/doc/buffer/~/Buffer | Buffer} instead.
+ * This will be removed in 0.226.0.
  */
 export interface ReadLineResult {
   /** The line read */


### PR DESCRIPTION
Towards #5898