### PR TITLE
docs(assert): add note and example for Blob comparison

### DIFF
--- a/assert/equals.ts
+++ b/assert/equals.ts
@@ -15,12 +15,25 @@ import { AssertionError } from "./assertion_error.ts";
  * Type parameter can be specified to ensure values under comparison have the
  * same type.
  *
+ * Note: When comparing `Blob` objects, you should first convert them to
+ * `Uint8Array` using the `Blob.arrayBuffer()` method and then compare their
+ * contents.
+ *
  * @example Usage
  * ```ts ignore
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals("world", "world"); // Doesn't throw
  * assertEquals("hello", "world"); // Throws
+ * ```
+ * @example Compare `Blob` objects
+ * ```ts ignore
+ * import { assertEquals } from "@std/assert";
+ *
+ * const bytes1 = await new Blob(["foo"]).bytes();
+ * const bytes2 = await new Blob(["foo"]).bytes();
+ *
+ * assertEquals(bytes1, bytes2);
  * ```
  *
  * @typeParam T The type of the values to compare. This is usually inferred.

--- a/assert/equals.ts
+++ b/assert/equals.ts
@@ -16,7 +16,7 @@ import { AssertionError } from "./assertion_error.ts";
  * same type.
  *
  * Note: When comparing `Blob` objects, you should first convert them to
- * `Uint8Array` using the `Blob.arrayBuffer()` method and then compare their
+ * `Uint8Array` using the `Blob.bytes()` method and then compare their
  * contents.
  *
  * @example Usage


### PR DESCRIPTION
This PR improves the documentation for the `assertEquals` function by addressing how to compare `Blob` objects.

Fixes #6202 