### PR TITLE
feat(cbor): add encoding/decoding for `new Map()` instance

### DIFF
--- a/cbor/_common_encode.ts
+++ b/cbor/_common_encode.ts
@@ -109,6 +109,38 @@ export function encodeDate(x: Date): Uint8Array {
   return output;
 }
 
+export function encodeMap(x: Map<CborType, CborType>): Uint8Array {
+  const len = x.size;
+  let head: Uint8Array;
+  if (len < 24) head = Uint8Array.from([0b101_00000 + len]);
+  else if (len < 2 ** 8) head = Uint8Array.from([0b101_11000, len]);
+  else {
+    head = new Uint8Array(9);
+    const view = new DataView(head.buffer);
+    if (len < 2 ** 16) {
+      head[0] = 0b101_11001;
+      view.setUint16(1, len);
+      head = head.subarray(0, 3);
+    } else if (len < 2 ** 32) {
+      head[0] = 0b101_11010;
+      view.setUint32(1, len);
+      head = head.subarray(0, 5);
+    } else {
+      head[0] = 0b101_11011;
+      view.setBigUint64(1, BigInt(len));
+    }
+  }
+  return concat([
+    Uint8Array.from([217, 1, 3]), // TagNumber 259
+    head,
+    ...x
+      .entries()
+      .map(([k, v]) => [encodeCbor(k), encodeCbor(v)])
+      .toArray()
+      .flat(),
+  ]);
+}
+
 export function encodeArray(x: CborType[]): Uint8Array {
   let head: number[];
   if (x.length < 24) head = [0b100_00000 + x.length];

--- a/cbor/_common_encode.ts
+++ b/cbor/_common_encode.ts
@@ -133,10 +133,9 @@ export function encodeMap(x: Map<CborType, CborType>): Uint8Array {
   return concat([
     Uint8Array.from([217, 1, 3]), // TagNumber 259
     head,
-    ...x
-      .entries()
+    ...Array.from(x
+      .entries())
       .map(([k, v]) => [encodeCbor(k), encodeCbor(v)])
-      .toArray()
       .flat(),
   ]);
 }

--- a/cbor/decode_cbor.ts
+++ b/cbor/decode_cbor.ts
@@ -21,7 +21,7 @@ import type { CborType } from "./types.ts";
  * @example Usage
  * ```ts
  * import { assert, assertEquals } from "@std/assert";
- * import { decodeCbor, encodeCbor } from "@std/cbor";
+ * import { type CborType, decodeCbor, encodeCbor } from "@std/cbor";
  *
  * const rawMessage = [
  *   "Hello World",
@@ -31,6 +31,8 @@ import type { CborType } from "./types.ts";
  *   -1,
  *   null,
  *   Uint8Array.from([0, 1, 2, 3]),
+ *   new Date(),
+ *   new Map<CborType, CborType>([[1, 2], ['3', 4], [[5], { a: 6 }]]),
  * ];
  *
  * const encodedMessage = encodeCbor(rawMessage);

--- a/cbor/decode_cbor_sequence.ts
+++ b/cbor/decode_cbor_sequence.ts
@@ -20,7 +20,7 @@ import type { CborType } from "./types.ts";
  * @example Usage
  * ```ts
  * import { assertEquals } from "@std/assert";
- * import { decodeCborSequence, encodeCborSequence } from "@std/cbor";
+ * import { type CborType, decodeCborSequence, encodeCborSequence } from "@std/cbor";
  *
  * const rawMessage = [
  *   "Hello World",
@@ -30,6 +30,8 @@ import type { CborType } from "./types.ts";
  *   -1,
  *   null,
  *   Uint8Array.from([0, 1, 2, 3]),
+ *   new Date(),
+ *   new Map<CborType, CborType>([[1, 2], ['3', 4], [[5], { a: 6 }]]),
  * ];
  *
  * const encodedMessage = encodeCborSequence(rawMessage);

--- a/cbor/encode_cbor.ts
+++ b/cbor/encode_cbor.ts
@@ -4,6 +4,7 @@ import {
   encodeArray,
   encodeBigInt,
   encodeDate,
+  encodeMap,
   encodeNumber,
   encodeObject,
   encodeString,
@@ -61,5 +62,6 @@ export function encodeCbor(value: CborType): Uint8Array {
   if (value instanceof Uint8Array) return encodeUint8Array(value);
   if (value instanceof Array) return encodeArray(value);
   if (value instanceof CborTag) return encodeTag(value);
+  if (value instanceof Map) return encodeMap(value);
   return encodeObject(value);
 }

--- a/cbor/encode_cbor.ts
+++ b/cbor/encode_cbor.ts
@@ -22,7 +22,7 @@ import type { CborType } from "./types.ts";
  * @example Usage
  * ```ts
  * import { assert, assertEquals } from "@std/assert";
- * import { decodeCbor, encodeCbor } from "@std/cbor";
+ * import { type CborType, decodeCbor, encodeCbor } from "@std/cbor";
  *
  * const rawMessage = [
  *   "Hello World",
@@ -32,6 +32,8 @@ import type { CborType } from "./types.ts";
  *   -1,
  *   null,
  *   Uint8Array.from([0, 1, 2, 3]),
+ *   new Date(),
+ *   new Map<CborType, CborType>([[1, 2], ['3', 4], [[5], { a: 6 }]]),
  * ];
  *
  * const encodedMessage = encodeCbor(rawMessage);

--- a/cbor/encode_cbor_sequence.ts
+++ b/cbor/encode_cbor_sequence.ts
@@ -12,7 +12,7 @@ import type { CborType } from "./types.ts";
  * @example Usage
  * ```ts
  * import { assertEquals } from "@std/assert";
- * import { decodeCborSequence, encodeCborSequence } from "@std/cbor";
+ * import { type CborType, decodeCborSequence, encodeCborSequence } from "@std/cbor";
  *
  * const rawMessage = [
  *   "Hello World",
@@ -22,6 +22,8 @@ import type { CborType } from "./types.ts";
  *   -1,
  *   null,
  *   Uint8Array.from([0, 1, 2, 3]),
+ *   new Date(),
+ *   new Map<CborType, CborType>([[1, 2], ['3', 4], [[5], { a: 6 }]]),
  * ];
  *
  * const encodedMessage = encodeCborSequence(rawMessage);

--- a/cbor/encode_cbor_test.ts
+++ b/cbor/encode_cbor_test.ts
@@ -5,6 +5,7 @@ import { concat } from "@std/bytes";
 import { random } from "./_common_test.ts";
 import { encodeCbor } from "./encode_cbor.ts";
 import { CborTag } from "./tag.ts";
+import type { CborType } from "./types.ts";
 
 Deno.test("encodeCbor() encoding undefined", () => {
   assertEquals(
@@ -233,6 +234,95 @@ Deno.test("encodeCbor() encoding Dates", () => {
     encodeCbor(date),
     new Uint8Array([0b110_00001, ...encodeCbor(date.getTime() / 1000)]),
   );
+});
+
+Deno.test("encodeCbor() encoding Map<CborType, CborType>", () => {
+  const map = new Map<CborType, CborType>([[1, 2], ["3", 4], [[5], { a: 6 }]]);
+  assertEquals(
+    encodeCbor(map),
+    Uint8Array.from([
+      217,
+      1,
+      3,
+      0b101_00000 + 3,
+      ...map
+        .entries()
+        .map(([k, v]) => [...encodeCbor(k), ...encodeCbor(v)])
+        .toArray()
+        .flat(),
+    ]),
+  );
+});
+
+Deno.test("encodeCbor() encoding Maps", () => {
+  let pairs = random(0, 24);
+  let entries: [number, number][] = new Array(pairs)
+    .fill(0)
+    .map((_, i) => [i, i]);
+  assertEquals(
+    encodeCbor(new Map(entries)),
+    Uint8Array.from([
+      217,
+      1,
+      3,
+      0b101_00000 + pairs,
+      ...entries.map(([k, v]) => [...encodeCbor(k), ...encodeCbor(v)]).flat(),
+    ]),
+  );
+
+  pairs = random(24, 2 ** 8);
+  entries = new Array(pairs)
+    .fill(0)
+    .map((_, i) => [i, i]);
+  assertEquals(
+    encodeCbor(new Map(entries)),
+    Uint8Array.from([
+      217,
+      1,
+      3,
+      0b101_11000,
+      pairs,
+      ...entries.map(([k, v]) => [...encodeCbor(k), ...encodeCbor(v)]).flat(),
+    ]),
+  );
+
+  pairs = random(2 ** 8, 2 ** 16);
+  entries = new Array(pairs)
+    .fill(0)
+    .map((_, i) => [i, i]);
+  assertEquals(
+    encodeCbor(new Map(entries)),
+    Uint8Array.from([
+      217,
+      1,
+      3,
+      0b101_11001,
+      pairs >> 8 & 0xFF,
+      pairs & 0xFF,
+      ...entries.map(([k, v]) => [...encodeCbor(k), ...encodeCbor(v)]).flat(),
+    ]),
+  );
+
+  pairs = random(2 ** 16, 2 ** 17);
+  entries = new Array(pairs)
+    .fill(0)
+    .map((_, i) => [i, i]);
+  assertEquals(
+    encodeCbor(new Map(entries)),
+    Uint8Array.from([
+      217,
+      1,
+      3,
+      0b101_11010,
+      pairs >> 24 & 0xFF,
+      pairs >> 16 & 0xFF,
+      pairs >> 8 & 0xFF,
+      pairs & 0xFF,
+      ...entries.map(([k, v]) => [...encodeCbor(k), ...encodeCbor(v)]).flat(),
+    ]),
+  );
+
+  // Can't test the next bracket up due to JavaScript limitations.
 });
 
 Deno.test("encodeCbor() encoding arrays", () => {

--- a/cbor/encode_cbor_test.ts
+++ b/cbor/encode_cbor_test.ts
@@ -245,10 +245,9 @@ Deno.test("encodeCbor() encoding Map<CborType, CborType>", () => {
       1,
       3,
       0b101_00000 + 3,
-      ...map
-        .entries()
+      ...Array.from(map
+        .entries())
         .map(([k, v]) => [...encodeCbor(k), ...encodeCbor(v)])
-        .toArray()
         .flat(),
     ]),
   );

--- a/cbor/types.ts
+++ b/cbor/types.ts
@@ -29,9 +29,14 @@ export type CborPrimitiveType =
  * {@link encodeCbor}, {@link decodeCbor}, {@link encodeCborSequence}, and
  * {@link decodeCborSequence}.
  */
-export type CborType = CborPrimitiveType | CborTag<CborType> | CborType[] | {
-  [k: string]: CborType;
-};
+export type CborType =
+  | CborPrimitiveType
+  | CborTag<CborType>
+  | Map<CborType, CborType>
+  | CborType[]
+  | {
+    [k: string]: CborType;
+  };
 
 /**
  * Specifies the encodable value types for the {@link CborSequenceEncoderStream}


### PR DESCRIPTION
Closes: https://github.com/denoland/std/issues/6249

These changes adds support for accepting a [Map](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map) instance in `encodeCbor` and returning it again from `decodeCbor`. It achieves this via the [259 tag number](https://www.iana.org/assignments/cbor-tags/cbor-tags.xhtml) ([Spec](https://github.com/shanewholloway/js-cbor-codec/blob/master/docs/CBOR-259-spec--explicit-maps.md)). 

While the code is mostly the same for encoding and decoding Objects, it differs in the need for limiting keys to only strings. It also guarantees that the order isn't at risk of being changed due to encoding/decoding.

This pull request does not add support for accepting Map instances via the streaming methods of this library. The logistics for decoding that is a bit more trickier to figure out.

```ts
import { assertEquals } from "@std/assert";
import { type CborType, decodeCbor, encodeCbor } from "@std/cbor";

assertEquals(
  decodeCbor(encodeCbor(new Map([[ 1, 2 ], [ "3", 4 ], [ [5], { a: 6 } ]]))),
  new Map([[ 1, 2 ], [ "3", 4 ], [ [5], { a: 6 } ]])
);
```