### PR TITLE
chore: update FileInfo fixture

### DIFF
--- a/http/etag_test.ts
+++ b/http/etag_test.ts
@@ -42,13 +42,14 @@ Deno.test({
 Deno.test({
   name: "eTag() handles Deno.FileInfo",
   async fn() {
-    const fixture: Deno.FileInfo = {
+    const fixture = {
       isFile: true,
       isDirectory: false,
       isSymlink: false,
       size: 1024,
       mtime: new Date(Date.UTC(96, 1, 2, 3, 4, 5, 6)),
       atime: null,
+      ctime: null,
       birthtime: null,
       dev: 0,
       ino: null,

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -188,14 +188,7 @@ Deno.test("serveDir() serves directory index", async () => {
   assertStringIncludes(page, '<a href="/hello.html">hello.html</a>');
   assertStringIncludes(page, '<a href="/tls/">tls/</a>');
   assertStringIncludes(page, "%2525A.txt");
-  // `Deno.FileInfo` is not completely compatible with Windows yet
-  // TODO(bartlomieju): `mode` should work correctly in the future.
-  // Correct this test case accordingly.
-  if (Deno.build.os === "windows") {
-    assertMatch(page, /<td class="mode">(\s)*\(unknown mode\)(\s)*<\/td>/);
-  } else {
-    assertMatch(page, /<td class="mode">(\s)*[a-zA-Z- ]{14}(\s)*<\/td>/);
-  }
+  assertMatch(page, /<td class="mode">(\s)*[a-zA-Z- ]{14}(\s)*<\/td>/);
 
   await Deno.remove(filePath);
 });
@@ -212,14 +205,7 @@ Deno.test("serveDir() serves directory index with file containing space in the f
   assertStringIncludes(page, '<a href="/hello.html">hello.html</a>');
   assertStringIncludes(page, '<a href="/tls/">tls/</a>');
   assertStringIncludes(page, "test%20file.txt");
-  // `Deno.FileInfo` is not completely compatible with Windows yet
-  // TODO(bartlomieju): `mode` should work correctly in the future.
-  // Correct this test case accordingly.
-  if (Deno.build.os === "windows") {
-    assertMatch(page, /<td class="mode">(\s)*\(unknown mode\)(\s)*<\/td>/);
-  } else {
-    assertMatch(page, /<td class="mode">(\s)*[a-zA-Z- ]{14}(\s)*<\/td>/);
-  }
+  assertMatch(page, /<td class="mode">(\s)*[a-zA-Z- ]{14}(\s)*<\/td>/);
 
   await Deno.remove(filePath);
 });


### PR DESCRIPTION
`FileInfo` type has been updated in this commit ( https://github.com/denoland/deno/commit/7becd83a3828b35331d0fcb82c64146e520f154b ), and now this test fixture needs to be updated