### PR TITLE
docs: simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,64 +11,13 @@ High-quality APIs for [Deno](https://deno.com/) and the web. Use fearlessly.
 > [JSR](https://jsr.io/@std). Older versions up till 0.224.0 are still available
 > at [deno.land/std](https://deno.land/std).
 
-## Packages
+## Resources
 
-The following list contains links to the Standard Library's packages and
-documentation:
-
-| Package                                                | Latest version                                                                            |
-| ------------------------------------------------------ | ----------------------------------------------------------------------------------------- |
-| [assert](https://jsr.io/@std/assert)                   | [![JSR](https://jsr.io/badges/@std/assert)](https://jsr.io/@std/assert)                   |
-| [async](https://jsr.io/@std/async)                     | [![JSR](https://jsr.io/badges/@std/async)](https://jsr.io/@std/async)                     |
-| [bytes](https://jsr.io/@std/bytes)                     | [![JSR](https://jsr.io/badges/@std/bytes)](https://jsr.io/@std/bytes)                     |
-| [cache](https://jsr.io/@std/cache)                     | [![JSR](https://jsr.io/badges/@std/cache)](https://jsr.io/@std/cache)                     |
-| [cli](https://jsr.io/@std/cli)                         | [![JSR](https://jsr.io/badges/@std/cli)](https://jsr.io/@std/cli)                         |
-| [collections](https://jsr.io/@std/collections)         | [![JSR](https://jsr.io/badges/@std/collections)](https://jsr.io/@std/collections)         |
-| [crypto](https://jsr.io/@std/crypto)                   | [![JSR](https://jsr.io/badges/@std/crypto)](https://jsr.io/@std/crypto)                   |
-| [csv](https://jsr.io/@std/csv)                         | [![JSR](https://jsr.io/badges/@std/csv)](https://jsr.io/@std/csv)                         |
-| [data-structures](https://jsr.io/@std/data-structures) | [![JSR](https://jsr.io/badges/@std/data-structures)](https://jsr.io/@std/data-structures) |
-| [datetime](https://jsr.io/@std/datetime)               | [![JSR](https://jsr.io/badges/@std/datetime)](https://jsr.io/@std/datetime)               |
-| [dotenv](https://jsr.io/@std/dotenv)                   | [![JSR](https://jsr.io/badges/@std/dotenv)](https://jsr.io/@std/dotenv)                   |
-| [encoding](https://jsr.io/@std/encoding)               | [![JSR](https://jsr.io/badges/@std/encoding)](https://jsr.io/@std/encoding)               |
-| [expect](https://jsr.io/@std/expect)                   | [![JSR](https://jsr.io/badges/@std/expect)](https://jsr.io/@std/expect)                   |
-| [fmt](https://jsr.io/@std/fmt)                         | [![JSR](https://jsr.io/badges/@std/fmt)](https://jsr.io/@std/fmt)                         |
-| [front-matter](https://jsr.io/@std/front-matter)       | [![JSR](https://jsr.io/badges/@std/front-matter)](https://jsr.io/@std/front-matter)       |
-| [fs](https://jsr.io/@std/fs)                           | [![JSR](https://jsr.io/badges/@std/fs)](https://jsr.io/@std/fs)                           |
-| [html](https://jsr.io/@std/html)                       | [![JSR](https://jsr.io/badges/@std/html)](https://jsr.io/@std/html)                       |
-| [http](https://jsr.io/@std/http)                       | [![JSR](https://jsr.io/badges/@std/http)](https://jsr.io/@std/http)                       |
-| [ini](https://jsr.io/@std/ini)                         | [![JSR](https://jsr.io/badges/@std/ini)](https://jsr.io/@std/ini)                         |
-| [io](https://jsr.io/@std/io)                           | [![JSR](https://jsr.io/badges/@std/io)](https://jsr.io/@std/io)                           |
-| [json](https://jsr.io/@std/json)                       | [![JSR](https://jsr.io/badges/@std/json)](https://jsr.io/@std/json)                       |
-| [jsonc](https://jsr.io/@std/jsonc)                     | [![JSR](https://jsr.io/badges/@std/jsonc)](https://jsr.io/@std/jsonc)                     |
-| [log](https://jsr.io/@std/log)                         | [![JSR](https://jsr.io/badges/@std/log)](https://jsr.io/@std/log)                         |
-| [media-types](https://jsr.io/@std/media-types)         | [![JSR](https://jsr.io/badges/@std/media-types)](https://jsr.io/@std/media-types)         |
-| [msgpack](https://jsr.io/@std/msgpack)                 | [![JSR](https://jsr.io/badges/@std/msgpack)](https://jsr.io/@std/msgpack)                 |
-| [net](https://jsr.io/@std/net)                         | [![JSR](https://jsr.io/badges/@std/net)](https://jsr.io/@std/net)                         |
-| [path](https://jsr.io/@std/path)                       | [![JSR](https://jsr.io/badges/@std/path)](https://jsr.io/@std/path)                       |
-| [random](https://jsr.io/@std/random)                   | [![JSR](https://jsr.io/badges/@std/random)](https://jsr.io/@std/random)                   |
-| [regexp](https://jsr.io/@std/regexp)                   | [![JSR](https://jsr.io/badges/@std/regexp)](https://jsr.io/@std/regexp)                   |
-| [semver](https://jsr.io/@std/semver)                   | [![JSR](https://jsr.io/badges/@std/semver)](https://jsr.io/@std/semver)                   |
-| [streams](https://jsr.io/@std/streams)                 | [![JSR](https://jsr.io/badges/@std/streams)](https://jsr.io/@std/streams)                 |
-| [tar](https://jsr.io/@std/tar)                         | [![JSR](https://jsr.io/badges/@std/tar)](https://jsr.io/@std/tar)                         |
-| [testing](https://jsr.io/@std/testing)                 | [![JSR](https://jsr.io/badges/@std/testing)](https://jsr.io/@std/testing)                 |
-| [text](https://jsr.io/@std/text)                       | [![JSR](https://jsr.io/badges/@std/text)](https://jsr.io/@std/text)                       |
-| [toml](https://jsr.io/@std/toml)                       | [![JSR](https://jsr.io/badges/@std/toml)](https://jsr.io/@std/toml)                       |
-| [ulid](https://jsr.io/@std/ulid)                       | [![JSR](https://jsr.io/badges/@std/ulid)](https://jsr.io/@std/ulid)                       |
-| [uuid](https://jsr.io/@std/uuid)                       | [![JSR](https://jsr.io/badges/@std/uuid)](https://jsr.io/@std/uuid)                       |
-| [webgpu](https://jsr.io/@std/webgpu)                   | [![JSR](https://jsr.io/badges/@std/webgpu)](https://jsr.io/@std/webgpu)                   |
-| [yaml](https://jsr.io/@std/yaml)                       | [![JSR](https://jsr.io/badges/@std/yaml)](https://jsr.io/@std/yaml)                       |
-
-## Architecture
-
-Check out the architecture guide [here](./.github/ARCHITECTURE.md).
-
-## Design
-
-Check out the design documentation [here](.github/ARCHITECTURE.md#design).
-
-## Contributing
-
-Check out the contributing guidelines [here](.github/CONTRIBUTING.md).
+- [Package list](https://jsr.io/@std)
+- [Architecture guide](./.github/ARCHITECTURE.md)
+- [Design documentation](.github/ARCHITECTURE.md#design)
+- [Contributing guidelines](.github/CONTRIBUTING.md)
+- [Frequently asked questions (FAQ)](./.github/FAQ.md)
 
 ## Releases
 
@@ -98,7 +47,3 @@ package versions <1.0.0 follow
 ```md
 [![Built with the Deno Standard Library](https://img.shields.io/badge/Built_with_std-blue?logo=deno)](https://jsr.io/@std)
 ```
-
-## Frequently Asked Questions
-
-Check out the frequently asked questions page [here](./.github/FAQ.md).


### PR DESCRIPTION
This PR simplifies the README document by having resources be listed in a "Resources" section. It also removes the package table, as now, we can directly link to JSR, which contains package version information.