### PR TITLE
fix(data-structures): ensure size consistency in RedBlackTree.from

### DIFF
--- a/data_structures/_binary_search_tree_internals.ts
+++ b/data_structures/_binary_search_tree_internals.ts
@@ -39,4 +39,5 @@ export const internals: {
     tree: BinarySearchTree<T>,
     node: BinarySearchNode<T>,
   ): BinarySearchNode<T> | null;
+  setSize<T>(tree: BinarySearchTree<T>, size: number): void;
 } = {} as typeof internals;

--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -140,6 +140,8 @@ export class BinarySearchTree<T> implements Iterable<T> {
       tree: BinarySearchTree<T>,
       node: BinarySearchNode<T>,
     ): BinarySearchNode<T> | null => tree.#removeNode(node);
+    internals.setSize = <T>(tree: BinarySearchTree<T>, size: number) =>
+      tree.#size = size;
   }
 
   /**

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -14,6 +14,7 @@ const {
   rotateNode,
   insertNode,
   removeNode,
+  setSize,
 } = internals;
 
 /**
@@ -251,6 +252,7 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
             nodes.push(right);
           }
         }
+        setSize(result, collection.size);
       }
     } else {
       result = (options?.compare

--- a/data_structures/red_black_tree_test.ts
+++ b/data_structures/red_black_tree_test.ts
@@ -375,6 +375,7 @@ Deno.test("RedBlackTree.from() handles default ascend comparator", () => {
   const originalTree: RedBlackTree<number> = new RedBlackTree();
   for (const value of values) originalTree.insert(value);
   let tree: RedBlackTree<number> = RedBlackTree.from(originalTree);
+  assertEquals(originalTree.size, tree.size);
   assertEquals([...originalTree], expected);
   assertEquals([...tree], expected);
   assertEquals([...tree.nlrValues()], [...originalTree.nlrValues()]);
@@ -434,6 +435,7 @@ Deno.test("RedBlackTree.from() handles descend comparator", () => {
   const originalTree: RedBlackTree<number> = new RedBlackTree(descend);
   for (const value of values) originalTree.insert(value);
   let tree: RedBlackTree<number> = RedBlackTree.from(originalTree);
+  assertEquals(originalTree.size, tree.size);
   assertEquals([...originalTree], expected);
   assertEquals([...tree], expected);
   assertEquals([...tree.nlrValues()], [...originalTree.nlrValues()]);


### PR DESCRIPTION
Previously, when cloning an existing RedBlackTree using the static from method, the new tree’s #size field was not updated, leading to a mismatch between the reported size and the actual number of nodes. This commit addresses the issue by directly assigning the original tree’s #size to the new instance after copying all nodes.

Additional tests have been added to verify that size remains accurate and consistent following the cloning process.