### PR TITLE
chore: fix heading level in Releases.md

### DIFF
--- a/Releases.md
+++ b/Releases.md
@@ -35,7 +35,7 @@
 - fix(http): make `file-server` work on Deno Deploy (#6033)
 - fix(http): use non-locale-sensitive string methods for comparison (#6029)
 
-### @std/internal 1.0.4 (patch)
+#### @std/internal 1.0.4 (patch)
 
 - chore: bump to internal@1.0.4 (#6020)
 


### PR DESCRIPTION
This line was manually modified during [the release](https://github.com/denoland/std/pull/6043), and this heading level should have been `H4` instead of `H3`