### PR TITLE
fix(cbor): number precision error in decoding test

### DIFF
--- a/cbor/decode_cbor_test.ts
+++ b/cbor/decode_cbor_test.ts
@@ -39,7 +39,7 @@ Deno.test("decodeCbor() decoding integers", () => {
   assertEquals(decodeCbor(encodeCbor(num)), num);
   assertEquals(decodeCbor(encodeCbor(BigInt(num))), num);
 
-  num = random(2 ** 32, 2 ** 64);
+  num = random(2 ** 32, Number.MAX_SAFE_INTEGER);
   assertEquals(decodeCbor(encodeCbor(num)), BigInt(num));
   assertEquals(decodeCbor(encodeCbor(BigInt(num))), BigInt(num));
 
@@ -59,7 +59,7 @@ Deno.test("decodeCbor() decoding integers", () => {
   assertEquals(decodeCbor(encodeCbor(num)), num);
   assertEquals(decodeCbor(encodeCbor(BigInt(num))), num);
 
-  num = -random(2 ** 32, 2 ** 64);
+  num = -random(2 ** 32, Number.MAX_SAFE_INTEGER);
   assertEquals(decodeCbor(encodeCbor(num)), BigInt(num));
   assertEquals(decodeCbor(encodeCbor(BigInt(num))), BigInt(num));
 });


### PR DESCRIPTION
Fixes: https://github.com/denoland/std/actions/runs/11310597614/job/31455830417#step:4:1

Due to the way JavaScript numbers work, numbers past `2 ** 53` lose precision. Weirdly though sometimes when converting them to BigInts they may gain more precision than they originally had. 