### PR TITLE
fix(tar): `UntarStream` bug

### DIFF
--- a/tar/untar_stream.ts
+++ b/tar/untar_stream.ts
@@ -176,7 +176,9 @@ export class UntarStream
   implements TransformStream<Uint8Array, TarStreamEntry> {
   #readable: ReadableStream<TarStreamEntry>;
   #writable: WritableStream<Uint8Array>;
-  #gen: AsyncGenerator<Uint8Array>;
+  #reader: ReadableStreamDefaultReader<Uint8Array>;
+  #buffer: Uint8Array[] = [];
+  // #gen: AsyncGenerator<Uint8Array>;
   #lock = false;
   constructor() {
     const { readable, writable } = new TransformStream<
@@ -185,43 +187,50 @@ export class UntarStream
     >();
     this.#readable = ReadableStream.from(this.#untar());
     this.#writable = writable;
+    this.#reader = readable.pipeThrough(new FixedChunkStream(512)).getReader();
+  }
 
-    this.#gen = async function* () {
-      const buffer: Uint8Array[] = [];
-      for await (
-        const chunk of readable.pipeThrough(new FixedChunkStream(512))
-      ) {
-        if (chunk.length !== 512) {
-          throw new RangeError(
-            `Cannot extract the tar archive: The tarball chunk has an unexpected number of bytes (${chunk.length})`,
-          );
-        }
+  async #read(): Promise<Uint8Array | undefined> {
+    const { done, value } = await this.#reader.read();
+    if (done) return undefined;
+    if (value.length !== 512) {
+      throw new RangeError(
+        `Cannot extract the tar archive: The tarball chunk has an unexpected number of bytes (${value.length})`,
+      );
+    }
+    this.#buffer.push(value);
+    return this.#buffer.shift();
+  }
 
-        buffer.push(chunk);
-        if (buffer.length > 2) yield buffer.shift()!;
-      }
-      if (buffer.length < 2) {
+  async *#untar(): AsyncGenerator<TarStreamEntry> {
+    for (let i = 0; i < 2; ++i) {
+      const { done, value } = await this.#reader.read();
+      if (done || value.length !== 512) {
         throw new RangeError(
           "Cannot extract the tar archive: The tarball is too small to be valid",
         );
       }
-      if (!buffer.every((value) => value.every((x) => x === 0))) {
-        throw new TypeError(
-          "Cannot extract the tar archive: The tarball has invalid ending",
-        );
-      }
-    }();
-  }
-
-  async *#untar(): AsyncGenerator<TarStreamEntry> {
+      this.#buffer.push(value);
+    }
     const decoder = new TextDecoder();
     while (true) {
       while (this.#lock) {
         await new Promise((resolve) => setTimeout(resolve, 0));
       }
 
-      const { done, value } = await this.#gen.next();
-      if (done) break;
+      // Check for premature ending
+      if (this.#buffer.every((value) => value.every((x) => x === 0))) {
+        await this.#reader.cancel("Tar Stream Finished");
+        return;
+      }
+
+      const value = await this.#read();
+      if (value == undefined) {
+        if (this.#buffer.every((value) => value.every((x) => x === 0))) break;
+        throw new TypeError(
+          "Cannot extract the tar archive: The tarball has invalid ending",
+        );
+      }
 
       // Validate Checksum
       const checksum = parseInt(
@@ -286,8 +295,8 @@ export class UntarStream
 
   async *#genFile(size: number): AsyncGenerator<Uint8Array> {
     for (let i = Math.ceil(size / 512); i > 0; --i) {
-      const { done, value } = await this.#gen.next();
-      if (done) {
+      const value = await this.#read();
+      if (value == undefined) {
         throw new SyntaxError(
           "Cannot extract the tar archive: Unexpected end of Tarball",
         );


### PR DESCRIPTION
Fixes: https://github.com/denoland/wasmbuild/pull/143

This pull request fixes a bug with the `UntarStream` class where it incorrectly assumes the contents of a stream will contain a tar file. This is incorrect as anything after a tar file can be appended and a valid tar decoder should ignore everything after it receives its 1024 bytes of `0b00` when checking for a header.