### PR TITLE
BREAKING(http/unstable): switch `params` and `info` args in `Handler` in `route()` for more conveniency

### DIFF
--- a/http/mod.ts
+++ b/http/mod.ts
@@ -104,6 +104,3 @@ export * from "./negotiation.ts";
 export * from "./server_sent_event_stream.ts";
 export * from "./user_agent.ts";
 export * from "./file_server.ts";
-// We keep this re-export as an exception for now as it's used in
-// `deno init --serve` output
-export * from "./unstable_route.ts";

--- a/http/unstable_route.ts
+++ b/http/unstable_route.ts
@@ -13,8 +13,8 @@
  */
 export type Handler = (
   request: Request,
+  params?: URLPatternResult,
   info?: Deno.ServeHandlerInfo,
-  params?: URLPatternResult | null,
 ) => Response | Promise<Response>;
 
 /**
@@ -56,7 +56,7 @@ export interface Route {
  *   },
  *   {
  *     pattern: new URLPattern({ pathname: "/users/:id" }),
- *     handler: (_req, _info, params) => new Response(params?.pathname.groups.id),
+ *     handler: (_req, params) => new Response(params?.pathname.groups.id),
  *   },
  *   {
  *     pattern: new URLPattern({ pathname: "/static/*" }),
@@ -102,7 +102,7 @@ export function route(
           ? route.method.includes(request.method)
           : request.method === (route.method ?? "GET"))
       ) {
-        return route.handler(request, info, match);
+        return route.handler(request, match, info);
       }
     }
     return defaultHandler(request, info);

--- a/http/unstable_route_test.ts
+++ b/http/unstable_route_test.ts
@@ -10,8 +10,7 @@ const routes: Route[] = [
   },
   {
     pattern: new URLPattern({ pathname: "/users/:id" }),
-    handler: (_request, _info, params) =>
-      new Response(params?.pathname.groups.id),
+    handler: (_request, params) => new Response(params?.pathname.groups.id),
   },
   {
     pattern: new URLPattern({ pathname: "/users/:id" }),


### PR DESCRIPTION
Closes  #5884

Not sure if it qualifies for "breaking change" since the API is still unstable, but it does break apps relying on current implementation `route()`

As explained in the linked issue, since `params: URLPatternResult` is way more likely to be used than `info: Deno.ServeHandlerInfo` in non-default handlers, it makes sense to switch them for improved DX