### PR TITLE
chore: upload code coverage report to Deploy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,8 +48,10 @@ jobs:
         run: deno task test:browser
         if: matrix.deno == 'v2.x' && matrix.os == 'ubuntu-latest'
 
-      - name: Generate lcov
-        run: deno task cov:gen
+      - name: Generate lcov and html reports
+        run: |
+          deno task cov:gen
+          deno task cov:view
 
       - name: Upload coverage
         uses: codecov/codecov-action@v5
@@ -57,6 +59,14 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:
           name: ${{ matrix.os }}-${{ matrix.deno }}
+
+      - name: Upload coverage to Deploy
+        uses: denoland/deployctl@v1
+        with:
+          project: std-coverage
+          root: coverage/html
+          entrypoint: jsr:@std/http@1/file-server
+        if: matrix.deno == 'canary' && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
 
       - name: Publish dry run
         run: deno publish --dry-run


### PR DESCRIPTION
This PR add the CI step, which upload the html coverage report to Deploy on every push to main branch and host them using `jsr:@std/http/file-server`.

The builtin html coverage report of std test will be visible at https://std-coverage.deno.dev/ after the successful upload.

closes #5982