### PR TITLE
fix(expect): fix error messages for `toMatchObject`

### DIFF
--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -487,9 +487,15 @@ export function toMatchObject(
   const triggerError = () => {
     const actualString = format(context.value);
     const expectedString = format(expected);
-    throw new AssertionError(
-      `Expected ${actualString} to NOT match ${expectedString}`,
-    );
+    if (context.isNot) {
+      throw new AssertionError(
+        `Expected ${actualString} to NOT match ${expectedString}`,
+      );
+    } else {
+      throw new AssertionError(
+        `Expected ${actualString} to match ${expectedString}`,
+      );
+    }
   };
 
   if (context.isNot && pass || !context.isNot && !pass) {

--- a/expect/_to_match_object_test.ts
+++ b/expect/_to_match_object_test.ts
@@ -1,7 +1,12 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 
 import { expect } from "./expect.ts";
-import { AssertionError, assertThrows } from "@std/assert";
+import {
+  AssertionError,
+  assertMatch,
+  assertNotMatch,
+  assertThrows,
+} from "@std/assert";
 
 Deno.test("expect().toMatchObject()", () => {
   const house0 = {
@@ -67,4 +72,21 @@ Deno.test("expect(),toMatchObject() with asyAsymmetric matcher", () => {
       y: expect.any(Number),
     },
   });
+});
+
+Deno.test("expect().toMatchObject() throws the correct error messages", () => {
+  {
+    const e = assertThrows(
+      () => expect({ a: 1 }).toMatchObject({ a: 2 }),
+      Error,
+    );
+    assertNotMatch(e.message, /NOT/);
+  }
+  {
+    const e = assertThrows(
+      () => expect({ a: 1 }).not.toMatchObject({ a: 1 }),
+      Error,
+    );
+    assertMatch(e.message, /NOT/);
+  }
 });


### PR DESCRIPTION
Matcher `toMatchObject` throws the same error message when it called with `.not` and without `.not`.

Without `.not`:

```ts
it("toMatchObject without not", () => {
  expect({ foo: 0 }).toMatchObject({ foo: 1 });
});
```

Error:

```
error: AssertionError: Expected {
  foo: 0,
} to NOT match {
  foo: 1,
}
```

With `.not`:

```ts
it("toMatchObject with not", () => {
  expect({ foo: 0 }).not.toMatchObject({ foo: 0 });
});
```

Error:

```
error: AssertionError: Expected {
  foo: 0,
} to NOT match {
  foo: 0,
}
```

Fixes #6224