### PR TITLE
fix(http): do not serve dot files when `showDotfiles=false`

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -707,6 +707,11 @@ async function createServeDirResponse(
     normalizedPath = normalizedPath.slice(0, -1);
   }
 
+  // Exclude dotfiles if showDotfiles is false
+  if (!showDotfiles && /\/\./.test(normalizedPath)) {
+    return createStandardResponse(STATUS_CODE.NotFound);
+  }
+
   const fsPath = join(target, normalizedPath);
   const fileInfo = await Deno.stat(fsPath);
 

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -445,7 +445,21 @@ Deno.test("serveDir() doesn't show directory listings", async () => {
   assertEquals(res.status, 404);
 });
 
-Deno.test("serveDir() doesn't show dotfiles", async () => {
+Deno.test("serveDir() shows dotfiles when showDotfiles=true", async () => {
+  const req1 = new Request("http://localhost/");
+  const res1 = await serveDir(req1, serveDirOptions);
+  const page1 = await res1.text();
+
+  assert(page1.includes(".dotfile"));
+
+  const req2 = new Request("http://localhost/.dotfile");
+  const res2 = await serveDir(req2, serveDirOptions);
+  const body = await res2.text();
+
+  assertEquals(body, "dotfile");
+});
+
+Deno.test("serveDir() doesn't show dotfiles when showDotfiles=false", async () => {
   const req1 = new Request("http://localhost/");
   const res1 = await serveDir(req1, {
     ...serveDirOptions,
@@ -462,7 +476,8 @@ Deno.test("serveDir() doesn't show dotfiles", async () => {
   });
   const body = await res2.text();
 
-  assertEquals(body, "dotfile");
+  assertEquals(res2.status, 404);
+  assertEquals(body, "Not Found");
 });
 
 Deno.test("serveDir() shows .. if it makes sense", async () => {


### PR DESCRIPTION
Currently file server serves dot files even when `showDotfiles=false` specified. This PR changes it to not serve dot files when `showDotfiles=false`.