### PR TITLE
fix(http): use non-locale-sensitive string methods for comparison

### DIFF
--- a/http/_negotiation/encoding.ts
+++ b/http/_negotiation/encoding.ts
@@ -71,7 +71,7 @@ function specify(
     return;
   }
   let s = 0;
-  if (spec.encoding.toLocaleLowerCase() === encoding.toLocaleLowerCase()) {
+  if (spec.encoding.toLowerCase() === encoding.toLowerCase()) {
     s = 1;
   } else if (spec.encoding !== "*") {
     return;

--- a/http/cookie.ts
+++ b/http/cookie.ts
@@ -358,7 +358,7 @@ function parseSetCookie(value: string): Cookie | null {
   };
 
   for (const [key, value] of attrs.slice(1)) {
-    switch (key.toLocaleLowerCase()) {
+    switch (key.toLowerCase()) {
       case "expires":
         cookie.expires = new Date(value);
         break;


### PR DESCRIPTION
Towards https://github.com/denoland/std/issues/6016

Doesn't include a fix for the various `text` functions as it's less obvious there what the correct fix should be (e.g. should a configurable `locale` option be added?)