### PR TITLE
refactor(path): always name the parameters (add param definition check in doc linter)

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -183,6 +183,9 @@ function assertHasReturnTag(document: { jsDoc: JsDoc; location: Location }) {
   }
 }
 
+/**
+ * Asserts that a @param tag has a corresponding function definition.
+ */
 function assertHasParamDefinition(
   document: DocNodeWithJsDoc<DocNodeFunction | ClassMethodDef>,
   param: JsDocTagParam,
@@ -322,6 +325,7 @@ function assertHasTypeParamTags(
  * Asserts that a function document has:
  * - A `@typeParam` tag for each type parameter.
  * - A {@linkcode https://jsdoc.app/tags-param | @param} tag for each parameter.
+ * - A parameter definition inside the function for each @param tag.
  * - A {@linkcode https://jsdoc.app/tags-returns | @returns} tag.
  * - At least one {@linkcode https://jsdoc.app/tags-example | @example} tag with
  *   a code snippet that executes successfully.

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -200,6 +200,7 @@ function assertHasParamDefinition(
     ) {
       return paramDoc.left.name === param.name;
     }
+    return false;
   });
 
   if (!paramDoc) {

--- a/path/posix/join_globs.ts
+++ b/path/posix/join_globs.ts
@@ -26,8 +26,9 @@ export type { GlobOptions };
  */
 export function joinGlobs(
   globs: string[],
-  { extended = true, globstar = false }: GlobOptions = {},
+  options: Pick<GlobOptions, "globstar"> = {},
 ): string {
+  const { globstar = false } = options;
   if (!globstar || globs.length === 0) {
     return join(...globs);
   }
@@ -40,5 +41,5 @@ export function joinGlobs(
     }
   }
   if (!joined) return ".";
-  return normalizeGlob(joined, { extended, globstar });
+  return normalizeGlob(joined, { globstar });
 }

--- a/path/posix/normalize_glob.ts
+++ b/path/posix/normalize_glob.ts
@@ -25,8 +25,9 @@ export type { GlobOptions };
  */
 export function normalizeGlob(
   glob: string,
-  { globstar = false }: GlobOptions = {},
+  options: Pick<GlobOptions, "globstar"> = {},
 ): string {
+  const { globstar = false }: GlobOptions = options;
   if (glob.match(/\0/g)) {
     throw new Error(`Glob contains invalid characters: "${glob}"`);
   }

--- a/path/windows/join_globs.ts
+++ b/path/windows/join_globs.ts
@@ -27,8 +27,9 @@ export type { GlobOptions };
  */
 export function joinGlobs(
   globs: string[],
-  { extended = true, globstar = false }: GlobOptions = {},
+  options: Pick<GlobOptions, "globstar"> = {},
 ): string {
+  const { globstar = false } = options;
   if (!globstar || globs.length === 0) {
     return join(...globs);
   }
@@ -41,5 +42,5 @@ export function joinGlobs(
     }
   }
   if (!joined) return ".";
-  return normalizeGlob(joined, { extended, globstar });
+  return normalizeGlob(joined, { globstar });
 }

--- a/path/windows/normalize_glob.ts
+++ b/path/windows/normalize_glob.ts
@@ -25,8 +25,9 @@ export type { GlobOptions };
  */
 export function normalizeGlob(
   glob: string,
-  { globstar = false }: GlobOptions = {},
+  options: Pick<GlobOptions, "globstar"> = {},
 ): string {
+  const { globstar = false }: GlobOptions = options;
   if (glob.match(/\0/g)) {
     throw new Error(`Glob contains invalid characters: "${glob}"`);
   }


### PR DESCRIPTION
Implements #5439

This implementation doesn't go well with unnamed parameters (see the other changes in `path/*`). IMO, this is ok. As named parameters and Jsdoc param names go hand in hand, especially considering these are public APIs. Also, immediately on implementation, this helped me uncover some unused fields in the same functions. I'm curious on your opinions on this.

<img width="1198" alt="image" src="https://github.com/user-attachments/assets/5cadc2ab-6908-402b-a616-4aced9be5af3">
