### PR TITLE
docs(log): correct the examples of `debug()`

### DIFF
--- a/log/debug.ts
+++ b/log/debug.ts
@@ -26,7 +26,7 @@ import "./setup.ts";
  * assertEquals(debug("This is a debug message."), "This is a debug message.");
  * // Prints: ""
  *
- * assertEquals(debug(() => "This is a debug message."), "This is a debug message.");
+ * assertEquals(debug(() => "This is a debug message."), undefined);
  * // Prints: ""
  * ```
  *
@@ -77,7 +77,7 @@ export function debug<T>(msg: () => T, ...args: unknown[]): T | undefined;
  * assertEquals(debug("This is a debug message."), "This is a debug message.");
  * // Prints: ""
  *
- * assertEquals(debug(() => "This is a debug message."), "This is a debug message.");
+ * assertEquals(debug(() => "This is a debug message."), undefined);
  * // Prints: ""
  * ```
  *


### PR DESCRIPTION
This PR fixes the error that has occurred since https://github.com/denoland/std/commit/827fe95620fda2e3426189f80e754fac67e09898.