### PR TITLE
docs(log): fix level name assertion in LogRecord example

### DIFF
--- a/log/logger.ts
+++ b/log/logger.ts
@@ -200,7 +200,7 @@ export class LogRecord {
    *   loggerName: "example",
    * });
    *
-   * assertEquals(record.loggerName, "example");
+   * assertEquals(record.levelName, "INFO");
    * ```
    */
   readonly levelName: string;


### PR DESCRIPTION
Hello.

This pull request fixes the assertion in the `LogRecord` class test to correctly check the level name. The original assertion was checking `loggerName`, but I believe it should verify `levelName` instead.
