### PR TITLE
fix(dotenv): handle multiline variables on Windows

### DIFF
--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -10,7 +10,7 @@ type LineParseResult = {
 type CharactersMap = { [key: string]: string };
 
 const RE_KEY_VALUE =
-  /^\s*(?:export\s+)?(?<key>[^\s=#]+?)\s*=[\ \t]*('\n?(?<notInterpolated>(.|\n)*?)\n?'|"\n?(?<interpolated>(.|\n)*?)\n?"|(?<unquoted>[^\n#]*)) *#*.*$/gm;
+  /^\s*(?:export\s+)?(?<key>[^\s=#]+?)\s*=[\ \t]*('\r?\n?(?<notInterpolated>(.|\r\n|\n)*?)\r?\n?'|"\r?\n?(?<interpolated>(.|\r\n|\n)*?)\r?\n?"|(?<unquoted>[^\r\n#]*)) *#*.*$/gm;
 
 const RE_VALID_KEY = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
 

--- a/dotenv/parse_test.ts
+++ b/dotenv/parse_test.ts
@@ -16,7 +16,7 @@ Deno.test("parse()", () => {
   );
 
   const load = parse(testDotenv);
-  assertEquals(Object.keys(load).length, 24, "parses 24 keys");
+  assertEquals(Object.keys(load).length, 26, "parses 26 keys");
   assertEquals(load.BASIC, "basic", "parses a basic variable");
   assertEquals(load.AFTER_EMPTY, "empty", "skips empty lines");
   assertEquals(load["#COMMENT"], undefined, "skips lines with comments");
@@ -47,8 +47,13 @@ Deno.test("parse()", () => {
   );
 
   assertEquals(
-    load.MULTILINE,
+    load.MULTILINE1,
     "hello\nworld",
+    "new lines are expanded in double quotes",
+  );
+  assertEquals(
+    load.MULTILINE2,
+    "hello\r\nworld",
     "new lines are expanded in double quotes",
   );
 
@@ -71,8 +76,13 @@ Deno.test("parse()", () => {
   );
 
   assertEquals(
-    load.MULTILINE_SINGLE_QUOTE,
+    load.MULTILINE_SINGLE_QUOTE1,
     "hello\\nworld",
+    "new lines are escaped in single quotes",
+  );
+  assertEquals(
+    load.MULTILINE_SINGLE_QUOTE2,
+    "hello\\r\\nworld",
     "new lines are escaped in single quotes",
   );
 

--- a/dotenv/testdata/.env.test
+++ b/dotenv/testdata/.env.test
@@ -8,11 +8,13 @@ QUOTED_DOUBLE="double quoted"
 EMPTY_SINGLE=''
 EMPTY_DOUBLE=""
 
-MULTILINE="hello\nworld"
+MULTILINE1="hello\nworld"
+MULTILINE2="hello\r\nworld"
 JSON='{"foo": "bar"}'
 WHITESPACE='    whitespace   '
 WHITESPACE_DOUBLE="    whitespace   "
-MULTILINE_SINGLE_QUOTE='hello\nworld'
+MULTILINE_SINGLE_QUOTE1='hello\nworld'
+MULTILINE_SINGLE_QUOTE2='hello\r\nworld'
 EQUALS='equ==als'
 THE_ANSWER=42
 


### PR DESCRIPTION
Current env parser do not support `.env` files with `\r\n` line break.

fixes #6170 