### PR TITLE
fix(expect): support expect.not.{arrayContaining,objectContaning,stringContaining,stringMatching}

### DIFF
--- a/expect/_array_containing_test.ts
+++ b/expect/_array_containing_test.ts
@@ -14,3 +14,17 @@ Deno.test("expect.arrayContaining() with array of mixed types", () => {
   expect([1, 2, 3, "hello", "bye"]).toEqual(expect.arrayContaining(arr));
   expect([4, "bye"]).not.toEqual(expect.arrayContaining(arr));
 });
+
+Deno.test("expect.not.arrayContaining with array of numbers", () => {
+  const arr = [7, 8, 9];
+  expect([1, 2, 3, 4]).toEqual(expect.not.arrayContaining(arr));
+  expect([1, 2, 3, 4]).not.toEqual(expect.arrayContaining(arr));
+  expect([4, 5, 6, 7]).toEqual(expect.not.arrayContaining(arr));
+  expect([4, 5, 6, 7]).not.toEqual(expect.arrayContaining(arr));
+});
+
+Deno.test("expect.arrayContaining() with array of mixed types", () => {
+  const arr = [5, "world"];
+  expect([1, 2, 3, "hello", "bye"]).toEqual(expect.not.arrayContaining(arr));
+  expect([4, "bye"]).not.toEqual(expect.arrayContaining(arr));
+});

--- a/expect/_object_containing_test.ts
+++ b/expect/_object_containing_test.ts
@@ -48,3 +48,17 @@ Deno.test("expect.objectContaining() with Deno Buffer", () => {
     expect.objectContaining({ foo: new DenoBuffer([1, 2, 3]) }),
   );
 });
+
+Deno.test("expect.not.objectContaining()", () => {
+  expect({ bar: "baz" }).toEqual(expect.not.objectContaining({ foo: "bar" }));
+  expect({ foo: ["bar", "baz"] }).toEqual(
+    expect.not.objectContaining({ foo: ["bar", "bar"] }),
+  );
+});
+
+Deno.test("expect.not.objectContaining() with symbols", () => {
+  const foo = Symbol("foo");
+  expect({ [foo]: { bar: "baz" } }).toEqual(
+    expect.objectContaining({ [foo]: { bar: "bazzzz" } }),
+  );
+});

--- a/expect/_string_containing_test.ts
+++ b/expect/_string_containing_test.ts
@@ -16,3 +16,17 @@ Deno.test("expect.stringContaining() with other types", () => {
   expect(["foo", "bar"]).not.toEqual(expect.stringContaining("foo"));
   expect({ foo: "bar" }).not.toEqual(expect.stringContaining(`{ foo: "bar" }`));
 });
+
+Deno.test("expect.not.stringContaining() with strings", () => {
+  expect("https://deno.com/").toEqual(expect.not.stringContaining("node"));
+  expect("deno").toEqual(expect.not.stringContaining("Deno"));
+  expect("foobar").toEqual(expect.not.stringContaining("bazz"));
+  expect("How are you?").toEqual(expect.not.stringContaining("Hello world!"));
+});
+
+Deno.test("expect.not.stringContaining() with other types", () => {
+  expect(123).toEqual(expect.not.stringContaining("1"));
+  expect(true).toEqual(expect.not.stringContaining("true"));
+  expect(["foo", "bar"]).toEqual(expect.not.stringContaining("foo"));
+  expect({ foo: "bar" }).toEqual(expect.not.stringContaining(`{ foo: "bar" }`));
+});

--- a/expect/_string_matching_test.ts
+++ b/expect/_string_matching_test.ts
@@ -17,3 +17,11 @@ Deno.test("expect.stringMatching() with RegExp", () => {
   expect("\e").not.toEqual(expect.stringMatching(/\s/));
   expect("queue").not.toEqual(expect.stringMatching(/en/));
 });
+
+Deno.test("expect.not.stringMatching()", () => {
+  expect("Hello, World").toEqual(expect.not.stringMatching("hello"));
+  expect("foobar").toEqual(expect.not.stringMatching("bazz"));
+  expect("How are you?").toEqual(expect.not.stringMatching(/Hello world!/));
+  expect("queue").toEqual(expect.not.stringMatching(/en/));
+  expect("\e").toEqual(expect.not.stringMatching(/\s/));
+});

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -527,3 +527,31 @@ expect.hasAssertions = hasAssertions as () => void;
 expect.objectContaining = asymmetricMatchers.objectContaining as (
   obj: Record<string, unknown>,
 ) => ReturnType<typeof asymmetricMatchers.objectContaining>;
+/**
+ * `expect.not.arrayContaining` matches any received array that does not contain all of the elements in the expected array.
+ *
+ * `expect.not.objectContaining` matches any received object that does not recursively match the expected properties.
+ *
+ * `expect.not.stringContaining`
+ *
+ * `expect.not.stringMatching`
+ *
+ * @example
+ * ```ts
+ * import { expect } from "@std/expect";
+ *
+ * Deno.test("expect.not.arrayContaining", () => {});
+ *
+ * Deno.test("expect.not.objectContaining", () => {});
+ *
+ * Deno.test("expect.not.stringContaining", () => {});
+ *
+ * Deno.test("expect.not.stringMatching", () => {});
+ * ```
+ */
+expect.not = {
+  arrayContaining: asymmetricMatchers.arrayNotContaining,
+  objectContaining: asymmetricMatchers.objectNotContaining,
+  stringContaining: asymmetricMatchers.stringNotContaining,
+  stringMatching: asymmetricMatchers.stringNotMatching,
+};

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -528,25 +528,44 @@ expect.objectContaining = asymmetricMatchers.objectContaining as (
   obj: Record<string, unknown>,
 ) => ReturnType<typeof asymmetricMatchers.objectContaining>;
 /**
- * `expect.not.arrayContaining` matches any received array that does not contain all of the elements in the expected array.
+ * `expect.not.arrayContaining` matches a received array which does not contain
+ * all of the elements in the expected array. That is, the expected array is not
+ * a subset of the received array.
  *
- * `expect.not.objectContaining` matches any received object that does not recursively match the expected properties.
+ * `expect.not.objectContaining` matches any received object that does not recursively
+ * match the expected properties. That is, the expected object is not a subset of the
+ * received object. Therefore, it matches a received object which contains properties
+ * that are not in the expected object.
  *
- * `expect.not.stringContaining`
+ * `expect.not.stringContaining` matches the received value if it is not a string
+ * or if it is a string that does not contain the exact expected string.
  *
- * `expect.not.stringMatching`
+ * `expect.not.stringMatching` matches the received value if it is not a string
+ * or if it is a string that does not match the expected string or regular expression.
  *
  * @example
  * ```ts
  * import { expect } from "@std/expect";
  *
- * Deno.test("expect.not.arrayContaining", () => {});
+ * Deno.test("expect.not.arrayContaining", () => {
+ *   const expected = ["Samantha"];
+ *   expect(["Alice", "Bob", "Eve"]).toEqual(expect.not.arrayContaining(expected));
+ * });
  *
- * Deno.test("expect.not.objectContaining", () => {});
+ * Deno.test("expect.not.objectContaining", () => {
+ *   const expected = { foo: "bar" };
+ *   expect({ bar: "baz" }).toEqual(expect.not.objectContaining(expected));
+ * });
  *
- * Deno.test("expect.not.stringContaining", () => {});
+ * Deno.test("expect.not.stringContaining", () => {
+ *   const expected = "Hello world!";
+ *   expect("How are you?").toEqual(expect.not.stringContaining(expected));
+ * });
  *
- * Deno.test("expect.not.stringMatching", () => {});
+ * Deno.test("expect.not.stringMatching", () => {
+ *   const expected = /Hello world!/;
+ *   expect("How are you?").toEqual(expect.not.stringMatching(expected));
+ * });
  * ```
  */
 expect.not = {

--- a/expect/mod.ts
+++ b/expect/mod.ts
@@ -54,10 +54,14 @@
  *   - {@linkcode expect.anything}
  *   - {@linkcode expect.any}
  *   - {@linkcode expect.arrayContaining}
+ *   - {@linkcode expect.not.arrayContaining}
  *   - {@linkcode expect.objectContaining}
+ *   - {@linkcode expect.not.objectContaining}
  *   - {@linkcode expect.closeTo}
  *   - {@linkcode expect.stringContaining}
+ *   - {@linkcode expect.not.stringContaining}
  *   - {@linkcode expect.stringMatching}
+ *   - {@linkcode expect.not.stringMatching}
  * - Utilities:
  *   - {@linkcode expect.addEqualityTester}
  *   - {@linkcode expect.extend}
@@ -69,8 +73,6 @@
  *   - `toMatchInlineSnapshot`
  *   - `toThrowErrorMatchingSnapshot`
  *   - `toThrowErrorMatchingInlineSnapshot`
- * - Asymmetric matchers:
- *   - `expect.not.objectContaining`
  * - Utilities:
  *   - `expect.assertions`
  *   - `expect.addSnapshotSerializer`


### PR DESCRIPTION
Part of https://github.com/denoland/std/issues/3964, support:

* expect.not.arrayContaining 
* expect.not.objectContaining 
* expect.not.stringContaining
* expect.not.stringMatching