### PR TITLE
docs(expect): clarify the tolerance in `toBeCloseTo`

### DIFF
--- a/expect/_types.ts
+++ b/expect/_types.ts
@@ -178,7 +178,7 @@ export interface Expected<IsAsync = false> {
 
   /**
    * Asserts that a given numerical value is approximately equal to an
-   * expected number within a within a certain margin of error
+   * expected number within a certain margin of error
    * (tolerance). Useful when comparing floating-point numbers, which
    * may be represented internally with precision errors.
    *

--- a/expect/_types.ts
+++ b/expect/_types.ts
@@ -177,7 +177,10 @@ export interface Expected<IsAsync = false> {
   toBeCalledWith(...expected: unknown[]): void;
 
   /**
-   * Asserts that the value is close to the specified number within a tolerance.
+   * Asserts that a given numerical value is approximately equal to an
+   * expected number within a within a certain margin of error
+   * (tolerance). Useful when comparing floating-point numbers, which
+   * may be represented internally with precision errors.
    *
    * @example Usage
    * ```ts
@@ -189,7 +192,8 @@ export interface Expected<IsAsync = false> {
    * ```
    *
    * @param candidate The candidate number.
-   * @param tolerance The tolerance value (optional).
+   * @param tolerance The number of significant decimal digits to
+   *   consider when comparing the values (optional, default 2).
    */
   toBeCloseTo(candidate: number, tolerance?: number): void;
 


### PR DESCRIPTION
I was looking for a more pedestrian matcher, that would assert a number being [within](https://jest-extended.jestcommunity.dev/docs/matchers/Number#tobewithinstart-end) a range, or ±X of the expected value. Clarified `toBeCloseTo` as useful for avoiding floating point precision errors instead.