### PR TITLE
docs(tar): fix example in creating directories

### DIFF
--- a/tar/mod.ts
+++ b/tar/mod.ts
@@ -16,7 +16,7 @@
  *     .pipeThrough(new UntarStream())
  * ) {
  *   const path = normalize(entry.path);
- *   await Deno.mkdir(dirname(path));
+ *   await Deno.mkdir(dirname(path), { recursive: true });
  *   await entry.readable?.pipeTo((await Deno.create(path)).writable);
  * }
  * ```

--- a/tar/untar_stream.ts
+++ b/tar/untar_stream.ts
@@ -167,7 +167,7 @@ export interface TarStreamEntry {
  *     .pipeThrough(new UntarStream())
  * ) {
  *   const path = normalize(entry.path);
- *   await Deno.mkdir(dirname(path));
+ *   await Deno.mkdir(dirname(path), { recursive: true });
  *   await entry.readable?.pipeTo((await Deno.create(path)).writable);
  * }
  * ```
@@ -359,7 +359,7 @@ export class UntarStream
    *     .pipeThrough(new UntarStream())
    * ) {
    *   const path = normalize(entry.path);
-   *   await Deno.mkdir(dirname(path));
+   *   await Deno.mkdir(dirname(path), { recursive: true });
    *   await entry.readable?.pipeTo((await Deno.create(path)).writable);
    * }
    * ```


### PR DESCRIPTION
This pull request fixes a highly probable bug in the JSDocs example where if the directory already exists, it throws an error, or if the directory's directory doesn't exist, it throws an error.