### PR TITLE
docs(cli): remove `parseArgs()` console logs from examples

### DIFF
--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -5,7 +5,7 @@
  * Command line arguments parser based on
  * {@link https://github.com/minimistjs/minimist | minimist}.
  *
- * @example
+ * @example Usage
  * ```ts
  * import { parseArgs } from "@std/cli/parse-args";
  *
@@ -278,18 +278,18 @@ export interface ParseOptions<
    *
    * @default {false}
    *
-   *  @example
+   * @example Double dash option is false
    * ```ts
    * // $ deno run example.ts -- a arg1
    * import { parseArgs } from "@std/cli/parse-args";
-   * const args = parseArgs(Deno.args, { "--": false }); // output: { _: [ "a", "arg1" ] }
+   * const args = parseArgs(Deno.args, { "--": false }); // args equals { _: [ "a", "arg1" ] }
    * ```
    *
-   *  @example
+   *  @example Double dash option is true
    * ```ts
    * // $ deno run example.ts -- a arg1
    * import { parseArgs } from "@std/cli/parse-args";
-   * const args = parseArgs(Deno.args, { "--": true }); // output: { _: [], --: [ "a", "arg1" ] }
+   * const args = parseArgs(Deno.args, { "--": true }); // args equals { _: [], --: [ "a", "arg1" ] }
    * ```
    */
   "--"?: TDoubleDash;

--- a/cli/parse_args.ts
+++ b/cli/parse_args.ts
@@ -9,7 +9,7 @@
  * ```ts
  * import { parseArgs } from "@std/cli/parse-args";
  *
- * console.dir(parseArgs(Deno.args));
+ * const args = parseArgs(Deno.args);
  * ```
  *
  * @module
@@ -282,10 +282,14 @@ export interface ParseOptions<
    * ```ts
    * // $ deno run example.ts -- a arg1
    * import { parseArgs } from "@std/cli/parse-args";
-   * console.dir(parseArgs(Deno.args, { "--": false }));
-   * // output: { _: [ "a", "arg1" ] }
-   * console.dir(parseArgs(Deno.args, { "--": true }));
-   * // output: { _: [], --: [ "a", "arg1" ] }
+   * const args = parseArgs(Deno.args, { "--": false }); // output: { _: [ "a", "arg1" ] }
+   * ```
+   *
+   *  @example
+   * ```ts
+   * // $ deno run example.ts -- a arg1
+   * import { parseArgs } from "@std/cli/parse-args";
+   * const args = parseArgs(Deno.args, { "--": true }); // output: { _: [], --: [ "a", "arg1" ] }
    * ```
    */
   "--"?: TDoubleDash;


### PR DESCRIPTION
This PR removes all `parseArgs()` console logs and adds a constant declaration instead. This is how it is done in other examples and also prevents logs when calling `deno task test`.