### PR TITLE
docs(datetime): remove outdated mention of `utc` option

### DIFF
--- a/datetime/format.ts
+++ b/datetime/format.ts
@@ -61,7 +61,7 @@ export interface FormatOptions {
  *
  * @example UTC formatting
  *
- * Enable UTC formatting by setting the `utc` option to `true`.
+ * Enable UTC formatting by setting the `timeZone` option to `"UTC"`.
  *
  * ```ts ignore
  * import { format } from "@std/datetime/format";


### PR DESCRIPTION
Fixes a trivial oversight in the docs that was missed in 4ec7dd4be99049e6721d4bf41b5a4d3ded7770b2 (#5647)