### PR TITLE
fix(expect): Fix `expect.arrayContaining` bug

### DIFF
--- a/expect/_array_containing_test.ts
+++ b/expect/_array_containing_test.ts
@@ -28,3 +28,30 @@ Deno.test("expect.arrayContaining() with array of mixed types", () => {
   expect([1, 2, 3, "hello", "bye"]).toEqual(expect.not.arrayContaining(arr));
   expect([4, "bye"]).not.toEqual(expect.arrayContaining(arr));
 });
+
+Deno.test("matchObject on array", () => {
+  const a = [
+    { foo: "bar" },
+    { foo: "baz" },
+  ];
+
+  expect(a).toEqual(expect.arrayContaining([
+    expect.objectContaining({ foo: "bar" }),
+  ]));
+});
+
+Deno.test("test from blog post", () => {
+  const state = [
+    { type: "START", data: "foo" },
+    { type: "START", data: "baz" },
+    { type: "END", data: "foo" },
+  ];
+
+  expect(state).toEqual(
+    expect.arrayContaining([
+      expect.objectContaining({
+        type: "END",
+      }),
+    ]),
+  );
+});

--- a/expect/_asymmetric_matchers.ts
+++ b/expect/_asymmetric_matchers.ts
@@ -1,6 +1,7 @@
 // Copyright 2018-2024 the Deno authors. All rights reserved. MIT license.
 // deno-lint-ignore-file no-explicit-any
 
+import { getCustomEqualityTesters } from "./_custom_equality_tester.ts";
 import { equal } from "./_equal.ts";
 
 export abstract class AsymmetricMatcher<T> {
@@ -76,7 +77,11 @@ export class ArrayContaining extends AsymmetricMatcher<any[]> {
 
   equals(other: any[]): boolean {
     const res = Array.isArray(other) &&
-      this.value.every((e) => other.includes(e));
+      this.value.every((e) =>
+        other.some((another) =>
+          equal(e, another, { customTesters: getCustomEqualityTesters() })
+        )
+      );
     return this.inverse ? !res : res;
   }
 }


### PR DESCRIPTION
This pr is to fix https://github.com/denoland/std/issues/6243.