### PR TITLE
fix(log): remove leaky `ConsoleHandler.prototype.applyColors()`

### DIFF
--- a/log/console_handler.ts
+++ b/log/console_handler.ts
@@ -9,6 +9,27 @@ export interface ConsoleHandlerOptions extends BaseHandlerOptions {
   useColors?: boolean;
 }
 
+function applyColors(msg: string, level: number): string {
+  switch (level) {
+    case LogLevels.INFO:
+      msg = blue(msg);
+      break;
+    case LogLevels.WARN:
+      msg = yellow(msg);
+      break;
+    case LogLevels.ERROR:
+      msg = red(msg);
+      break;
+    case LogLevels.CRITICAL:
+      msg = bold(red(msg));
+      break;
+    default:
+      break;
+  }
+
+  return msg;
+}
+
 /**
  * This is the default logger. It will output color coded log messages to the
  * console via `console.log()`.
@@ -25,28 +46,7 @@ export class ConsoleHandler extends BaseHandler {
     let msg = super.format(logRecord);
 
     if (this.#useColors) {
-      msg = this.applyColors(msg, logRecord.level);
-    }
-
-    return msg;
-  }
-
-  applyColors(msg: string, level: number): string {
-    switch (level) {
-      case LogLevels.INFO:
-        msg = blue(msg);
-        break;
-      case LogLevels.WARN:
-        msg = yellow(msg);
-        break;
-      case LogLevels.ERROR:
-        msg = red(msg);
-        break;
-      case LogLevels.CRITICAL:
-        msg = bold(red(msg));
-        break;
-      default:
-        break;
+      msg = applyColors(msg, logRecord.level);
     }
 
     return msg;


### PR DESCRIPTION
There doesn't appear to be a reason for this to be a method on the `ConsoleHandler` class. This move avoids the need to document it as a method.