### PR TITLE
fix(async): `abortable` should prevent uncaught error when promise is rejected

### DIFF
--- a/async/abortable.ts
+++ b/async/abortable.ts
@@ -127,9 +127,9 @@ function abortablePromise<T>(
   p: Promise<T>,
   signal: AbortSignal,
 ): Promise<T> {
-  if (signal.aborted) return Promise.reject(signal.reason);
   const { promise, reject } = Promise.withResolvers<never>();
   const abort = () => reject(signal.reason);
+  if (signal.aborted) abort();
   signal.addEventListener("abort", abort, { once: true });
   return Promise.race([promise, p]).finally(() => {
     signal.removeEventListener("abort", abort);

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -1,47 +1,47 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 import { assertEquals, assertRejects } from "@std/assert";
 import { abortable } from "./abortable.ts";
+import { delay } from "./delay.ts";
 
 Deno.test("abortable() handles promise", async () => {
   const c = new AbortController();
   const { promise, resolve } = Promise.withResolvers<string>();
-  const t = setTimeout(() => resolve("Hello"), 100);
+  setTimeout(() => resolve("Hello"), 10);
   const result = await abortable(promise, c.signal);
   assertEquals(result, "Hello");
-  clearTimeout(t);
 });
 
 Deno.test("abortable() handles promise with aborted signal after delay", async () => {
   const c = new AbortController();
   const { promise, resolve } = Promise.withResolvers<string>();
-  const t = setTimeout(() => resolve("Hello"), 100);
-  setTimeout(() => c.abort(), 50);
+  setTimeout(() => resolve("Hello"), 10);
+  setTimeout(() => c.abort(), 5);
   const error = await assertRejects(
     () => abortable(promise, c.signal),
     DOMException,
     "The signal has been aborted",
   );
   assertEquals(error.name, "AbortError");
-  clearTimeout(t);
+  await delay(5); // wait for the promise to resolve
 });
 
 Deno.test("abortable() handles promise with aborted signal after delay with reason", async () => {
   const c = new AbortController();
   const { promise, resolve } = Promise.withResolvers<string>();
-  const t = setTimeout(() => resolve("Hello"), 100);
-  setTimeout(() => c.abort(new Error("This is my reason")), 50);
+  setTimeout(() => resolve("Hello"), 10);
+  setTimeout(() => c.abort(new Error("This is my reason")), 5);
   await assertRejects(
     () => abortable(promise, c.signal),
     Error,
     "This is my reason",
   );
-  clearTimeout(t);
+  await delay(5); // wait for the promise to resolve
 });
 
 Deno.test("abortable() handles promise with already aborted signal", async () => {
   const c = new AbortController();
   const { promise, resolve } = Promise.withResolvers<string>();
-  const t = setTimeout(() => resolve("Hello"), 100);
+  setTimeout(() => resolve("Hello"), 10);
   c.abort();
   const error = await assertRejects(
     async () => {
@@ -51,26 +51,26 @@ Deno.test("abortable() handles promise with already aborted signal", async () =>
     "The signal has been aborted",
   );
   assertEquals(error.name, "AbortError");
-  clearTimeout(t);
+  await delay(10); // wait for the promise to resolve
 });
 
 Deno.test("abortable() handles promise with already aborted signal with reason", async () => {
   const c = new AbortController();
   const { promise, resolve } = Promise.withResolvers<string>();
-  const t = setTimeout(() => resolve("Hello"), 100);
+  setTimeout(() => resolve("Hello"), 10);
   c.abort(new Error("This is my reason"));
   await assertRejects(
     () => abortable(promise, c.signal),
     Error,
     "This is my reason",
   );
-  clearTimeout(t);
+  await delay(10); // wait for the promise to resolve
 });
 
 Deno.test("abortable.AsyncIterable()", async () => {
   const c = new AbortController();
   const { promise, resolve } = Promise.withResolvers<string>();
-  const t = setTimeout(() => resolve("Hello"), 100);
+  setTimeout(() => resolve("My promise resolved"), 10);
   const a = async function* () {
     yield "Hello";
     await promise;
@@ -78,19 +78,18 @@ Deno.test("abortable.AsyncIterable()", async () => {
   };
   const items = await Array.fromAsync(abortable(a(), c.signal));
   assertEquals(items, ["Hello", "World"]);
-  clearTimeout(t);
 });
 
 Deno.test("abortable.AsyncIterable() handles aborted signal after delay", async () => {
   const c = new AbortController();
   const { promise, resolve } = Promise.withResolvers<string>();
-  const t = setTimeout(() => resolve("Hello"), 100);
+  setTimeout(() => resolve("My promise resolved"), 10);
   const a = async function* () {
     yield "Hello";
     await promise;
     yield "World";
   };
-  setTimeout(() => c.abort(), 50);
+  setTimeout(() => c.abort(), 5);
   const items: string[] = [];
   const error = await assertRejects(
     async () => {
@@ -103,13 +102,12 @@ Deno.test("abortable.AsyncIterable() handles aborted signal after delay", async 
   );
   assertEquals(error.name, "AbortError");
   assertEquals(items, ["Hello"]);
-  clearTimeout(t);
 });
 
 Deno.test("abortable.AsyncIterable() handles already aborted signal", async () => {
   const c = new AbortController();
   const { promise, resolve } = Promise.withResolvers<string>();
-  const t = setTimeout(() => resolve("Hello"), 100);
+  setTimeout(() => resolve("My promise resolved"), 10);
   const a = async function* () {
     yield "Hello";
     await promise;
@@ -128,7 +126,7 @@ Deno.test("abortable.AsyncIterable() handles already aborted signal", async () =
   );
   assertEquals(error.name, "AbortError");
   assertEquals(items, []);
-  clearTimeout(t);
+  await delay(10); // wait for the promise to resolve
 });
 
 Deno.test("abortable.AsyncIterable() calls return before throwing", async () => {
@@ -146,6 +144,7 @@ Deno.test("abortable.AsyncIterable() calls return before throwing", async () => 
         }),
       return: () => {
         returnCalled = true;
+        clearTimeout(timeoutId);
         return Promise.resolve({ value: undefined, done: true });
       },
     }),
@@ -164,7 +163,6 @@ Deno.test("abortable.AsyncIterable() calls return before throwing", async () => 
   assertEquals(returnCalled, true);
   assertEquals(error.name, "AbortError");
   assertEquals(items, []);
-  clearTimeout(timeoutId!);
 });
 
 Deno.test("abortable.AsyncIterable() behaves just like original when not aborted", async () => {

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -207,17 +207,6 @@ Deno.test("abortable.AsyncIterable() behaves just like original when return is c
   assertEquals(await abortableIterator.next(), await normalIterator.next());
 });
 
-Deno.test("abortable() handles rejected promise", async () => {
-  const c = new AbortController();
-  const { promise, reject } = Promise.withResolvers<string>();
-  setTimeout(() => reject(new Error("This is my error")), 10);
-  await assertRejects(
-    () => abortable(promise, c.signal),
-    Error,
-    "This is my error",
-  );
-});
-
 Deno.test("abortable() does not throw when the signal is already aborted and the promise is already rejected", async () => {
   const promise = Promise.reject(new Error("Rejected"));
   const signal = AbortSignal.abort();

--- a/async/abortable_test.ts
+++ b/async/abortable_test.ts
@@ -206,3 +206,24 @@ Deno.test("abortable.AsyncIterable() behaves just like original when return is c
   );
   assertEquals(await abortableIterator.next(), await normalIterator.next());
 });
+
+Deno.test("abortable() handles rejected promise", async () => {
+  const c = new AbortController();
+  const { promise, reject } = Promise.withResolvers<string>();
+  setTimeout(() => reject(new Error("This is my error")), 10);
+  await assertRejects(
+    () => abortable(promise, c.signal),
+    Error,
+    "This is my error",
+  );
+});
+
+Deno.test("abortable() does not throw when the signal is already aborted and the promise is already rejected", async () => {
+  const promise = Promise.reject(new Error("Rejected"));
+  const signal = AbortSignal.abort();
+  await assertRejects(
+    () => abortable(promise, signal),
+    DOMException,
+    "The signal has been aborted",
+  );
+});


### PR DESCRIPTION
In `abortable`:
- If the signal is aborted with delay and the promise is rejected, an uncaught error does not occur. This is OK.
- If the signal is already aborted and the promise is rejected, an uncaught error occurs.

Uncaught errors should not occur in either case.

Also, I changed the tests to use `delay` instead of `clearTimeout` to detect leaks.