### PR TITLE
docs(streams): rest arguments not being asserted in docs

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -307,6 +307,9 @@ function assertFunctionDocs(
     if (param.kind === "identifier") {
       assertHasParamTag(document, param.name);
     }
+    if (param.kind === "rest" && param.arg.kind === "identifier") {
+      assertHasParamTag(document, param.arg.name);
+    }
     if (param.kind === "assign" && param.left.kind === "identifier") {
       assertHasParamTag(document, param.left.name);
     }

--- a/streams/early_zip_readable_streams.ts
+++ b/streams/early_zip_readable_streams.ts
@@ -12,6 +12,7 @@
  * even after one of them ends, use {@linkcode zipReadableStreams}.
  *
  * @typeparam T The type of the chunks in the input streams.
+ * @param streams An iterable of `ReadableStream`s to merge.
  * @returns A `ReadableStream` that will emit the zipped chunks
  *
  * @example Zip 2 streams with the same length

--- a/streams/zip_readable_streams.ts
+++ b/streams/zip_readable_streams.ts
@@ -11,6 +11,7 @@
  * the other streams when one of them ends, use {@linkcode earlyZipReadableStreams}.
  *
  * @typeparam T The type of the chunks in the input/output streams.
+ * @param streams An iterable of `ReadableStream`s to merge.
  * @returns A `ReadableStream` that will emit the zipped chunks.
  *
  * @example Zip 2 streams with the same length


### PR DESCRIPTION
Currently, rest arguments are not being asserted when `lint:docs` is run. This PR fixes the issue and adds missing `@param`   field to docs.