### PR TITLE
feat(expect): support `expect.objectContaining`

### DIFF
--- a/expect/_asymmetric_matchers.ts
+++ b/expect/_asymmetric_matchers.ts
@@ -1,6 +1,8 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file no-explicit-any
 
+import { equal } from "./_equal.ts";
+
 export abstract class AsymmetricMatcher<T> {
   constructor(
     protected value: T,
@@ -144,4 +146,32 @@ export class StringMatching extends AsymmetricMatcher<RegExp> {
 
 export function stringMatching(pattern: string | RegExp): StringMatching {
   return new StringMatching(pattern);
+}
+
+export class ObjectContaining
+  extends AsymmetricMatcher<Record<string, unknown>> {
+  constructor(obj: Record<string, unknown>) {
+    super(obj);
+  }
+
+  equals(other: Record<string, unknown>): boolean {
+    const keys = Object.keys(this.value);
+
+    for (const key of keys) {
+      if (
+        !Object.prototype.hasOwnProperty.call(other, key) ||
+        !equal(this.value[key], other[key])
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+}
+
+export function objectContaining(
+  obj: Record<string, unknown>,
+): ObjectContaining {
+  return new ObjectContaining(obj);
 }

--- a/expect/_object_containing_test.ts
+++ b/expect/_object_containing_test.ts
@@ -1,0 +1,54 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { Buffer } from "node:buffer";
+import { Buffer as DenoBuffer } from "@std/io/buffer";
+import { expect } from "./expect.ts";
+
+Deno.test("expect.objectContaining()", () => {
+  expect({ bar: "baz" }).toEqual(expect.objectContaining({ bar: "baz" }));
+  expect({ foo: undefined }).toEqual(
+    expect.objectContaining({ foo: undefined }),
+  );
+  expect({ bar: "baz" }).not.toEqual(expect.objectContaining({ foo: "bar" }));
+});
+
+Deno.test("expect.objectContaining() with nested objects", () => {
+  expect({ foo: { bar: "baz" } }).toEqual(
+    expect.objectContaining({ foo: { bar: "baz" } }),
+  );
+  expect({ foo: { bar: "baz" } }).not.toEqual(
+    expect.objectContaining({ foo: { bar: "bar" } }),
+  );
+});
+
+Deno.test("expect.objectContaining() with symbols", () => {
+  const foo = Symbol("foo");
+  const bar = Symbol("bar");
+  expect({ [foo]: { bar: "baz" } }).toEqual(
+    expect.objectContaining({ [foo]: { bar: "baz" } }),
+  );
+  expect({ [foo]: { bar: "baz" } }).not.toEqual(
+    expect.objectContaining({ [bar]: { bar: "baz" } }),
+  );
+});
+
+Deno.test("expect.objectContaining() with nested arrays", () => {
+  expect({ foo: ["bar", "baz"] }).toEqual(
+    expect.objectContaining({ foo: ["bar", "baz"] }),
+  );
+  expect({ foo: ["bar", "baz"] }).not.toEqual(
+    expect.objectContaining({ foo: ["bar", "bar"] }),
+  );
+});
+
+Deno.test("expect.objectContaining() with Node Buffer", () => {
+  expect({ foo: Buffer.from("foo") }).toEqual(
+    expect.objectContaining({ foo: Buffer.from("foo") }),
+  );
+});
+
+Deno.test("expect.objectContaining() with Deno Buffer", () => {
+  expect({ foo: new DenoBuffer([1, 2, 3]) }).toEqual(
+    expect.objectContaining({ foo: new DenoBuffer([1, 2, 3]) }),
+  );
+});

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -509,3 +509,21 @@ expect.stringMatching = asymmetricMatchers.stringMatching as (
  * ```
  */
 expect.hasAssertions = hasAssertions as () => void;
+/**
+ * `expect.objectContaining(object)` matches any received object that recursively matches the expected properties.
+ * That is, the expected object is not a subset of the received object. Therefore, it matches a received object
+ * which contains properties that are not in the expected object.
+ *
+ * @example
+ * ```ts
+ * import { expect } from "@std/expect";
+ *
+ * Deno.test("example", () => {
+ *   expect({ bar: 'baz' }).toEqual(expect.objectContaining({ bar: 'bar'}));
+ *   expect({ bar: 'baz' }).not.toEqual(expect.objectContaining({ foo: 'bar'}));
+ * });
+ * ```
+ */
+expect.objectContaining = asymmetricMatchers.objectContaining as (
+  obj: Record<string, unknown>,
+) => ReturnType<typeof asymmetricMatchers.objectContaining>;


### PR DESCRIPTION
Part of https://github.com/denoland/std/issues/3964, support expect.objectContaining api