### PR TITLE
feat(cli/unstable): export `/unstable-prompt-select`

### DIFF
--- a/cli/deno.json
+++ b/cli/deno.json
@@ -5,6 +5,7 @@
     ".": "./mod.ts",
     "./parse-args": "./parse_args.ts",
     "./prompt-secret": "./prompt_secret.ts",
+    "./unstable-prompt-select": "./unstable_prompt_select.ts",
     "./unstable-spinner": "./unstable_spinner.ts",
     "./unicode-width": "./unicode_width.ts"
   }


### PR DESCRIPTION
`promptSelect()` has been added in #6190, but it does not seem to be exported. This PR exports it.