### PR TITLE
chore: fix gha permission for deployctl action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    permissions:
+      id-token: write # Required for deployctl
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Currently `deployctl` action seems failing because of permission error. https://github.com/denoland/std/actions/runs/12268957111/job/34231703522

This PR should fix it.

Note: `contents: write` permission is already given at top-level.