### PR TITLE
fix(testing): stop code execution in `describe.ignore`

### DIFF
--- a/testing/_test_suite.ts
+++ b/testing/_test_suite.ts
@@ -82,7 +82,40 @@ export class TestSuiteInternal<T> implements TestSuite<T> {
     this.symbol = Symbol();
     TestSuiteInternal.suites.set(this.symbol, this);
 
-    const { fn } = describe;
+    const { fn, ignore } = describe;
+    if (ignore) {
+      const {
+        name,
+        only,
+        permissions,
+        sanitizeExit,
+        sanitizeOps,
+        sanitizeResources,
+      } = describe;
+      const options: Deno.TestDefinition = {
+        name,
+        fn: async () => {},
+        ignore: true,
+      };
+      if (only !== undefined) {
+        options.only = only;
+      }
+      if (permissions !== undefined) {
+        options.permissions = permissions;
+      }
+      if (sanitizeExit !== undefined) {
+        options.sanitizeExit = sanitizeExit;
+      }
+      if (sanitizeOps !== undefined) {
+        options.sanitizeOps = sanitizeOps;
+      }
+      if (sanitizeResources !== undefined) {
+        options.sanitizeResources = sanitizeResources;
+      }
+      TestSuiteInternal.registerTest(options);
+      return;
+    }
+
     if (fn) {
       const temp = TestSuiteInternal.current;
       TestSuiteInternal.current = this;


### PR DESCRIPTION
In the current implementation, code inside a `describe` block is executed in every case, even when `describe.ignore` or `describe.skip` is used. This behavior is reflected in the following example and is currently tested as expected behavior:

Code:

```ts
describe.ignore("should ignore", () => {
  assert(false);
});
```

Error:

```sh
Uncaught error from ./main.ts FAILED

 ERRORS 

./main.ts (uncaught error)
error: (in promise) AssertionError
    throw new AssertionError(msg);
          ^
```

This happens because the describe block is treated as a list of steps rather than as a single step itself. In my implementation, all code inside a describe.ignore block is ignored.

Fixes #6233 