### PR TITLE
fix(http): make `file-server` work on Deno Deploy

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -65,6 +65,9 @@ interface EntryInfo {
 const ENV_PERM_STATUS =
   Deno.permissions.querySync?.({ name: "env", variable: "DENO_DEPLOYMENT_ID" })
     .state ?? "granted"; // for deno deploy
+const NET_PERM_STATUS =
+  Deno.permissions.querySync?.({ name: "sys", kind: "networkInterfaces" })
+    .state ?? "granted" ; // for deno deploy
 const DENO_DEPLOYMENT_ID = ENV_PERM_STATUS === "granted"
   ? Deno.env.get("DENO_DEPLOYMENT_ID")
   : undefined;
@@ -836,10 +839,7 @@ function main() {
 
   function onListen({ port, hostname }: { port: number; hostname: string }) {
     let networkAddress: string | undefined = undefined;
-    if (
-      Deno.permissions.querySync?.({ name: "sys", kind: "networkInterfaces" })
-        .state ?? "granted" === "granted"
-    ) {
+    if (NET_PERM_STATUS === "granted") {
       networkAddress = getNetworkAddress();
     }
     const protocol = useTls ? "https" : "http";

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -67,7 +67,7 @@ const ENV_PERM_STATUS =
     .state ?? "granted"; // for deno deploy
 const NET_PERM_STATUS =
   Deno.permissions.querySync?.({ name: "sys", kind: "networkInterfaces" })
-    .state ?? "granted" ; // for deno deploy
+    .state ?? "granted"; // for deno deploy
 const DENO_DEPLOYMENT_ID = ENV_PERM_STATUS === "granted"
   ? Deno.env.get("DENO_DEPLOYMENT_ID")
   : undefined;

--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -837,8 +837,8 @@ function main() {
   function onListen({ port, hostname }: { port: number; hostname: string }) {
     let networkAddress: string | undefined = undefined;
     if (
-      Deno.permissions.querySync({ name: "sys", kind: "networkInterfaces" })
-        .state === "granted"
+      Deno.permissions.querySync?.({ name: "sys", kind: "networkInterfaces" })
+        .state ?? "granted" === "granted"
     ) {
       networkAddress = getNetworkAddress();
     }


### PR DESCRIPTION
## Why?

Because `Deno.permissions.querySync` is not a defined function in the deploy environment.

## What?

Conditionally call `Deno.permissions.querySync` and nullish coalesce to “granted” for network access.