### PR TITLE
chore: check publish --dry-run after testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,10 @@ jobs:
         with:
           name: ${{ matrix.os }}-${{ matrix.deno }}
 
+      - name: Publish dry run
+        run: deno publish --dry-run
+        if: matrix.deno == 'canary' && matrix.os == 'ubuntu-latest'
+
   test-node:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
@@ -160,22 +164,3 @@ jobs:
       - name: Rebuild Wasm and verify it hasn't changed
         if: success() && steps.source.outputs.modified == 'true'
         run: deno task --cwd ${{ matrix.module }} --config deno.json wasmbuild --check
-
-  publish-dry-run:
-    runs-on: ubuntu-latest
-    timeout-minutes: 30
-    permissions:
-      contents: read
-      id-token: write
-
-    steps:
-      - name: Clone repository
-        uses: actions/checkout@v4
-
-      - name: Set up Deno
-        uses: denoland/setup-deno@v2
-        with:
-          deno-version: canary
-
-      - name: Publish (dry run)
-        run: deno publish --dry-run


### PR DESCRIPTION
This PR updates the CI workflow to check `publish --dry-run` after test runs.

This prevents the case like 2024.11.13 release ( https://github.com/denoland/std/actions/runs/11815536146/job/32916891866 ), which failed because the git repository state became dirty after the test run and CI didn't detect it