### PR TITLE
fix(expect): support `expect.addSnapshotSerializer`

### DIFF
--- a/expect/_serializer.ts
+++ b/expect/_serializer.ts
@@ -1,0 +1,13 @@
+import type { SnapshotPlugin } from "./_types.ts";
+
+const INTERNAL_PLUGINS: SnapshotPlugin[] = [
+  // TODO(eryue0220): support internal snapshot serializer plugins
+];
+
+export function addSnapshotSerializer(plugin: SnapshotPlugin) {
+  INTERNAL_PLUGINS.unshift(plugin);
+}
+
+export function getSnapshotSerializer() {
+  return INTERNAL_PLUGINS;
+}

--- a/expect/_serializer.ts
+++ b/expect/_serializer.ts
@@ -6,10 +6,10 @@ const INTERNAL_PLUGINS: SnapshotPlugin[] = [
   // TODO(eryue0220): support internal snapshot serializer plugins
 ];
 
-export function addSnapshotSerializer(plugin: SnapshotPlugin) {
+export function addSerializer(plugin: SnapshotPlugin) {
   INTERNAL_PLUGINS.unshift(plugin);
 }
 
-export function getSnapshotSerializer() {
+export function getSerializer() {
   return INTERNAL_PLUGINS;
 }

--- a/expect/_serializer.ts
+++ b/expect/_serializer.ts
@@ -1,3 +1,5 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
 import type { SnapshotPlugin } from "./_types.ts";
 
 const INTERNAL_PLUGINS: SnapshotPlugin[] = [

--- a/expect/_serializer_test.ts
+++ b/expect/_serializer_test.ts
@@ -1,0 +1,23 @@
+// Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
+
+import { expect } from "./expect.ts";
+import { addSerializer, getSerializer } from "./_serializer.ts";
+import type { SnapshotPlugin } from "./_types.ts";
+
+const foo: SnapshotPlugin = {
+  serialize() {
+    return "foot";
+  },
+  test() {
+    return false;
+  },
+};
+
+Deno.test("initial serializer", () => {
+  expect(getSerializer()).toHaveLength(0);
+});
+
+Deno.test("add serializer", () => {
+  addSerializer(foo);
+  expect(getSerializer()).toHaveLength(1);
+});

--- a/expect/_types.ts
+++ b/expect/_types.ts
@@ -915,3 +915,5 @@ export interface OldSnapshotPlugin {
   ) => string;
   test: Test;
 }
+
+export type SnapshotPlugin = NewSnapshotPlugin | OldSnapshotPlugin;

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -59,10 +59,10 @@ import {
   toStrictEqual,
   toThrow,
 } from "./_matchers.ts";
-import { addSnapshotSerializer } from "./_serializer.ts";
+import { addSerializer } from "./_serializer.ts";
 import { isPromiseLike } from "./_utils.ts";
 import * as asymmetricMatchers from "./_asymmetric_matchers.ts";
-import type { Tester } from "./_types.ts";
+import type { SnapshotPlugin, Tester } from "./_types.ts";
 
 export type { AnyConstructor, Async, Expected } from "./_types.ts";
 
@@ -615,4 +615,6 @@ expect.not = {
  * expect.addSnapshotSerializer(serializer);
  * ```
  */
-expect.addSnapshotSerializer = addSnapshotSerializer;
+expect.addSnapshotSerializer = addSerializer as (
+  plugin: SnapshotPlugin,
+) => void;

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -604,7 +604,7 @@ expect.not = {
  * `expect.addSnapshotSerializer` adds a module that formats application-specific data structures.
  *
  * For an individual test file, an added module precedes any modules from snapshotSerializers configuration,
- * which precede the default snapshot serializers for built-in JavaScript types and for React elements.
+ * which precede the default snapshot serializers for built-in JavaScript types.
  * The last module added is the first module tested.
  *
  * @example

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -59,6 +59,7 @@ import {
   toStrictEqual,
   toThrow,
 } from "./_matchers.ts";
+import { addSnapshotSerializer } from "./_serializer.ts";
 import { isPromiseLike } from "./_utils.ts";
 import * as asymmetricMatchers from "./_asymmetric_matchers.ts";
 import type { Tester } from "./_types.ts";
@@ -599,3 +600,19 @@ expect.not = {
   stringContaining: asymmetricMatchers.stringNotContaining,
   stringMatching: asymmetricMatchers.stringNotMatching,
 };
+/**
+ * `expect.addSnapshotSerializer` adds a module that formats application-specific data structures.
+ *
+ * For an individual test file, an added module precedes any modules from snapshotSerializers configuration,
+ * which precede the default snapshot serializers for built-in JavaScript types and for React elements.
+ * The last module added is the first module tested.
+ *
+ * @example
+ * ```ts
+ * import { expect } from "@std/expect";
+ * import serializer from "my-serializer-module";
+ *
+ * expect.addSnapshotSerializer(serializer);
+ * ```
+ */
+expect.addSnapshotSerializer = addSnapshotSerializer;

--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -608,11 +608,11 @@ expect.not = {
  * The last module added is the first module tested.
  *
  * @example
- * ```ts
+ * ```ts no-eval
  * import { expect } from "@std/expect";
- * import serializer from "my-serializer-module";
+ * import serializerAnsi from "npm:jest-snapshot-serializer-ansi";
  *
- * expect.addSnapshotSerializer(serializer);
+ * expect.addSnapshotSerializer(serializerAnsi);
  * ```
  */
 expect.addSnapshotSerializer = addSerializer as (

--- a/expect/mod.ts
+++ b/expect/mod.ts
@@ -63,6 +63,7 @@
  *   - {@linkcode expect.stringMatching}
  *   - {@linkcode expect.not.stringMatching}
  * - Utilities:
+ *   - {@linkcode expect.addSnapshotSerializer}
  *   - {@linkcode expect.assertions}
  *   - {@linkcode expect.addEqualityTester}
  *   - {@linkcode expect.extend}
@@ -74,8 +75,6 @@
  *   - `toMatchInlineSnapshot`
  *   - `toThrowErrorMatchingSnapshot`
  *   - `toThrowErrorMatchingInlineSnapshot`
- * - Utilities:
- *   - `expect.addSnapshotSerializer`
  *
  * The tracking issue to add support for unsupported parts of the API is
  * {@link https://github.com/denoland/std/issues/3964}.


### PR DESCRIPTION
Part of #3964, support `expect.addSnapshotSerializer` api.