### PR TITLE
fix(fs): fix copying of symlink directories on Windows

### DIFF
--- a/fs/copy.ts
+++ b/fs/copy.ts
@@ -137,7 +137,7 @@ async function copySymLink(
 ) {
   await ensureValidCopy(src, dest, options);
   const originSrcFilePath = await Deno.readLink(src);
-  const type = getFileInfoType(await Deno.lstat(src));
+  const type = getFileInfoType(await Deno.lstat(originSrcFilePath));
   if (isWindows) {
     await Deno.symlink(originSrcFilePath, dest, {
       type: type === "dir" ? "dir" : "file",
@@ -161,7 +161,7 @@ function copySymlinkSync(
 ) {
   ensureValidCopySync(src, dest, options);
   const originSrcFilePath = Deno.readLinkSync(src);
-  const type = getFileInfoType(Deno.lstatSync(src));
+  const type = getFileInfoType(Deno.lstatSync(originSrcFilePath));
   if (isWindows) {
     Deno.symlinkSync(originSrcFilePath, dest, {
       type: type === "dir" ? "dir" : "file",


### PR DESCRIPTION
This PR fixes the handling of symlink directories in the `copy` function on Windows. Previously, copying a directory that was a symlink resulted in creating a symlink of type `"file"` instead of `"dir"`.

The test case for copying symlink directories passed because `Deno.lstat()` (which does not follow symlinks) was used. However, when `Deno.stat()` (which follows symlinks) was used on this type of symlink, the system would throw a `PermissionDenied` error.