### PR TITLE
feat(collections/unstable): support `Iterable` argument in `takeLastWhile()`

### DIFF
--- a/collections/deno.json
+++ b/collections/deno.json
@@ -50,6 +50,7 @@
     "./unstable-drop-last-while": "./unstable_drop_last_while.ts",
     "./unstable-sample": "./unstable_sample.ts",
     "./unstable-sort-by": "./unstable_sort_by.ts",
+    "./unstable-take-last-while": "./unstable_take_last_while.ts",
     "./unstable-take-while": "./unstable_take_while.ts",
     "./unstable-without-all": "./unstable_without_all.ts",
     "./unzip": "./unzip.ts",

--- a/collections/unstable_take_last_while.ts
+++ b/collections/unstable_take_last_while.ts
@@ -5,6 +5,8 @@
  * Returns all elements in the given iterable after the last element that does not
  * match the given predicate.
  *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
  * @typeParam T The type of the iterable elements.
  *
  * @param iterable The iterable to take elements from.

--- a/collections/unstable_take_last_while.ts
+++ b/collections/unstable_take_last_while.ts
@@ -1,0 +1,47 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+// This module is browser compatible.
+
+/**
+ * Returns all elements in the given iterable after the last element that does not
+ * match the given predicate.
+ *
+ * @typeParam T The type of the iterable elements.
+ *
+ * @param iterable The iterable to take elements from.
+ * @param predicate The predicate function to determine if an element should be
+ * included.
+ *
+ * @returns An array containing all elements after the last element that does
+ * not match the predicate.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { takeLastWhile } from "@std/collections/unstable-take-last-while";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const numbers = [1, 2, 3, 4, 5, 6];
+ * const result = takeLastWhile(numbers, (number) => number > 4);
+ * assertEquals(result, [5, 6]);
+ * ```
+ */
+export function takeLastWhile<T>(
+  iterable: Iterable<T>,
+  predicate: (el: T) => boolean,
+): T[] {
+  if (Array.isArray(iterable)) {
+    let offset = iterable.length;
+    while (0 < offset && predicate(iterable[offset - 1] as T)) {
+      offset--;
+    }
+    return iterable.slice(offset);
+  }
+  const result: T[] = [];
+  for (const el of iterable) {
+    if (predicate(el)) {
+      result.push(el);
+    } else {
+      result.length = 0;
+    }
+  }
+  return result;
+}

--- a/collections/unstable_take_last_while_test.ts
+++ b/collections/unstable_take_last_while_test.ts
@@ -1,0 +1,118 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { assertEquals } from "@std/assert";
+import { takeLastWhile } from "./unstable_take_last_while.ts";
+
+Deno.test("(unstable) takeLastWhile() handles num array", () => {
+  const arr = [1, 2, 3, 4, 5, 6];
+  const actual = takeLastWhile(arr, (i) => i !== 4);
+
+  assertEquals(actual, [5, 6]);
+});
+
+Deno.test("(unstable) takeLastWhile() adds two to each num in predicate", () => {
+  const arr = [1, 2, 3, 4, 5, 6];
+  const actual = takeLastWhile(arr, (i) => i + 2 !== 6);
+
+  assertEquals(actual, [5, 6]);
+});
+
+Deno.test("(unstable) takeLastWhile() handles negatives", () => {
+  const arr = [-1, -2, -3, -4, -5, -6];
+
+  const actual = takeLastWhile(arr, (i) => i < -4);
+  assertEquals(actual, [-5, -6]);
+});
+
+Deno.test("(unstable) takeLastWhile() handles no mutation", () => {
+  const arr = [1, 2, 3, 4, 5, 6];
+
+  const actual = takeLastWhile(arr, (i) => i !== 4);
+  assertEquals(actual, [5, 6]);
+  assertEquals(arr, [1, 2, 3, 4, 5, 6]);
+});
+
+Deno.test("(unstable) takeLastWhile() handles empty input array returns empty array", () => {
+  const arr: number[] = [];
+
+  const actual = takeLastWhile(arr, (i) => i > 4);
+
+  assertEquals(actual, []);
+});
+
+Deno.test("(unstable) takeLastWhile() returns empty array when the last element doesn't match the predicate", () => {
+  const arr = [1, 2, 3, 4];
+
+  const actual = takeLastWhile(arr, (i) => i !== 4);
+
+  assertEquals(actual, []);
+});
+
+Deno.test("(unstable) takeLastWhile() returns the same array when all elements match the predicate", () => {
+  const arr = [1, 2, 3, 4];
+
+  const actual = takeLastWhile(arr, (i) => i !== 400);
+
+  assertEquals(actual, [1, 2, 3, 4]);
+});
+
+Deno.test("(unstable) handles generator", () => {
+  function* gen() {
+    yield 1;
+    yield 2;
+    yield 3;
+    yield 4;
+    yield 5;
+    yield 6;
+  }
+  const actual = takeLastWhile(gen(), (i) => i !== 4);
+  assertEquals(actual, [5, 6]);
+});
+
+Deno.test("(unstable) takeLastWhile() returns empty array when the last generator element does not match the predicate", () => {
+  function* gen() {
+    yield 1;
+    yield 2;
+    yield 3;
+    yield 4;
+  }
+
+  const actual = takeLastWhile(gen(), (i) => i !== 4);
+  assertEquals(actual, []);
+});
+
+Deno.test("(unstable) takeLastWhile() returns the same array when all elements match the predicate", () => {
+  function* gen(): Generator<number> {
+    yield 1;
+    yield 2;
+    yield 3;
+    yield 4;
+  }
+  const actual = takeLastWhile(gen(), (i) => i !== 400);
+  assertEquals(actual, [1, 2, 3, 4]);
+});
+
+Deno.test("(unstable) takeLastWhile() empty generator returns empty array", () => {
+  function* gen(): Generator<number> {}
+  const actual = takeLastWhile(gen(), (i) => i > 4);
+  assertEquals(actual, []);
+});
+
+Deno.test("(unstable) takeLastWhile() gets from last matching element from an array", () => {
+  const arr = [1, 2, 3, 4, 5, 6];
+  const actual = takeLastWhile(arr, (i) => i !== 2 && i !== 4);
+  assertEquals(actual, [5, 6]);
+});
+
+Deno.test("(unstable) takeLastWhile() gets from last matching element from a generator", () => {
+  function* gen(): Generator<number> {
+    yield 1;
+    yield 2;
+    yield 3;
+    yield 4;
+    yield 5;
+    yield 6;
+  }
+  const actual = takeLastWhile(gen(), (i) => i !== 2 && i !== 4);
+  assertEquals(actual, [5, 6]);
+});


### PR DESCRIPTION
Create a backwards compatible unstable version of `takeLastWhile()` that accepts an iterable instead of arrays.

The array version is significantly more performant, so adding a special case for when the iterable is an array.

#5470