### PR TITLE
fix(fs): use `stat` function in `stat` example

### DIFF
--- a/fs/unstable_stat.ts
+++ b/fs/unstable_stat.ts
@@ -11,7 +11,7 @@ import type { FileInfo } from "./unstable_types.ts";
  * ```ts
  * import { assert } from "@std/assert";
  * import { stat } from "@std/fs/unstable-stat";
- * const fileInfo = await Deno.stat("README.md");
+ * const fileInfo = await stat("README.md");
  * assert(fileInfo.isFile);
  * ```
  *


### PR DESCRIPTION
The code example in the stat function imports the `stat` function but uses `Deno.stat` instead of `stat`.