### PR TITLE
test(cbor): empty string being excluded from expected result

### DIFF
--- a/cbor/text_encoder_stream_test.ts
+++ b/cbor/text_encoder_stream_test.ts
@@ -13,12 +13,13 @@ Deno.test(
     const strings = [
       "a".repeat(random(0, 24)),
       "a".repeat(random(24, 2 ** 8)),
-      "a".repeat(random(2 ** 8, 2 ** 10)),
+      "a".repeat(random(2 ** 8, 2 ** 16)),
+      "a".repeat(random(2 ** 16, 2 ** 17)),
     ];
 
     const expectedOutput = concat([
       new Uint8Array([0b011_11111]),
-      ...strings.filter((x) => x).map((x) => encodeCbor(x)),
+      ...strings.map((x) => encodeCbor(x)),
       new Uint8Array([0b111_11111]),
     ]);
 
@@ -39,12 +40,13 @@ Deno.test(
     const strings = [
       "a".repeat(random(0, 24)),
       "a".repeat(random(24, 2 ** 8)),
-      "a".repeat(random(2 ** 8, 2 ** 10)),
+      "a".repeat(random(2 ** 8, 2 ** 16)),
+      "a".repeat(random(2 ** 16, 2 ** 17)),
     ];
 
     const expectedOutput = concat([
       new Uint8Array([0b011_11111]),
-      ...strings.filter((x) => x).map((x) => encodeCbor(x)),
+      ...strings.map((x) => encodeCbor(x)),
       new Uint8Array([0b111_11111]),
     ]);
 

--- a/cbor/text_encoder_stream_test.ts
+++ b/cbor/text_encoder_stream_test.ts
@@ -6,56 +6,48 @@ import { random } from "./_common_test.ts";
 import { encodeCbor } from "./encode_cbor.ts";
 import { CborTextEncoderStream } from "./text_encoder_stream.ts";
 
-Deno.test(
-  "CborTextEncoderStream() correctly encoding",
-  { ignore: true },
-  async () => {
-    const strings = [
-      "a".repeat(random(0, 24)),
-      "a".repeat(random(24, 2 ** 8)),
-      "a".repeat(random(2 ** 8, 2 ** 16)),
-      "a".repeat(random(2 ** 16, 2 ** 17)),
-    ];
+Deno.test("CborTextEncoderStream() correctly encoding", async () => {
+  const strings = [
+    "a".repeat(random(0, 24)),
+    "a".repeat(random(24, 2 ** 8)),
+    "a".repeat(random(2 ** 8, 2 ** 16)),
+    "a".repeat(random(2 ** 16, 2 ** 17)),
+  ];
 
-    const expectedOutput = concat([
-      new Uint8Array([0b011_11111]),
-      ...strings.map((x) => encodeCbor(x)),
-      new Uint8Array([0b111_11111]),
-    ]);
+  const expectedOutput = concat([
+    new Uint8Array([0b011_11111]),
+    ...strings.map((x) => encodeCbor(x)),
+    new Uint8Array([0b111_11111]),
+  ]);
 
-    const actualOutput = concat(
-      await Array.fromAsync(
-        ReadableStream.from(strings).pipeThrough(new CborTextEncoderStream()),
-      ),
-    );
+  const actualOutput = concat(
+    await Array.fromAsync(
+      ReadableStream.from(strings).pipeThrough(new CborTextEncoderStream()),
+    ),
+  );
 
-    assertEquals(actualOutput, expectedOutput);
-  },
-);
+  assertEquals(actualOutput, expectedOutput);
+});
 
-Deno.test(
-  "CborTextEncoderStream.from() correctly encoding",
-  { ignore: true },
-  async () => {
-    const strings = [
-      "a".repeat(random(0, 24)),
-      "a".repeat(random(24, 2 ** 8)),
-      "a".repeat(random(2 ** 8, 2 ** 16)),
-      "a".repeat(random(2 ** 16, 2 ** 17)),
-    ];
+Deno.test("CborTextEncoderStream.from() correctly encoding", async () => {
+  const strings = [
+    "a".repeat(random(0, 24)),
+    "a".repeat(random(24, 2 ** 8)),
+    "a".repeat(random(2 ** 8, 2 ** 16)),
+    "a".repeat(random(2 ** 16, 2 ** 17)),
+  ];
 
-    const expectedOutput = concat([
-      new Uint8Array([0b011_11111]),
-      ...strings.map((x) => encodeCbor(x)),
-      new Uint8Array([0b111_11111]),
-    ]);
+  const expectedOutput = concat([
+    new Uint8Array([0b011_11111]),
+    ...strings.map((x) => encodeCbor(x)),
+    new Uint8Array([0b111_11111]),
+  ]);
 
-    const actualOutput = concat(
-      await Array.fromAsync(
-        CborTextEncoderStream.from(strings).readable,
-      ),
-    );
+  const actualOutput = concat(
+    await Array.fromAsync(
+      CborTextEncoderStream.from(strings).readable,
+    ),
+  );
 
-    assertEquals(actualOutput, expectedOutput);
-  },
-);
+  assertEquals(actualOutput, expectedOutput);
+});


### PR DESCRIPTION
Closes: https://github.com/denoland/std/issues/6102

The expected result was filtering out empty strings provided in the input text, while `CborTextEncoderStream` doesn't remove them. The test appeared flaky because of the randomness of the test. In the event the first random chose zero (which is a 1 in 24 chance), an empty string would be one of the chunks. An empty string is encoded as byte 96. 

Lowering the size of the strings had no effect on the flakiness of the tests, but I am assuming that's why they were lowered in the first place.