### PR TITLE
feat(yaml/unstable): create unstable yaml parse, add support of custom types

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -105,6 +105,7 @@ const ENTRY_POINTS = [
   "../uuid/unstable_v7.ts",
   "../webgpu/mod.ts",
   "../yaml/mod.ts",
+  "../yaml/unstable_parse.ts",
 ] as const;
 
 const TS_SNIPPET = /```ts[\s\S]*?```/g;

--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -92,6 +92,16 @@ function createSchema({ explicitTypes = [], implicitTypes = [], include }: {
   return { implicitTypes, explicitTypes, typeMap };
 }
 
+/** Add an explicit type to the given schema */
+export function addExplicitTypeToSchema(
+  schema: Schema,
+  type: ExplicitType,
+): void {
+  schema.explicitTypes.push(type);
+  schema.typeMap[type.kind].set(type.tag, type);
+  schema.typeMap.fallback.set(type.tag, type);
+}
+
 /**
  * Standard YAML's failsafe schema.
  *

--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -4,6 +4,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // This module is browser compatible.
 
+/** The kind of the type */
 export type KindType = "sequence" | "scalar" | "mapping";
 /**
  * The style variation for `styles` option of {@linkcode stringify}
@@ -17,17 +18,28 @@ export type StyleVariant =
   | "octal"
   | "hexadecimal";
 
+/** The function to represent the value in the given style */
 export type RepresentFn<D> = (data: D, style?: StyleVariant) => string;
 
+/**
+ * A type definition for a YAML type.
+ */
 // deno-lint-ignore no-explicit-any
 export interface Type<K extends KindType, D = any> {
+  /** The tag of the type */
   tag: string;
+  /** The kind of the type. */
   kind: K;
+  /** The predicate to check if the data is of this type */
   predicate?: (data: unknown) => data is D;
+  /** The representation of the value of this type */
   represent?: RepresentFn<D> | Record<string, RepresentFn<D>>;
+  /** The default style to use */
   defaultStyle?: StyleVariant;
+  /** The function to check if the given YAML node is of this type */
   // deno-lint-ignore no-explicit-any
   resolve: (data: any) => boolean;
+  /** The function to create a value of this type from the given YAML text. */
   // deno-lint-ignore no-explicit-any
   construct: (data: any) => D;
 }

--- a/yaml/unstable_parse.ts
+++ b/yaml/unstable_parse.ts
@@ -1,0 +1,143 @@
+// Ported from js-yaml v3.13.1:
+// https://github.com/nodeca/js-yaml/commit/665aadda42349dcae869f12040d9b10ef18d12da
+// Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+import { isEOL } from "./_chars.ts";
+import { LoaderState } from "./_loader_state.ts";
+import {
+  addExplicitTypeToSchema,
+  SCHEMA_MAP,
+  type SchemaType,
+} from "./_schema.ts";
+import type { KindType, RepresentFn, Type } from "./_type.ts";
+
+export type { KindType, RepresentFn, Type };
+
+export type { SchemaType };
+
+/** Options for {@linkcode parse}. */
+export interface ParseOptions {
+  /**
+   * Name of the schema to use.
+   *
+   * @default {"default"}
+   */
+  schema?: SchemaType;
+  /**
+   * If `true`, duplicate keys will overwrite previous values. Otherwise,
+   * duplicate keys will throw a {@linkcode SyntaxError}.
+   *
+   * @default {false}
+   */
+  allowDuplicateKeys?: boolean;
+  /**
+   * If defined, a function to call on warning messages taking an
+   * {@linkcode Error} as its only argument.
+   */
+  onWarning?(error: Error): void;
+  /** The custom types to use */
+  types?: Type<"scalar">[];
+}
+
+function sanitizeInput(input: string) {
+  input = String(input);
+
+  if (input.length > 0) {
+    // Add trailing `\n` if not exists
+    if (!isEOL(input.charCodeAt(input.length - 1))) input += "\n";
+
+    // Strip BOM
+    if (input.charCodeAt(0) === 0xfeff) input = input.slice(1);
+  }
+
+  // Use 0 as string terminator. That significantly simplifies bounds check.
+  input += "\0";
+
+  return input;
+}
+
+/**
+ * Parse and return a YAML string as a parsed YAML document object.
+ *
+ * Note: This does not support functions. Untrusted data is safe to parse.
+ *
+ * @example Usage
+ * ```ts
+ * import { parse } from "@std/yaml/parse";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const data = parse(`
+ * id: 1
+ * name: Alice
+ * `);
+ *
+ * assertEquals(data, { id: 1, name: "Alice" });
+ * ```
+ *
+ * @throws {SyntaxError} Throws error on invalid YAML.
+ * @param content YAML string to parse.
+ * @param options Parsing options.
+ * @returns Parsed document.
+ */
+export function parse(
+  content: string,
+  options: ParseOptions = {},
+): unknown {
+  content = sanitizeInput(content);
+  const schema = SCHEMA_MAP.get(options.schema!)!;
+  if (options.types) {
+    for (const type of options.types) {
+      addExplicitTypeToSchema(schema, type);
+    }
+  }
+  const state = new LoaderState(content, { ...options, schema });
+  const documentGenerator = state.readDocuments();
+  const document = documentGenerator.next().value;
+  if (!documentGenerator.next().done) {
+    throw new SyntaxError(
+      "Found more than 1 document in the stream: expected a single document",
+    );
+  }
+  return document ?? null;
+}
+
+/**
+ * Same as {@linkcode parse}, but understands multi-document YAML sources, and
+ * returns multiple parsed YAML document objects.
+ *
+ * @example Usage
+ * ```ts
+ * import { parseAll } from "@std/yaml/parse";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const data = parseAll(`
+ * ---
+ * id: 1
+ * name: Alice
+ * ---
+ * id: 2
+ * name: Bob
+ * ---
+ * id: 3
+ * name: Eve
+ * `);
+ * assertEquals(data, [ { id: 1, name: "Alice" }, { id: 2, name: "Bob" }, { id: 3, name: "Eve" }]);
+ * ```
+ *
+ * @param content YAML string to parse.
+ * @param options Parsing options.
+ * @returns Array of parsed documents.
+ */
+export function parseAll(content: string, options: ParseOptions = {}): unknown {
+  content = sanitizeInput(content);
+  const schema = SCHEMA_MAP.get(options.schema!)!;
+  if (options.types) {
+    for (const type of options.types) {
+      addExplicitTypeToSchema(schema, type);
+    }
+  }
+  const state = new LoaderState(content, { ...options, schema });
+  return [...state.readDocuments()];
+}

--- a/yaml/unstable_parse.ts
+++ b/yaml/unstable_parse.ts
@@ -11,11 +11,20 @@ import {
   SCHEMA_MAP,
   type SchemaType,
 } from "./_schema.ts";
-import type { KindType, RepresentFn, Type } from "./_type.ts";
+import type { KindType } from "./_type.ts";
 
-export type { KindType, RepresentFn, Type };
+export type { KindType };
 
-export type { SchemaType };
+/** The custom type definition for parsing */
+export type Type = {
+  /** The tag of the type */
+  tag: string;
+  /** The kind of the type. */
+  kind: KindType;
+  /** The function to create a value of this type from the given YAML text. */
+  // deno-lint-ignore no-explicit-any
+  construct: (data: any) => unknown;
+};
 
 /** Options for {@linkcode parse}. */
 export interface ParseOptions {
@@ -38,7 +47,7 @@ export interface ParseOptions {
    */
   onWarning?(error: Error): void;
   /** The custom types to use */
-  types?: Type<"scalar">[];
+  types?: Type[];
 }
 
 function sanitizeInput(input: string) {
@@ -86,10 +95,10 @@ export function parse(
   options: ParseOptions = {},
 ): unknown {
   content = sanitizeInput(content);
-  const schema = SCHEMA_MAP.get(options.schema!)!;
+  const schema = SCHEMA_MAP.get(options.schema!) ?? SCHEMA_MAP.get("default")!;
   if (options.types) {
     for (const type of options.types) {
-      addExplicitTypeToSchema(schema, type);
+      addExplicitTypeToSchema(schema, { ...type, resolve: () => true });
     }
   }
   const state = new LoaderState(content, { ...options, schema });
@@ -132,10 +141,10 @@ export function parse(
  */
 export function parseAll(content: string, options: ParseOptions = {}): unknown {
   content = sanitizeInput(content);
-  const schema = SCHEMA_MAP.get(options.schema!)!;
+  const schema = SCHEMA_MAP.get(options.schema!) ?? SCHEMA_MAP.get("default")!;
   if (options.types) {
     for (const type of options.types) {
-      addExplicitTypeToSchema(schema, type);
+      addExplicitTypeToSchema(schema, { ...type, resolve: () => true });
     }
   }
   const state = new LoaderState(content, { ...options, schema });

--- a/yaml/unstable_parse_test.ts
+++ b/yaml/unstable_parse_test.ts
@@ -1,3 +1,26 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
-// TODO
+import { assertEquals } from "@std/assert/equals";
+import { parse } from "./unstable_parse.ts";
+
+Deno.test("(unstable) parse() supports `types[]` option for customizing types", () => {
+  const yaml = `---
+id: 1
+foo: !foo bar
+`;
+
+  const result = parse(yaml, {
+    types: [{
+      tag: "!foo",
+      kind: "scalar",
+      construct: (data) => {
+        const result: string = data !== null ? data : "";
+        return {
+          value: result,
+          tag: "!foo",
+        };
+      },
+    }],
+  });
+  assertEquals(result, { id: 1, foo: { value: "bar", tag: "!foo" } });
+});

--- a/yaml/unstable_parse_test.ts
+++ b/yaml/unstable_parse_test.ts
@@ -1,0 +1,3 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+// TODO


### PR DESCRIPTION
This PR adds `types` option to unstable `parse` function to support custom type definition.

related #6037 