### PR TITLE
fix(regexp): escape leading digit

### DIFF
--- a/regexp/escape.ts
+++ b/regexp/escape.ts
@@ -93,5 +93,5 @@ export function escape(str: string): string {
   return str.replaceAll(
     RX_REGEXP_ESCAPE,
     (m) => RESERVED_CHARS[m as keyof typeof RESERVED_CHARS],
-  ).replace(/^\d/, (m) => `\\x${m.codePointAt(0)!.toString(16)}`);
+  ).replace(/^[0-9a-zA-Z]/, (m) => `\\x${m.codePointAt(0)!.toString(16)}`);
 }

--- a/regexp/escape.ts
+++ b/regexp/escape.ts
@@ -93,5 +93,5 @@ export function escape(str: string): string {
   return str.replaceAll(
     RX_REGEXP_ESCAPE,
     (m) => RESERVED_CHARS[m as keyof typeof RESERVED_CHARS],
-  );
+  ).replace(/^\d/, (m) => `\\x${m.codePointAt(0)!.toString(16)}`);
 }

--- a/regexp/escape_test.ts
+++ b/regexp/escape_test.ts
@@ -90,3 +90,12 @@ Deno.test("escape() works with all ASCII", async (t) => {
     });
   });
 });
+
+Deno.test("escape() escapes the leading digit", () => {
+  const escaped = escape("1");
+  assertEquals(escaped, "\\x31");
+
+  const re = new RegExp(`^${escaped}$`);
+  assertMatch("1", re);
+  assertNotMatch("a", re);
+});

--- a/regexp/escape_test.ts
+++ b/regexp/escape_test.ts
@@ -91,11 +91,10 @@ Deno.test("escape() works with all ASCII", async (t) => {
   });
 });
 
-Deno.test("escape() escapes the leading digit", () => {
-  const escaped = escape("1");
-  assertEquals(escaped, "\\x31");
-
-  const re = new RegExp(`^${escaped}$`);
-  assertMatch("1", re);
-  assertNotMatch("a", re);
+Deno.test("escape() escapes the leading digit and ascii-letter", () => {
+  assertEquals(escape("123"), "\\x3123");
+  assertEquals(escape("abc"), "\\x61bc");
+  assertEquals(escape("ABC"), "\\x41BC");
+  assertEquals(escape("xyz"), "\\x78yz");
+  assertEquals(escape("XYZ"), "\\x58YZ");
 });


### PR DESCRIPTION
This PR updates `escape` of `@std/regexp`. Now `escape` escapes the leading digit as recommended in #3656. This behavior is aligned with regexp-escape proposal ( https://github.com/tc39/proposal-regex-escaping, polyfill: https://npm.im/regexp.escape )

closes #3656