### PR TITLE
test(expect): check error message of `.toBeCloseTo()`

### DIFF
--- a/expect/_to_be_close_to_test.ts
+++ b/expect/_to_be_close_to_test.ts
@@ -39,3 +39,21 @@ Deno.test("expect().toBeCloseTo() throws custom message", () => {
     new RegExp(`^${msg}`),
   );
 });
+
+Deno.test("expect().toBeCloseTo() throws error messages which include expected and actual values", () => {
+  assertThrows(
+    () => {
+      expect(0.2 + 0.11).toBeCloseTo(0.3);
+    },
+    AssertionError,
+    `Expected the value 0.31 to be close to 0.3 (using 2 digits), but it is not`,
+  );
+
+  assertThrows(
+    () => {
+      expect(0.2 + 0.1).not.toBeCloseTo(0.3);
+    },
+    AssertionError,
+    `Expected the value 0.30000000000000004 not to be close to 0.3 (using 2 digits), but it is`,
+  );
+});


### PR DESCRIPTION
This PR adds the test case to check the fix #6291