### PR TITLE
test(fs): do not write files in source tree during test

### DIFF
--- a/fs/empty_dir_test.ts
+++ b/fs/empty_dir_test.ts
@@ -8,10 +8,9 @@ import {
 import * as path from "@std/path";
 import { emptyDir, emptyDirSync } from "./empty_dir.ts";
 
-const testdataDir = path.join(import.meta.dirname!, "testdata");
-
 Deno.test("emptyDir() creates a new dir if it does not exist", async function () {
-  const testDir = path.join(testdataDir, "empty_dir_test_1");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_empty_dir_" });
+  const testDir = path.join(tempDirPath, "empty_dir_test_1");
   const testNestDir = path.join(testDir, "nest");
   // empty a dir which not exist. then it will create new one
   await emptyDir(testNestDir);
@@ -21,13 +20,16 @@ Deno.test("emptyDir() creates a new dir if it does not exist", async function ()
     const stat = await Deno.stat(testNestDir);
     assertEquals(stat.isDirectory, true);
   } finally {
-    // remove the test dir
-    await Deno.remove(testDir, { recursive: true });
+    // Cleanup and remove test directories.
+    await Deno.remove(tempDirPath, { recursive: true });
   }
 });
 
 Deno.test("emptyDirSync() creates a new dir if it does not exist", function () {
-  const testDir = path.join(testdataDir, "empty_dir_test_2");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_empty_dir_sync_",
+  });
+  const testDir = path.join(tempDirPath, "empty_dir_test_2");
   const testNestDir = path.join(testDir, "nest");
   // empty a dir which does not exist, then it will a create new one.
   emptyDirSync(testNestDir);
@@ -37,13 +39,14 @@ Deno.test("emptyDirSync() creates a new dir if it does not exist", function () {
     const stat = Deno.statSync(testNestDir);
     assertEquals(stat.isDirectory, true);
   } finally {
-    // remove the test dir
-    Deno.removeSync(testDir, { recursive: true });
+    // Cleanup and remove test directories.
+    Deno.removeSync(tempDirPath, { recursive: true });
   }
 });
 
 Deno.test("emptyDir() empties nested dirs and files", async function () {
-  const testDir = path.join(testdataDir, "empty_dir_test_3");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_empty_dir_" });
+  const testDir = path.join(tempDirPath, "empty_dir_test_3");
   const testNestDir = path.join(testDir, "nest");
   // create test dir
   await emptyDir(testNestDir);
@@ -80,13 +83,16 @@ Deno.test("emptyDir() empties nested dirs and files", async function () {
       },
     );
   } finally {
-    // remote test dir
-    await Deno.remove(testDir, { recursive: true });
+    // Cleanup and remove test directory.
+    await Deno.remove(tempDirPath, { recursive: true });
   }
 });
 
 Deno.test("emptyDirSync() empties nested dirs and files", function () {
-  const testDir = path.join(testdataDir, "empty_dir_test_4");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_empty_dir_sync_",
+  });
+  const testDir = path.join(tempDirPath, "empty_dir_test_4");
   const testNestDir = path.join(testDir, "nest");
   // create test dir
   emptyDirSync(testNestDir);
@@ -119,11 +125,14 @@ Deno.test("emptyDirSync() empties nested dirs and files", function () {
       Deno.statSync(testDirFile);
     });
   } finally {
-    // remote test dir
-    Deno.removeSync(testDir, { recursive: true });
+    // Cleanup and remove test directory.
+    Deno.removeSync(tempDirPath, { recursive: true });
   }
 });
 
+// Testing the permissions of emptyDir and emptyDirSync functions in a script
+// that is running inside a Deno child process.
+const testdataDir = path.join(import.meta.dirname!, "testdata");
 interface Scenes {
   read: boolean; // --allow-read
   write: boolean; // --allow-write
@@ -191,9 +200,11 @@ for (const s of scenes) {
   Deno.test(`${title} permission`, async function (): Promise<
     void
   > {
-    const testfolder = path.join(testdataDir, "testfolder");
-
+    const tempDirPath = await Deno.makeTempDir({
+      prefix: "deno_std_empty_dir_permissions_",
+    });
     try {
+      const testfolder = path.join(tempDirPath, "testfolder");
       await Deno.mkdir(testfolder);
 
       await Deno.writeTextFile(
@@ -224,6 +235,10 @@ for (const s of scenes) {
           ),
         );
 
+        // Passing the testfolder path as an argument to empty_dir.ts and
+        // empty_dir_sync.ts scripts.
+        args.push(testfolder);
+
         const command = new Deno.Command(Deno.execPath(), {
           args,
           stderr: "inherit",
@@ -233,13 +248,13 @@ for (const s of scenes) {
       } catch (err) {
         // deno-lint-ignore no-console
         console.log(err);
-        await Deno.remove(testfolder, { recursive: true });
+        await Deno.remove(tempDirPath, { recursive: true });
         throw err;
       }
     } finally {
       // Make the test rerunnable
       // Otherwise it would throw an error due to mkdir fail.
-      await Deno.remove(testfolder, { recursive: true });
+      await Deno.remove(tempDirPath, { recursive: true });
       // done
     }
   });

--- a/fs/ensure_dir_test.ts
+++ b/fs/ensure_dir_test.ts
@@ -1,7 +1,6 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 import { assertEquals, assertRejects, assertThrows } from "@std/assert";
 import * as path from "@std/path";
-import { copy, copySync } from "./copy.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 import { IS_DENO_2 } from "../internal/_is_deno_2.ts";
@@ -84,13 +83,7 @@ Deno.test("ensureDirSync() ensures existing dir exists", function () {
 });
 
 Deno.test("ensureDir() accepts links to dirs", async function () {
-  const tempDirPath = await Deno.makeTempDir({
-    prefix: "deno_std_ensure_dir_",
-  });
-  // Copy ensure_dir and contents into temporary directory.
-  const tempEnsureDir = path.join(tempDirPath, "ensure_dir");
-  await copy(testdataDir, tempEnsureDir);
-  const ldir = path.join(tempEnsureDir, "ldir");
+  const ldir = path.join(testdataDir, "ldir");
 
   await ensureDir(ldir);
 
@@ -99,18 +92,10 @@ Deno.test("ensureDir() accepts links to dirs", async function () {
   // ldir should be still be a symlink
   const { isSymlink } = await Deno.lstat(ldir);
   assertEquals(isSymlink, true);
-
-  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureDirSync() accepts links to dirs", function () {
-  const tempDirPath = Deno.makeTempDirSync({
-    prefix: "deno_std_ensure_dir_sync_",
-  });
-  // Copy ensure_dir and contents into temporary directory.
-  const tempEnsureDir = path.join(tempDirPath, "ensure_dir");
-  copySync(testdataDir, tempEnsureDir);
-  const ldir = path.join(tempEnsureDir, "ldir");
+  const ldir = path.join(testdataDir, "ldir");
 
   ensureDirSync(ldir);
 
@@ -119,8 +104,6 @@ Deno.test("ensureDirSync() accepts links to dirs", function () {
   // ldir should be still be a symlink
   const { isSymlink } = Deno.lstatSync(ldir);
   assertEquals(isSymlink, true);
-
-  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureDir() rejects if input is a file", async function () {
@@ -168,13 +151,7 @@ Deno.test("ensureDirSync() throws if input is a file", function () {
 });
 
 Deno.test("ensureDir() rejects links to files", async function () {
-  const tempDirPath = await Deno.makeTempDir({
-    prefix: "deno_std_ensure_dir_",
-  });
-  // Copy ensure_dir and contents into temporary directory.
-  const tempEnsureDir = path.join(tempDirPath, "ensure_dir");
-  await copy(testdataDir, tempEnsureDir);
-  const lf = path.join(tempEnsureDir, "lf");
+  const lf = path.join(testdataDir, "lf");
 
   await assertRejects(
     async () => {
@@ -183,18 +160,10 @@ Deno.test("ensureDir() rejects links to files", async function () {
     Error,
     `Failed to ensure directory exists: expected 'dir', got 'file'`,
   );
-
-  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureDirSync() rejects links to files", function () {
-  const tempDirPath = Deno.makeTempDirSync({
-    prefix: "deno_std_ensure_dir_sync_",
-  });
-  // Copy ensure_dir and contents into temporary directory.
-  const tempEnsureDir = path.join(tempDirPath, "ensure_dir");
-  copySync(testdataDir, tempEnsureDir);
-  const lf = path.join(tempEnsureDir, "lf");
+  const lf = path.join(testdataDir, "lf");
 
   assertThrows(
     () => {
@@ -203,8 +172,6 @@ Deno.test("ensureDirSync() rejects links to files", function () {
     Error,
     `Failed to ensure directory exists: expected 'dir', got 'file'`,
   );
-
-  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test({
@@ -252,11 +219,8 @@ Deno.test({
   name: "ensureDir() isn't racy",
   async fn() {
     for (const _ of Array(100)) {
-      const tempDirPath = await Deno.makeTempDir({
-        prefix: "deno_std_ensure_dir_",
-      });
       const dir = path.join(
-        tempDirPath,
+        await Deno.makeTempDir(),
         "check",
         "race",
       );
@@ -266,8 +230,6 @@ Deno.test({
         ensureDir(dir),
         ensureDir(dir),
       ]);
-
-      await Deno.remove(tempDirPath, { recursive: true });
     }
   },
 });

--- a/fs/ensure_file_test.ts
+++ b/fs/ensure_file_test.ts
@@ -8,7 +8,10 @@ const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("ensureFile() creates file if it does not exist", async function () {
-  const testDir = path.join(testdataDir, "ensure_file_1");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_file_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_file_1");
   const testFile = path.join(testDir, "test.txt");
 
   try {
@@ -17,12 +20,15 @@ Deno.test("ensureFile() creates file if it does not exist", async function () {
     // test file should exists.
     await Deno.stat(testFile);
   } finally {
-    await Deno.remove(testDir, { recursive: true });
+    await Deno.remove(tempDirPath, { recursive: true });
   }
 });
 
 Deno.test("ensureFileSync() creates file if it does not exist", function () {
-  const testDir = path.join(testdataDir, "ensure_file_2");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_file_sync_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_file_2");
   const testFile = path.join(testDir, "test.txt");
 
   try {
@@ -31,12 +37,15 @@ Deno.test("ensureFileSync() creates file if it does not exist", function () {
     // test file should exists.
     Deno.statSync(testFile);
   } finally {
-    Deno.removeSync(testDir, { recursive: true });
+    Deno.removeSync(tempDirPath, { recursive: true });
   }
 });
 
 Deno.test("ensureFile() ensures existing file exists", async function () {
-  const testDir = path.join(testdataDir, "ensure_file_3");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_file_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_file_3");
   const testFile = path.join(testDir, "test.txt");
 
   try {
@@ -48,12 +57,15 @@ Deno.test("ensureFile() ensures existing file exists", async function () {
     // test file should exists.
     await Deno.stat(testFile);
   } finally {
-    await Deno.remove(testDir, { recursive: true });
+    await Deno.remove(tempDirPath, { recursive: true });
   }
 });
 
 Deno.test("ensureFileSync() ensures existing file exists", function () {
-  const testDir = path.join(testdataDir, "ensure_file_4");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_file_sync_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_file_4");
   const testFile = path.join(testDir, "test.txt");
 
   try {
@@ -65,12 +77,15 @@ Deno.test("ensureFileSync() ensures existing file exists", function () {
     // test file should exists.
     Deno.statSync(testFile);
   } finally {
-    Deno.removeSync(testDir, { recursive: true });
+    Deno.removeSync(tempDirPath, { recursive: true });
   }
 });
 
 Deno.test("ensureFile() rejects if input is dir", async function () {
-  const testDir = path.join(testdataDir, "ensure_file_5");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_file_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_file_5");
 
   try {
     await Deno.mkdir(testDir, { recursive: true });
@@ -83,12 +98,15 @@ Deno.test("ensureFile() rejects if input is dir", async function () {
       `Failed to ensure file exists: expected 'file', got 'dir'`,
     );
   } finally {
-    await Deno.remove(testDir, { recursive: true });
+    await Deno.remove(tempDirPath, { recursive: true });
   }
 });
 
 Deno.test("ensureFileSync() throws if input is dir", function () {
-  const testDir = path.join(testdataDir, "ensure_file_6");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_file_sync_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_file_6");
 
   try {
     Deno.mkdirSync(testDir, { recursive: true });
@@ -101,7 +119,7 @@ Deno.test("ensureFileSync() throws if input is dir", function () {
       `Failed to ensure file exists: expected 'file', got 'dir'`,
     );
   } finally {
-    Deno.removeSync(testDir, { recursive: true });
+    Deno.removeSync(tempDirPath, { recursive: true });
   }
 });
 
@@ -150,14 +168,14 @@ Deno.test({
     "ensureFile() can write file without write permissions on parent directory",
   permissions: {
     read: true,
-    write: [
-      path.join(testdataDir, "ensure_file_9"),
-      path.join(testdataDir, "ensure_file_9", "test.txt"),
-    ],
+    write: true,
     run: [Deno.execPath()],
   },
   async fn() {
-    const testDir = path.join(testdataDir, "ensure_file_9");
+    const tempDirPath = await Deno.makeTempDir({
+      prefix: "deno_std_ensure_file_",
+    });
+    const testDir = path.join(tempDirPath, "ensure_file_9");
     const testFile = path.join(testDir, "test.txt");
 
     try {
@@ -178,6 +196,7 @@ Deno.test({
           `Deno.removeSync("${testDir}", { recursive: true });`,
         ],
       }).output();
+      await Deno.remove(tempDirPath, { recursive: true });
     }
   },
 });
@@ -187,14 +206,14 @@ Deno.test({
     "ensureFileSync() can write file without write permissions on parent directory",
   permissions: {
     read: true,
-    write: [
-      path.join(testdataDir, "ensure_file_10"),
-      path.join(testdataDir, "ensure_file_10", "test.txt"),
-    ],
+    write: true,
     run: [Deno.execPath()],
   },
   fn() {
-    const testDir = path.join(testdataDir, "ensure_file_10");
+    const tempDirPath = Deno.makeTempDirSync({
+      prefix: "deno_std_ensure_file_sync_",
+    });
+    const testDir = path.join(tempDirPath, "ensure_file_10");
     const testFile = path.join(testDir, "test.txt");
 
     try {
@@ -215,6 +234,7 @@ Deno.test({
           `Deno.removeSync("${testDir}", { recursive: true });`,
         ],
       }).outputSync();
+      Deno.removeSync(tempDirPath, { recursive: true });
     }
   },
 });

--- a/fs/ensure_link_test.ts
+++ b/fs/ensure_link_test.ts
@@ -8,8 +8,11 @@ const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("ensureLink() rejects if src and dest do not exist", async function () {
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_link_",
+  });
   const srcDir = path.join(testdataDir, "ensure_link_1");
-  const destDir = path.join(testdataDir, "ensure_link_1_2");
+  const destDir = path.join(tempDirPath, "ensure_link_1_2");
   const testFile = path.join(srcDir, "test.txt");
   const linkFile = path.join(destDir, "link.txt");
 
@@ -19,11 +22,14 @@ Deno.test("ensureLink() rejects if src and dest do not exist", async function ()
     },
   );
 
-  await Deno.remove(destDir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureLinkSync() throws if src and dest do not exist", function () {
-  const testDir = path.join(testdataDir, "ensure_link_2");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_link_sync_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_link_2");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
 
@@ -31,11 +37,14 @@ Deno.test("ensureLinkSync() throws if src and dest do not exist", function () {
     ensureLinkSync(testFile, linkFile);
   });
 
-  Deno.removeSync(testDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureLink() ensures dest links to the src", async function () {
-  const testDir = path.join(testdataDir, "ensure_link_3");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_link_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_link_3");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
 
@@ -70,11 +79,14 @@ Deno.test("ensureLink() ensures dest links to the src", async function () {
   assertEquals(testFileContent2, "abc");
   assertEquals(testFileContent2, linkFileContent2);
 
-  await Deno.remove(testDir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureLinkSync() ensures dest links to the src", function () {
-  const testDir = path.join(testdataDir, "ensure_link_4");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_link_sync_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_link_4");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
 
@@ -118,12 +130,15 @@ Deno.test("ensureLinkSync() ensures dest links to the src", function () {
   assertEquals(testFileContent2, "abc");
   assertEquals(testFileContent2, linkFileContent2);
 
-  Deno.removeSync(testDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureLink() rejects if link does not exist", async function () {
-  const testDir = path.join(testdataDir, "ensure_link_origin_3");
-  const linkDir = path.join(testdataDir, "ensure_link_link_3");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_link_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_link_origin_3");
+  const linkDir = path.join(tempDirPath, "ensure_link_link_3");
   const testFile = path.join(testDir, "test.txt");
 
   await Deno.mkdir(testDir, { recursive: true });
@@ -137,12 +152,15 @@ Deno.test("ensureLink() rejects if link does not exist", async function () {
     // "Access is denied. (os error 5)" // throw in CI
   );
 
-  await Deno.remove(testDir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureLinkSync() throws if link does not exist", function () {
-  const testDir = path.join(testdataDir, "ensure_link_origin_3");
-  const linkDir = path.join(testdataDir, "ensure_link_link_3");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_link_sync_",
+  });
+  const testDir = path.join(tempDirPath, "ensure_link_origin_3");
+  const linkDir = path.join(tempDirPath, "ensure_link_link_3");
   const testFile = path.join(testDir, "test.txt");
 
   Deno.mkdirSync(testDir, { recursive: true });
@@ -156,5 +174,5 @@ Deno.test("ensureLinkSync() throws if link does not exist", function () {
     // "Access is denied. (os error 5)" // throw in CI
   );
 
-  Deno.removeSync(testDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });

--- a/fs/ensure_symlink_test.ts
+++ b/fs/ensure_symlink_test.ts
@@ -15,7 +15,10 @@ const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
 const testdataDir = path.resolve(moduleDir, "testdata");
 
 Deno.test("ensureSymlink() rejects if file does not exist", async function () {
-  const testDir = path.join(testdataDir, "link_file_1");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_symlink_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_1");
   const testFile = path.join(testDir, "test.txt");
 
   await assertRejects(
@@ -31,10 +34,15 @@ Deno.test("ensureSymlink() rejects if file does not exist", async function () {
       });
     },
   );
+
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlinkSync() throws if file does not exist", function () {
-  const testDir = path.join(testdataDir, "link_file_2");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_symlink_sync_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_2");
   const testFile = path.join(testDir, "test.txt");
 
   assertThrows(() => {
@@ -45,10 +53,15 @@ Deno.test("ensureSymlinkSync() throws if file does not exist", function () {
     Deno.statSync(testFile);
     throw new Error("test file should exist.");
   });
+
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlink() ensures linkName links to target", async function () {
-  const testDir = path.join(testdataDir, "link_file_3");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_symlink_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_3");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
 
@@ -64,11 +77,14 @@ Deno.test("ensureSymlink() ensures linkName links to target", async function () 
   assertEquals(srcStat.isFile, true);
   assertEquals(linkStat.isSymlink, true);
 
-  await Deno.remove(testDir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlinkSync() ensures linkName links to target", function () {
-  const testDir = path.join(testdataDir, "link_file_4");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_symlink_sync_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_4");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
 
@@ -84,11 +100,14 @@ Deno.test("ensureSymlinkSync() ensures linkName links to target", function () {
   assertEquals(srcStat.isFile, true);
   assertEquals(linkStat.isSymlink, true);
 
-  Deno.removeSync(testDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlink() rejects if the linkName path already exist", async function () {
-  const testDir = path.join(testdataDir, "link_file_5");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_symlink_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_5");
   const linkFile = path.join(testDir, "test.txt");
   const linkDir = path.join(testDir, "test_dir");
   const linkSymlink = path.join(testDir, "test_symlink");
@@ -121,11 +140,14 @@ Deno.test("ensureSymlink() rejects if the linkName path already exist", async fu
   assertEquals(await Deno.readLink(linkSymlink), "non-existent");
   assertEquals(await Deno.readTextFile(targetFile), "targetFile");
 
-  await Deno.remove(testDir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlinkSync() throws if the linkName path already exist", function () {
-  const testDir = path.join(testdataDir, "link_file_6");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_symlink_sync_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_6");
   const linkFile = path.join(testDir, "test.txt");
   const linkDir = path.join(testDir, "test_dir");
   const linkSymlink = path.join(testDir, "test_symlink");
@@ -152,12 +174,15 @@ Deno.test("ensureSymlinkSync() throws if the linkName path already exist", funct
   assertEquals(Deno.readLinkSync(linkSymlink), "non-existent");
   assertEquals(Deno.readTextFileSync(targetFile), "targetFile");
 
-  Deno.removeSync(testDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlink() ensures dir linkName links to dir target", async function () {
-  const testDir = path.join(testdataDir, "link_file_origin_3");
-  const linkDir = path.join(testdataDir, "link_file_link_3");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_symlink_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_origin_3");
+  const linkDir = path.join(tempDirPath, "link_file_link_3");
   const testFile = path.join(testDir, "test.txt");
 
   await Deno.mkdir(testDir, { recursive: true });
@@ -174,13 +199,15 @@ Deno.test("ensureSymlink() ensures dir linkName links to dir target", async func
   assertEquals(testDirStat.isDirectory, true);
   assertEquals(linkDirStat.isSymlink, true);
 
-  await Deno.remove(linkDir, { recursive: true });
-  await Deno.remove(testDir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlinkSync() ensures dir linkName links to dir target", function () {
-  const testDir = path.join(testdataDir, "link_file_origin_3");
-  const linkDir = path.join(testdataDir, "link_file_link_3");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_symlink_sync_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_origin_3");
+  const linkDir = path.join(tempDirPath, "link_file_link_3");
   const testFile = path.join(testDir, "test.txt");
 
   Deno.mkdirSync(testDir, { recursive: true });
@@ -197,12 +224,14 @@ Deno.test("ensureSymlinkSync() ensures dir linkName links to dir target", functi
   assertEquals(testDirStat.isDirectory, true);
   assertEquals(linkDirStat.isSymlink, true);
 
-  Deno.removeSync(linkDir, { recursive: true });
-  Deno.removeSync(testDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlink() creates symlink with relative target", async function () {
-  const testDir = path.join(testdataDir, "symlink-relative");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_symlink_",
+  });
+  const testDir = path.join(tempDirPath, "symlink-relative");
   const testLinkName = path.join(testDir, "link.txt");
   const testFile = path.join(testDir, "target.txt");
 
@@ -220,11 +249,14 @@ Deno.test("ensureSymlink() creates symlink with relative target", async function
   assertEquals(testDirStat.isDirectory, true);
   assertEquals(linkDirStat.isSymlink, true);
 
-  await Deno.remove(testDir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlinkSync() creates symlink with relative target", function () {
-  const testDir = path.join(testdataDir, "symlink-relative-sync");
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_ensure_symlink_sync_",
+  });
+  const testDir = path.join(tempDirPath, "symlink-relative-sync");
   const testLinkName = path.join(testDir, "link.txt");
   const testFile = path.join(testDir, "target.txt");
 
@@ -242,7 +274,7 @@ Deno.test("ensureSymlinkSync() creates symlink with relative target", function (
   assertEquals(testDirStat.isDirectory, true);
   assertEquals(linkDirStat.isSymlink, true);
 
-  Deno.removeSync(testDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("ensureSymlink() rejects when the target path doesn't exist", async () => {
@@ -272,7 +304,10 @@ Deno.test("ensureSymlink() works with URLs", {
   // TODO(kt3k): The 2nd test case doesn't pass on Windows. Fix it.
   ignore: Deno.build.os === "windows",
 }, async () => {
-  const testDir = path.join(testdataDir, "link_file_with_url");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_ensure_symlink_",
+  });
+  const testDir = path.join(tempDirPath, "link_file_with_url");
   const testFile = path.join(testDir, "test.txt");
   const linkFile = path.join(testDir, "link.txt");
   {
@@ -308,6 +343,7 @@ Deno.test("ensureSymlink() works with URLs", {
       await Deno.remove(testDir, { recursive: true });
     }
   }
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test(

--- a/fs/move_test.ts
+++ b/fs/move_test.ts
@@ -6,23 +6,24 @@ import { ensureFile, ensureFileSync } from "./ensure_file.ts";
 import { ensureDir, ensureDirSync } from "./ensure_dir.ts";
 import { existsSync } from "./exists.ts";
 
-const moduleDir = path.dirname(path.fromFileUrl(import.meta.url));
-const testdataDir = path.resolve(moduleDir, "testdata");
-
 Deno.test("move() rejects if src dir does not exist", async function () {
-  const srcDir = path.join(testdataDir, "move_test_src_1");
-  const destDir = path.join(testdataDir, "move_test_dest_1");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+  const srcDir = path.join(tempDirPath, "move_test_src_1");
+  const destDir = path.join(tempDirPath, "move_test_dest_1");
   // if src directory not exist
   await assertRejects(
     async () => {
       await move(srcDir, destDir);
     },
   );
+
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("move() creates dest dir if it does not exist", async function () {
-  const srcDir = path.join(testdataDir, "move_test_src_2");
-  const destDir = path.join(testdataDir, "move_test_dest_2");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+  const srcDir = path.join(tempDirPath, "move_test_src_2");
+  const destDir = path.join(tempDirPath, "move_test_dest_2");
 
   await Deno.mkdir(srcDir, { recursive: true });
 
@@ -36,14 +37,15 @@ Deno.test("move() creates dest dir if it does not exist", async function () {
     "should not throw error",
   );
 
-  await Deno.remove(destDir);
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test(
   "move() creates dest dir if it does not exist and overwrite option is set to true",
   async function () {
-    const srcDir = path.join(testdataDir, "move_test_src_2");
-    const destDir = path.join(testdataDir, "move_test_dest_2");
+    const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+    const srcDir = path.join(tempDirPath, "move_test_src_2");
+    const destDir = path.join(tempDirPath, "move_test_dest_2");
 
     await Deno.mkdir(srcDir, { recursive: true });
 
@@ -57,13 +59,14 @@ Deno.test(
       "should not throw error",
     );
 
-    await Deno.remove(destDir);
+    await Deno.remove(tempDirPath, { recursive: true });
   },
 );
 
 Deno.test("move() rejects if src file does not exist", async function () {
-  const srcFile = path.join(testdataDir, "move_test_src_3", "test.txt");
-  const destFile = path.join(testdataDir, "move_test_dest_3", "test.txt");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+  const srcFile = path.join(tempDirPath, "move_test_src_3", "test.txt");
+  const destFile = path.join(tempDirPath, "move_test_dest_3", "test.txt");
 
   // if src directory not exist
   await assertRejects(
@@ -71,11 +74,14 @@ Deno.test("move() rejects if src file does not exist", async function () {
       await move(srcFile, destFile);
     },
   );
+
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("move() moves file and can overwrite content", async function () {
-  const srcDir = path.join(testdataDir, "move_test_src_4");
-  const destDir = path.join(testdataDir, "move_test_dest_4");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+  const srcDir = path.join(tempDirPath, "move_test_src_4");
+  const destDir = path.join(tempDirPath, "move_test_dest_4");
   const srcFile = path.join(srcDir, "test.txt");
   const destFile = path.join(destDir, "test.txt");
   const srcContent = new TextEncoder().encode("src");
@@ -121,11 +127,13 @@ Deno.test("move() moves file and can overwrite content", async function () {
     Deno.remove(srcDir, { recursive: true }),
     Deno.remove(destDir, { recursive: true }),
   ]);
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("move() moves dir", async function () {
-  const srcDir = path.join(testdataDir, "move_test_src_5");
-  const destDir = path.join(testdataDir, "move_test_dest_5");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+  const srcDir = path.join(tempDirPath, "move_test_src_5");
+  const destDir = path.join(tempDirPath, "move_test_dest_5");
   const srcFile = path.join(srcDir, "test.txt");
   const destFile = path.join(destDir, "test.txt");
   const srcContent = new TextEncoder().encode("src");
@@ -143,14 +151,15 @@ Deno.test("move() moves dir", async function () {
   const destFileContent = await Deno.readTextFile(destFile);
   assertEquals(destFileContent, "src");
 
-  await Deno.remove(destDir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test(
   "move() moves files if src and dest exist and can overwrite content",
   async function () {
-    const srcDir = path.join(testdataDir, "move_test_src_6");
-    const destDir = path.join(testdataDir, "move_test_dest_6");
+    const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+    const srcDir = path.join(tempDirPath, "move_test_src_6");
+    const destDir = path.join(tempDirPath, "move_test_dest_6");
     const srcFile = path.join(srcDir, "test.txt");
     const destFile = path.join(destDir, "test.txt");
     const srcContent = new TextEncoder().encode("src");
@@ -176,12 +185,13 @@ Deno.test(
     const destFileContent = await Deno.readTextFile(destFile);
     assertEquals(destFileContent, "src");
 
-    await Deno.remove(destDir, { recursive: true });
+    await Deno.remove(tempDirPath, { recursive: true });
   },
 );
 
 Deno.test("move() rejects when dest is its own sub dir", async function () {
-  const srcDir = path.join(testdataDir, "move_test_src_7");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+  const srcDir = path.join(tempDirPath, "move_test_src_7");
   const destDir = path.join(srcDir, "nest");
 
   await ensureDir(destDir);
@@ -193,21 +203,25 @@ Deno.test("move() rejects when dest is its own sub dir", async function () {
     Error,
     `Cannot move '${srcDir}' to a subdirectory of itself, '${destDir}'.`,
   );
-  await Deno.remove(srcDir, { recursive: true });
+
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() throws if src dir does not exist", function () {
-  const srcDir = path.join(testdataDir, "move_sync_test_src_1");
-  const destDir = path.join(testdataDir, "move_sync_test_dest_1");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const srcDir = path.join(tempDirPath, "move_sync_test_src_1");
+  const destDir = path.join(tempDirPath, "move_sync_test_dest_1");
   // if src directory not exist
   assertThrows(() => {
     moveSync(srcDir, destDir);
   });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() creates dest dir if it does not exist", function () {
-  const srcDir = path.join(testdataDir, "move_sync_test_src_2");
-  const destDir = path.join(testdataDir, "move_sync_test_dest_2");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const srcDir = path.join(tempDirPath, "move_sync_test_src_2");
+  const destDir = path.join(tempDirPath, "move_sync_test_dest_2");
 
   Deno.mkdirSync(srcDir, { recursive: true });
 
@@ -221,12 +235,13 @@ Deno.test("moveSync() creates dest dir if it does not exist", function () {
     "should not throw error",
   );
 
-  Deno.removeSync(destDir);
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() creates dest dir if it does not exist and overwrite option is set to true", function () {
-  const srcDir = path.join(testdataDir, "move_sync_test_src_2");
-  const destDir = path.join(testdataDir, "move_sync_test_dest_2");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const srcDir = path.join(tempDirPath, "move_sync_test_src_2");
+  const destDir = path.join(tempDirPath, "move_sync_test_dest_2");
 
   Deno.mkdirSync(srcDir, { recursive: true });
 
@@ -240,22 +255,25 @@ Deno.test("moveSync() creates dest dir if it does not exist and overwrite option
     "should not throw error",
   );
 
-  Deno.removeSync(destDir);
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() throws if src file does not exist", function () {
-  const srcFile = path.join(testdataDir, "move_sync_test_src_3", "test.txt");
-  const destFile = path.join(testdataDir, "move_sync_test_dest_3", "test.txt");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const srcFile = path.join(tempDirPath, "move_sync_test_src_3", "test.txt");
+  const destFile = path.join(tempDirPath, "move_sync_test_dest_3", "test.txt");
 
   // if src directory not exist
   assertThrows(() => {
     moveSync(srcFile, destFile);
   });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() moves file and can overwrite content", function () {
-  const srcDir = path.join(testdataDir, "move_sync_test_src_4");
-  const destDir = path.join(testdataDir, "move_sync_test_dest_4");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const srcDir = path.join(tempDirPath, "move_sync_test_src_4");
+  const destDir = path.join(tempDirPath, "move_sync_test_dest_4");
   const srcFile = path.join(srcDir, "test.txt");
   const destFile = path.join(destDir, "test.txt");
   const srcContent = new TextEncoder().encode("src");
@@ -296,13 +314,13 @@ Deno.test("moveSync() moves file and can overwrite content", function () {
   assertEquals(new TextDecoder().decode(Deno.readFileSync(destFile)), "src");
 
   // clean up
-  Deno.removeSync(srcDir, { recursive: true });
-  Deno.removeSync(destDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() moves dir", function () {
-  const srcDir = path.join(testdataDir, "move_sync_test_src_5");
-  const destDir = path.join(testdataDir, "move_sync_test_dest_5");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const srcDir = path.join(tempDirPath, "move_sync_test_src_5");
+  const destDir = path.join(tempDirPath, "move_sync_test_dest_5");
   const srcFile = path.join(srcDir, "test.txt");
   const destFile = path.join(destDir, "test.txt");
   const srcContent = new TextEncoder().encode("src");
@@ -320,12 +338,13 @@ Deno.test("moveSync() moves dir", function () {
   const destFileContent = new TextDecoder().decode(Deno.readFileSync(destFile));
   assertEquals(destFileContent, "src");
 
-  Deno.removeSync(destDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() moves files if src and dest exist and can overwrite content", function () {
-  const srcDir = path.join(testdataDir, "move_sync_test_src_6");
-  const destDir = path.join(testdataDir, "move_sync_test_dest_6");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const srcDir = path.join(tempDirPath, "move_sync_test_src_6");
+  const destDir = path.join(tempDirPath, "move_sync_test_dest_6");
   const srcFile = path.join(srcDir, "test.txt");
   const destFile = path.join(destDir, "test.txt");
   const srcContent = new TextEncoder().encode("src");
@@ -347,11 +366,12 @@ Deno.test("moveSync() moves files if src and dest exist and can overwrite conten
   const destFileContent = new TextDecoder().decode(Deno.readFileSync(destFile));
   assertEquals(destFileContent, "src");
 
-  Deno.removeSync(destDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() throws when dest is its own sub dir", function () {
-  const srcDir = path.join(testdataDir, "move_sync_test_src_7");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const srcDir = path.join(tempDirPath, "move_sync_test_src_7");
   const destDir = path.join(srcDir, "nest");
 
   ensureDirSync(destDir);
@@ -363,11 +383,12 @@ Deno.test("moveSync() throws when dest is its own sub dir", function () {
     Error,
     `Cannot move '${srcDir}' to a subdirectory of itself, '${destDir}'.`,
   );
-  Deno.removeSync(srcDir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("move() accepts overwrite option set to true for file content", async function () {
-  const dir = path.join(testdataDir, "move_same_file_1");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+  const dir = path.join(tempDirPath, "move_same_file_1");
   const file = path.join(dir, "test.txt");
   const url = path.toFileUrl(file);
   const content = new TextEncoder().encode("test");
@@ -393,11 +414,12 @@ Deno.test("move() accepts overwrite option set to true for file content", async 
     assertEquals(await Deno.readTextFile(src), "test");
   }
 
-  await Deno.remove(dir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("move() accepts overwrite option set to true for directories", async function () {
-  const dir = path.join(testdataDir, "move_same_dir_1");
+  const tempDirPath = await Deno.makeTempDir({ prefix: "deno_std_move_" });
+  const dir = path.join(tempDirPath, "move_same_dir_1");
   const url = path.toFileUrl(dir);
 
   // Make sure test dir exists
@@ -425,11 +447,12 @@ Deno.test("move() accepts overwrite option set to true for directories", async f
     );
   }
 
-  await Deno.remove(dir, { recursive: true });
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
 Deno.test("moveSync() accepts overwrite option set to true for file content", function () {
-  const dir = path.join(testdataDir, "move_sync_same_file_1");
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const dir = path.join(tempDirPath, "move_sync_same_file_1");
   const file = path.join(dir, "test.txt");
   const url = path.toFileUrl(file);
   const content = new TextEncoder().encode("test");
@@ -455,11 +478,12 @@ Deno.test("moveSync() accepts overwrite option set to true for file content", fu
     assertEquals(Deno.readTextFileSync(src), "test");
   }
 
-  Deno.removeSync(dir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
-Deno.test("move() accepts overwrite option set to true for directories", function () {
-  const dir = path.join(testdataDir, "move_sync_same_dir_1");
+Deno.test("moveSync() accepts overwrite option set to true for directories", function () {
+  const tempDirPath = Deno.makeTempDirSync({ prefix: "deno_std_move_sync_" });
+  const dir = path.join(tempDirPath, "move_sync_same_dir_1");
   const url = path.toFileUrl(dir);
 
   // Make sure test dir exists
@@ -487,5 +511,5 @@ Deno.test("move() accepts overwrite option set to true for directories", functio
     );
   }
 
-  Deno.removeSync(dir, { recursive: true });
+  Deno.removeSync(tempDirPath, { recursive: true });
 });

--- a/fs/testdata/empty_dir.ts
+++ b/fs/testdata/empty_dir.ts
@@ -2,7 +2,8 @@
 import { emptyDir } from "../empty_dir.ts";
 
 try {
-  await emptyDir("fs/testdata/testfolder");
+  // Empty testfolder stored in Deno.args where the child.txt is located.
+  await emptyDir(Deno.args[0]!);
   console.log("success");
 } catch (error) {
   console.log(error);

--- a/fs/testdata/empty_dir_sync.ts
+++ b/fs/testdata/empty_dir_sync.ts
@@ -2,7 +2,8 @@
 import { emptyDirSync } from "../empty_dir.ts";
 
 try {
-  emptyDirSync("fs/testdata/testfolder");
+  // Empty testfolder stored in Deno.args where the child.txt is located.
+  emptyDirSync(Deno.args[0]!);
   console.log("success");
 } catch (error) {
   console.log(error);

--- a/fs/walk_test.ts
+++ b/fs/walk_test.ts
@@ -6,16 +6,18 @@ import {
   assertRejects,
   assertThrows,
 } from "@std/assert";
+import { copy, copySync } from "./copy.ts";
 import { fromFileUrl, resolve } from "@std/path";
 
 const testdataDir = resolve(fromFileUrl(import.meta.url), "../testdata/walk");
 
 async function assertWalkPaths(
+  parentDir: string,
   rootPath: string,
   expectedPaths: string[],
   options?: WalkOptions,
 ) {
-  const root = resolve(testdataDir, rootPath);
+  const root = resolve(parentDir, rootPath);
   const entries = await Array.fromAsync(walk(root, options));
 
   const expected = expectedPaths.map((path) => resolve(root, path));
@@ -24,11 +26,12 @@ async function assertWalkPaths(
 }
 
 function assertWalkSyncPaths(
+  parentDir: string,
   rootPath: string,
   expectedPaths: string[],
   options?: WalkOptions,
 ) {
-  const root = resolve(testdataDir, rootPath);
+  const root = resolve(parentDir, rootPath);
   const entriesSync = Array.from(walkSync(root, options));
 
   const expected = expectedPaths.map((path) => resolve(root, path));
@@ -37,126 +40,196 @@ function assertWalkSyncPaths(
 }
 
 Deno.test("walk() returns current dir for empty dir", async () => {
-  const emptyDir = resolve(testdataDir, "empty_dir");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_walk_",
+  });
+  const emptyDir = resolve(tempDirPath, "empty_dir");
   await Deno.mkdir(emptyDir);
-  await assertWalkPaths("empty_dir", ["."]);
-  await Deno.remove(emptyDir);
+  await assertWalkPaths(tempDirPath, "empty_dir", ["."]);
+  await Deno.remove(tempDirPath, { recursive: true });
 });
 
-Deno.test("walkSync() returns current dir for empty dir", async () => {
-  const emptyDir = resolve(testdataDir, "empty_dir");
-  await Deno.mkdir(emptyDir);
-  assertWalkSyncPaths("empty_dir", ["."]);
-  await Deno.remove(emptyDir);
+Deno.test("walkSync() returns current dir for empty dir", () => {
+  const tempDirPath = Deno.makeTempDirSync({
+    prefix: "deno_std_walk_sync_",
+  });
+  const emptyDir = resolve(tempDirPath, "empty_dir");
+  Deno.mkdirSync(emptyDir);
+  assertWalkSyncPaths(tempDirPath, "empty_dir", ["."]);
+  Deno.removeSync(tempDirPath, { recursive: true });
 });
 
 Deno.test("walk() returns current dir and single file", async () =>
-  await assertWalkPaths("single_file", [".", "x"]));
+  await assertWalkPaths(testdataDir, "single_file", [".", "x"]));
 
 Deno.test("walkSync() returns current dir and single file", () =>
-  assertWalkSyncPaths("single_file", [".", "x"]));
+  assertWalkSyncPaths(testdataDir, "single_file", [".", "x"]));
 
 Deno.test("walk() returns current dir, subdir, and nested file", async () =>
-  await assertWalkPaths("nested_single_file", [".", "a", "a/x"]));
+  await assertWalkPaths(testdataDir, "nested_single_file", [".", "a", "a/x"]));
 
 Deno.test("walkSync() returns current dir, subdir, and nested file", () =>
-  assertWalkSyncPaths("nested_single_file", [".", "a", "a/x"]));
+  assertWalkSyncPaths(testdataDir, "nested_single_file", [".", "a", "a/x"]));
 
 Deno.test("walk() accepts maxDepth option", async () =>
-  await assertWalkPaths("depth", [".", "a", "a/b", "a/b/c"], { maxDepth: 3 }));
+  await assertWalkPaths(testdataDir, "depth", [".", "a", "a/b", "a/b/c"], {
+    maxDepth: 3,
+  }));
 
 Deno.test("walkSync() accepts maxDepth option", () =>
-  assertWalkSyncPaths("depth", [".", "a", "a/b", "a/b/c"], { maxDepth: 3 }));
+  assertWalkSyncPaths(testdataDir, "depth", [".", "a", "a/b", "a/b/c"], {
+    maxDepth: 3,
+  }));
 
 Deno.test("walk() accepts includeDirs option set to false", async () =>
-  await assertWalkPaths("depth", ["a/b/c/d/x"], { includeDirs: false }));
+  await assertWalkPaths(testdataDir, "depth", ["a/b/c/d/x"], {
+    includeDirs: false,
+  }));
 
 Deno.test("walkSync() accepts includeDirs option set to false", () =>
-  assertWalkSyncPaths("depth", ["a/b/c/d/x"], { includeDirs: false }));
+  assertWalkSyncPaths(testdataDir, "depth", ["a/b/c/d/x"], {
+    includeDirs: false,
+  }));
 
 Deno.test("walk() accepts includeFiles option set to false", async () =>
-  await assertWalkPaths("depth", [".", "a", "a/b", "a/b/c", "a/b/c/d"], {
+  await assertWalkPaths(testdataDir, "depth", [
+    ".",
+    "a",
+    "a/b",
+    "a/b/c",
+    "a/b/c/d",
+  ], {
     includeFiles: false,
   }));
 
 Deno.test("walkSync() accepts includeFiles option set to false", () =>
-  assertWalkSyncPaths("depth", [".", "a", "a/b", "a/b/c", "a/b/c/d"], {
+  assertWalkSyncPaths(testdataDir, "depth", [
+    ".",
+    "a",
+    "a/b",
+    "a/b/c",
+    "a/b/c/d",
+  ], {
     includeFiles: false,
   }));
 
 Deno.test("walk() accepts ext option as strings", async () =>
-  await assertWalkPaths("ext", ["y.rs", "x.ts"], {
+  await assertWalkPaths(testdataDir, "ext", ["y.rs", "x.ts"], {
     exts: [".rs", ".ts"],
   }));
 
 Deno.test("walk() accepts ext option as strings (excluding period prefix)", async () =>
-  await assertWalkPaths("ext", ["y.rs", "x.ts"], {
+  await assertWalkPaths(testdataDir, "ext", ["y.rs", "x.ts"], {
     exts: ["rs", "ts"],
   }));
 
 Deno.test("walkSync() accepts ext option as strings", () =>
-  assertWalkSyncPaths("ext", ["y.rs", "x.ts"], {
+  assertWalkSyncPaths(testdataDir, "ext", ["y.rs", "x.ts"], {
     exts: [".rs", ".ts"],
   }));
 
 Deno.test("walkSync() accepts ext option as strings (excluding period prefix)", () =>
-  assertWalkSyncPaths("ext", ["y.rs", "x.ts"], {
+  assertWalkSyncPaths(testdataDir, "ext", ["y.rs", "x.ts"], {
     exts: [".rs", ".ts"],
   }));
 
 Deno.test("walk() accepts ext option as regExps", async () =>
-  await assertWalkPaths("match", ["x", "y"], {
+  await assertWalkPaths(testdataDir, "match", ["x", "y"], {
     match: [/x/, /y/],
   }));
 
 Deno.test("walkSync() accepts ext option as regExps", () =>
-  assertWalkSyncPaths("match", ["x", "y"], {
+  assertWalkSyncPaths(testdataDir, "match", ["x", "y"], {
     match: [/x/, /y/],
   }));
 
 Deno.test("walk() accepts skip option as regExps", async () =>
-  await assertWalkPaths("match", [".", "z"], {
+  await assertWalkPaths(testdataDir, "match", [".", "z"], {
     skip: [/x/, /y/],
   }));
 
 Deno.test("walkSync() accepts skip option as regExps", () =>
-  assertWalkSyncPaths("match", [".", "z"], {
+  assertWalkSyncPaths(testdataDir, "match", [".", "z"], {
     skip: [/x/, /y/],
   }));
 
 // https://github.com/denoland/deno_std/issues/1358
 Deno.test("walk() accepts followSymlinks option set to true", async () =>
-  await assertWalkPaths("symlink", [".", "a", "a/z", "a", "a/z", "x", "x"], {
+  await assertWalkPaths(testdataDir, "symlink", [
+    ".",
+    "a",
+    "a/z",
+    "a",
+    "a/z",
+    "x",
+    "x",
+  ], {
     followSymlinks: true,
   }));
 
 Deno.test("walkSync() accepts followSymlinks option set to true", () =>
-  assertWalkSyncPaths("symlink", [".", "a", "a/z", "a", "a/z", "x", "x"], {
+  assertWalkSyncPaths(testdataDir, "symlink", [
+    ".",
+    "a",
+    "a/z",
+    "a",
+    "a/z",
+    "x",
+    "x",
+  ], {
     followSymlinks: true,
   }));
 
 Deno.test("walk() accepts followSymlinks option set to true with canonicalize option set to false", async () =>
-  await assertWalkPaths("symlink", [".", "a", "a/z", "b", "b/z", "x", "y"], {
+  await assertWalkPaths(testdataDir, "symlink", [
+    ".",
+    "a",
+    "a/z",
+    "b",
+    "b/z",
+    "x",
+    "y",
+  ], {
     followSymlinks: true,
     canonicalize: false,
   }));
 
 Deno.test("walkSync() accepts followSymlinks option set to true with canonicalize option set to false", () =>
-  assertWalkSyncPaths("symlink", [".", "a", "a/z", "b", "b/z", "x", "y"], {
+  assertWalkSyncPaths(testdataDir, "symlink", [
+    ".",
+    "a",
+    "a/z",
+    "b",
+    "b/z",
+    "x",
+    "y",
+  ], {
     followSymlinks: true,
     canonicalize: false,
   }));
 
 Deno.test("walk() accepts followSymlinks option set to false", async () => {
-  await assertWalkPaths("symlink", [".", "a", "a/z", "b", "x", "y"], {
+  await assertWalkPaths(testdataDir, "symlink", [
+    ".",
+    "a",
+    "a/z",
+    "b",
+    "x",
+    "y",
+  ], {
     followSymlinks: false,
   });
 });
 
 Deno.test("walkSync() accepts followSymlinks option set to false", () => {
-  assertWalkSyncPaths("symlink", [".", "a", "a/z", "b", "x", "y"], {
-    followSymlinks: false,
-  });
+  assertWalkSyncPaths(
+    testdataDir,
+    "symlink",
+    [".", "a", "a/z", "b", "x", "y"],
+    {
+      followSymlinks: false,
+    },
+  );
 });
 
 Deno.test("walk() rejects Deno.errors.NotFound for non-existent root", async () => {
@@ -177,14 +250,23 @@ Deno.test({
   name: "walk() walks unix socket",
   ignore: Deno.build.os === "windows",
   async fn() {
-    const path = resolve(testdataDir, "socket", "a.sock");
+    const tempDirPath = await Deno.makeTempDir({
+      prefix: "deno_std_walk_",
+    });
+    // Copy contents from "walk/socket" into temporary directory.
+    await copy(resolve(testdataDir, "socket"), resolve(tempDirPath, "socket"));
+    const path = resolve(tempDirPath, "socket", "a.sock");
     try {
       using _listener = Deno.listen({ path, transport: "unix" });
-      await assertWalkPaths("socket", [".", "a.sock", ".gitignore"], {
+      await assertWalkPaths(tempDirPath, "socket", [
+        ".",
+        "a.sock",
+        ".gitignore",
+      ], {
         followSymlinks: true,
       });
     } finally {
-      await Deno.remove(path);
+      await Deno.remove(tempDirPath, { recursive: true });
     }
   },
 });
@@ -193,15 +275,25 @@ Deno.test({
 Deno.test({
   name: "walkSync() walks unix socket",
   ignore: Deno.build.os === "windows",
-  async fn() {
-    const path = resolve(testdataDir, "socket", "a.sock");
+  fn() {
+    const tempDirPath = Deno.makeTempDirSync({
+      prefix: "deno_std_walk_sync_",
+    });
+    // Copy contents from "walk/socket" into temporary directory.
+    copySync(resolve(testdataDir, "socket"), resolve(tempDirPath, "socket"));
+    const path = resolve(tempDirPath, "socket", "a.sock");
     try {
       using _listener = Deno.listen({ path, transport: "unix" });
-      assertWalkSyncPaths("socket", [".", "a.sock", ".gitignore"], {
-        followSymlinks: true,
-      });
+      assertWalkSyncPaths(
+        tempDirPath,
+        "socket",
+        [".", "a.sock", ".gitignore"],
+        {
+          followSymlinks: true,
+        },
+      );
     } finally {
-      await Deno.remove(path);
+      Deno.removeSync(tempDirPath, { recursive: true });
     }
   },
 });
@@ -210,32 +302,47 @@ Deno.test({
   name: "walk() walks fifo files on unix",
   ignore: Deno.build.os === "windows",
   async fn() {
+    const tempDirPath = await Deno.makeTempDir({
+      prefix: "deno_std_walk_",
+    });
+    // Copy contents from "walk/fifo" into temporary directory.
+    await copy(resolve(testdataDir, "fifo"), resolve(tempDirPath, "fifo"));
     const command = new Deno.Command("mkfifo", {
-      args: [resolve(testdataDir, "fifo", "fifo")],
+      args: [resolve(tempDirPath, "fifo", "fifo")],
     });
     await command.output();
-    await assertWalkPaths("fifo", [".", "fifo", ".gitignore"], {
+    await assertWalkPaths(tempDirPath, "fifo", [".", "fifo", ".gitignore"], {
       followSymlinks: true,
     });
+    await Deno.remove(tempDirPath, { recursive: true });
   },
 });
 
 Deno.test({
   name: "walkSync() walks fifo files on unix",
   ignore: Deno.build.os === "windows",
-  async fn() {
-    const command = new Deno.Command("mkfifo", {
-      args: [resolve(testdataDir, "fifo", "fifo")],
+  fn() {
+    const tempDirPath = Deno.makeTempDirSync({
+      prefix: "deno_std_walk_sync_",
     });
-    await command.output();
-    assertWalkSyncPaths("fifo", [".", "fifo", ".gitignore"], {
+    // Copy contents from "walk/fifo" into temporary directory.
+    copySync(resolve(testdataDir, "fifo"), resolve(tempDirPath, "fifo"));
+    const command = new Deno.Command("mkfifo", {
+      args: [resolve(tempDirPath, "fifo", "fifo")],
+    });
+    command.outputSync();
+    assertWalkSyncPaths(tempDirPath, "fifo", [".", "fifo", ".gitignore"], {
       followSymlinks: true,
     });
+    Deno.removeSync(tempDirPath, { recursive: true });
   },
 });
 
 Deno.test("walk() rejects with `Deno.errors.NotFound` when root is removed during execution", async () => {
-  const root = resolve(testdataDir, "error");
+  const tempDirPath = await Deno.makeTempDir({
+    prefix: "deno_std_walk_",
+  });
+  const root = resolve(tempDirPath, "error");
   await Deno.mkdir(root);
   try {
     await assertRejects(
@@ -250,5 +357,7 @@ Deno.test("walk() rejects with `Deno.errors.NotFound` when root is removed durin
   } catch (err) {
     await Deno.remove(root, { recursive: true });
     throw err;
+  } finally {
+    await Deno.remove(tempDirPath, { recursive: true });
   }
 });


### PR DESCRIPTION
This pull request addresses the issue of files and directories being created and written into the source tree while testing functions in the `fs` package. Creation of temporary directories were incorporated into the existing tests where applicable.    

Fixes #5358 . 