### PR TITLE
fix(data-structures): ensure size consistency in BinarySearchTree.from

### DIFF
--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -281,6 +281,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
             nodes.push(right);
           }
         }
+        result.#size = collection.#size;
       }
     } else {
       result = (options?.compare

--- a/data_structures/binary_search_tree_test.ts
+++ b/data_structures/binary_search_tree_test.ts
@@ -392,6 +392,7 @@ Deno.test("BinarySearchTree.from() handles default ascend comparator", () => {
   let tree: BinarySearchTree<number> = BinarySearchTree.from(originalTree);
   assertEquals([...originalTree], expected);
   assertEquals([...tree], expected);
+  assertEquals(tree.size, originalTree.size);
   assertEquals([...tree.nlrValues()], [...originalTree.nlrValues()]);
   assertEquals([...tree.lvlValues()], [...originalTree.lvlValues()]);
 
@@ -443,6 +444,7 @@ Deno.test("BinarySearchTree.from() handles descend comparator", () => {
   let tree: BinarySearchTree<number> = BinarySearchTree.from(originalTree);
   assertEquals([...originalTree], expected);
   assertEquals([...tree], expected);
+  assertEquals(tree.size, originalTree.size);
   assertEquals([...tree.nlrValues()], [...originalTree.nlrValues()]);
   assertEquals([...tree.lvlValues()], [...originalTree.lvlValues()]);
 


### PR DESCRIPTION
Previously, when cloning an existing BinarySearchTree using the static from method, the new tree’s #size field was not updated, leading to a mismatch between the reported size and the actual number of nodes. This commit addresses the issue by directly assigning the original tree’s #size to the new instance after copying all nodes.

Additional tests have been added to verify that size remains accurate and consistent following the cloning process.