### PR TITLE
fix(assert): add formatting  for `assertNotEquals` error messages

### DIFF
--- a/assert/not_equals.ts
+++ b/assert/not_equals.ts
@@ -3,6 +3,7 @@
 
 import { equal } from "./equal.ts";
 import { AssertionError } from "./assertion_error.ts";
+import { format } from "@std/internal/format";
 
 /**
  * Make an assertion that `actual` and `expected` are not equal, deeply.
@@ -27,8 +28,8 @@ export function assertNotEquals<T>(actual: T, expected: T, msg?: string) {
   if (!equal(actual, expected)) {
     return;
   }
-  const actualString = String(actual);
-  const expectedString = String(expected);
+  const actualString = format(actual);
+  const expectedString = format(expected);
   const msgSuffix = msg ? `: ${msg}` : ".";
   throw new AssertionError(
     `Expected actual: ${actualString} not to be: ${expectedString}${msgSuffix}`,

--- a/assert/not_equals_test.ts
+++ b/assert/not_equals_test.ts
@@ -17,7 +17,7 @@ Deno.test("assertNotEquals() throws", () => {
       assertNotEquals("foo", "foo");
     },
     AssertionError,
-    "Expected actual: foo not to be: foo.",
+    'Expected actual: "foo" not to be: "foo".',
   );
 });
 
@@ -27,6 +27,6 @@ Deno.test("assertNotEquals() throws with custom message", () => {
       assertNotEquals("foo", "foo", "CUSTOM MESSAGE");
     },
     AssertionError,
-    "Expected actual: foo not to be: foo: CUSTOM MESSAGE",
+    'Expected actual: "foo" not to be: "foo": CUSTOM MESSAGE',
   );
 });


### PR DESCRIPTION
As mentioned in #4955, this PR changes the way messages are formatted in `assertNotEquals`.

## Current errors

Code: `assertNotEquals("1", "1");`

Output: `error: AssertionError: Expected actual: 1 not to be: 1.`

---

Code: `assertNotEquals({ foo: 1 }, { foo: 1 });`

Output:
`error: AssertionError: Expected actual: [object Object] not to be: [object Object].`

---

Code: `assertNotEquals([1, 2], [1, 2]);`

Output: `error: AssertionError: Expected actual: 1,2 not to be: 1,2.`

---

## Errors after fix

Code:

```ts
assertNotEquals("1", "1");
```

Output:

```shell
error: AssertionError: Expected actual: "1" not to be: "1".
```

---

Code:

```ts
assertNotEquals({ foo: 1 }, { foo: 1 });
```

Output:

```shell
error: AssertionError: Expected actual: {
  foo: 1,
} not to be: {
  foo: 1,
}.
```

---

Code:

```ts
assertNotEquals([1, 2], [1, 2]);
```

Output:

```shell
error: AssertionError: Expected actual: [
  1,
  2,
] not to be: [
  1,
  2,
].
```

Fixes #4955
