### PR TITLE
fix(http): fix tablet and smarttv in Device.type literal types

### DIFF
--- a/http/user_agent.ts
+++ b/http/user_agent.ts
@@ -85,11 +85,11 @@ export interface Device {
   /** The type of device. */
   readonly type:
     | "console"
-    | "mobile"
-    | "table"
-    | "smartv"
-    | "wearable"
     | "embedded"
+    | "mobile"
+    | "tablet"
+    | "smarttv"
+    | "wearable"
     | undefined;
   /** The vendor of the device. */
   readonly vendor: string | undefined;


### PR DESCRIPTION
I believe two of the literal types for `Device.type` have typos. The `const` values being returned are correct, but attempting a comparison like `device.type === 'tablet'` currently errors.

```ts
error: TS2367 [ERROR]: This comparison appears to be unintentional because the types '"console" | "mobile" | "table" | "smartv" | "wearable" | "embedded" | undefined' and '"tablet"' have no overlap.
export const isTablet = (device: Device) => device.type === 'tablet'
                                            ~~~~~~~~~~~~~~~~~~~~~~~~
```

`"table"` should be `"table[t]"` and `"smartv"` should be `"smart[t]v"`.

This PR fixes the two typos, and adjusts the sort order to match the order of [the `const`'s above](https://github.com/denoland/std/pull/6129/files#diff-9b1df331f9b4a9ec031bf0b92f1fa21a2fa39f771e3c0f89c5ec9bffa619d517L22-L27) to make it easier to visually compare values as a set.