### PR TITLE
test(bytes): document the cases being tested for equals/startsWith/endsWith

### DIFF
--- a/bytes/ends_with_test.ts
+++ b/bytes/ends_with_test.ts
@@ -1,13 +1,42 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
-
 import { assert } from "@std/assert";
 import { endsWith } from "./ends_with.ts";
 
-Deno.test("endsWith()", () => {
-  const v = endsWith(new Uint8Array([0, 1, 2]), new Uint8Array([1, 2]));
-  const v2 = endsWith(new Uint8Array([0, 1, 2]), new Uint8Array([0, 1]));
-  const v3 = endsWith(new Uint8Array([0, 1, 2]), new Uint8Array([0, 1, 2, 3]));
-  assert(v);
-  assert(!v2);
-  assert(!v3);
+Deno.test("endsWith()", async (t) => {
+  await t.step("`true` where `source` and `suffix` are identical", () => {
+    assert(endsWith(
+      new Uint8Array([0, 1, 2, 3]),
+      new Uint8Array([0, 1, 2, 3]),
+    ));
+  });
+  await t.step("`true` where `source` ends with `suffix`", () => {
+    assert(endsWith(
+      new Uint8Array([0, 1, 2]),
+      new Uint8Array([1, 2]),
+    ));
+  });
+  await t.step("`false` with a common but only partial suffix", () => {
+    assert(
+      !endsWith(
+        new Uint8Array([0, 1, 2]),
+        new Uint8Array([0, 2]),
+      ),
+    );
+  });
+  await t.step("`false` where `suffix` is longer", () => {
+    assert(
+      !endsWith(
+        new Uint8Array([0, 1, 2]),
+        new Uint8Array([0, 2, 3, 4]),
+      ),
+    );
+  });
+  await t.step("`false` where `suffix` ends with `source`", () => {
+    assert(
+      !endsWith(
+        new Uint8Array([1, 2]),
+        new Uint8Array([0, 1, 2]),
+      ),
+    );
+  });
 });

--- a/bytes/equals_test.ts
+++ b/bytes/equals_test.ts
@@ -2,13 +2,37 @@
 import { equals } from "./equals.ts";
 import { assert, assertEquals, assertNotEquals } from "@std/assert";
 
-Deno.test("equals()", () => {
-  const v = equals(new Uint8Array([0, 1, 2, 3]), new Uint8Array([0, 1, 2, 3]));
-  const v2 = equals(new Uint8Array([0, 1, 2, 2]), new Uint8Array([0, 1, 2, 3]));
-  const v3 = equals(new Uint8Array([0, 1, 2, 3]), new Uint8Array([0, 1, 2]));
-  assert(v);
-  assert(!v2);
-  assert(!v3);
+Deno.test("equals()", async (t) => {
+  await t.step("`true` where `a` and `b` are identical", () => {
+    assert(equals(
+      new Uint8Array([0, 1, 2, 3]),
+      new Uint8Array([0, 1, 2, 3]),
+    ));
+  });
+  await t.step("`false` where last byte differs", () => {
+    assert(
+      !equals(
+        new Uint8Array([0, 1, 2, 3]),
+        new Uint8Array([0, 1, 2, 255]),
+      ),
+    );
+  });
+  await t.step("`false` where `b` is a truncated version of `a`", () => {
+    assert(
+      !equals(
+        new Uint8Array([0, 1, 2, 0]),
+        new Uint8Array([0, 1, 2]),
+      ),
+    );
+  });
+  await t.step("`false` where `a` is a truncated version of `b`", () => {
+    assert(
+      !equals(
+        new Uint8Array([0, 1, 2]),
+        new Uint8Array([0, 1, 2, 0]),
+      ),
+    );
+  });
 });
 
 const THRESHOLD_32_BIT = 160;

--- a/bytes/starts_with_test.ts
+++ b/bytes/starts_with_test.ts
@@ -2,14 +2,41 @@
 import { assert } from "@std/assert";
 import { startsWith } from "./starts_with.ts";
 
-Deno.test("startsWith()", () => {
-  const v = startsWith(new Uint8Array([0, 1, 2]), new Uint8Array([0, 1]));
-  const v2 = startsWith(new Uint8Array([0, 1, 2]), new Uint8Array([0, 2]));
-  const v3 = startsWith(
-    new Uint8Array([0, 1, 2]),
-    new Uint8Array([0, 2, 3, 4]),
-  );
-  assert(v);
-  assert(!v2);
-  assert(!v3);
+Deno.test("startsWith()", async (t) => {
+  await t.step("`true` where `source` and `prefix` are identical", () => {
+    assert(startsWith(
+      new Uint8Array([0, 1, 2, 3]),
+      new Uint8Array([0, 1, 2, 3]),
+    ));
+  });
+  await t.step("`true` where `source` starts with `prefix`", () => {
+    assert(startsWith(
+      new Uint8Array([0, 1, 2]),
+      new Uint8Array([0, 1]),
+    ));
+  });
+  await t.step("`false` with a common but only partial prefix", () => {
+    assert(
+      !startsWith(
+        new Uint8Array([0, 1, 2]),
+        new Uint8Array([0, 2]),
+      ),
+    );
+  });
+  await t.step("`false` where `prefix` is longer", () => {
+    assert(
+      !startsWith(
+        new Uint8Array([0, 1, 2]),
+        new Uint8Array([0, 2, 3, 4]),
+      ),
+    );
+  });
+  await t.step("`false` where `prefix` starts with `source`", () => {
+    assert(
+      !startsWith(
+        new Uint8Array([0, 1]),
+        new Uint8Array([0, 1, 2]),
+      ),
+    );
+  });
 });


### PR DESCRIPTION
Current tests are kinda confusing and unclear what's being tested. It could help resolve confusion like https://github.com/denoland/std/issues/6146 if there was a specific test case (`` startsWith() ... `true` where `source` starts with `prefix` ``) that could be pointed to as failing upon the proposed change.