### PR TITLE
docs(http/unstable): add example for multiple request methods on route

### DIFF
--- a/http/mod.ts
+++ b/http/mod.ts
@@ -79,7 +79,12 @@
  *   {
  *     pattern: new URLPattern({ pathname: "/static/*" }),
  *     handler: (req: Request) => serveDir(req)
- *   }
+ *   },
+ *   {
+ *     method: ["GET", "HEAD"],
+ *     pattern: new URLPattern({ pathname: "/api" }),
+ *     handler: (req: Request) => new Response(req.method === 'HEAD' ? null : 'ok'),
+ *   },
  * ];
  *
  * function defaultHandler(_req: Request) {

--- a/http/unstable_route.ts
+++ b/http/unstable_route.ts
@@ -63,8 +63,8 @@ export interface Route {
  *     handler: (req: Request) => serveDir(req)
  *   },
  *   {
- *     pattern: new URLPattern({ pathname: "/api" }),
  *     method: ["GET", "HEAD"],
+ *     pattern: new URLPattern({ pathname: "/api" }),
  *     handler: (req: Request) => new Response(req.method === 'HEAD' ? null : 'ok'),
  *   },
  * ];


### PR DESCRIPTION
This adds an example of the multiple request methods on route definition.