### PR TITLE
docs(archive): update `@std/archive` deprecation notices

### DIFF
--- a/archive/_common.ts
+++ b/archive/_common.ts
@@ -7,7 +7,7 @@ import type { Reader } from "@std/io/types";
  * Base interface for {@linkcode TarMeta}.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -48,7 +48,7 @@ export interface TarInfo {
  * Base interface for {@linkcode TarMetaWithLinkName}.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */

--- a/archive/mod.ts
+++ b/archive/mod.ts
@@ -63,7 +63,7 @@
  * ```
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *

--- a/archive/tar.ts
+++ b/archive/tar.ts
@@ -45,7 +45,7 @@ export type { TarInfo, TarMeta };
  * Options for {@linkcode Tar.append}.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -126,7 +126,7 @@ function formatHeader(data: TarData): Uint8Array {
  * Base interface for {@linkcode TarDataWithSource}.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -180,7 +180,7 @@ export interface TarData {
  * Tar data interface for {@linkcode Tar.data}.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -202,7 +202,7 @@ export interface TarDataWithSource extends TarData {
  * have the '.tar' extension.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * ### Usage
  * The workflow is to create a Tar instance, append files to it, and then write the

--- a/archive/untar.ts
+++ b/archive/untar.ts
@@ -47,7 +47,7 @@ export type { Reader, Seeker };
  * symbolic link values without polluting the world of archive writers.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -60,7 +60,7 @@ export interface TarMetaWithLinkName extends TarMeta {
  * Tar header with raw, unprocessed bytes as values.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
@@ -103,7 +103,7 @@ function parseHeader(buffer: Uint8Array): TarHeader {
  * Tar entry
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
@@ -134,7 +134,7 @@ export interface TarEntry extends TarMetaWithLinkName {}
  * Contains tar header metadata and a reader to the entry's body.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
@@ -338,7 +338,7 @@ export class TarEntry implements Reader {
  * archives typically have the '.tar' extension.
  *
  * @deprecated Use {@linkcode https://jsr.io/@std/tar | @std/tar} instead.
- * `@std/archive` will be removed in the future.
+ * `@std/archive` will be removed after 0.225.4.
  *
  * ### Supported file formats
  * Only the ustar file format is supported.  This is the most common format. The


### PR DESCRIPTION
This is based on the next version of `@std/archive` being 0.225.4.