### PR TITLE
fix(data-structures): implement deep cloning for BinarySearchNode and…

### DIFF
--- a/data_structures/_binary_search_node.ts
+++ b/data_structures/_binary_search_node.ts
@@ -17,13 +17,27 @@ export class BinarySearchNode<T> {
   }
 
   static from<T>(node: BinarySearchNode<T>): BinarySearchNode<T> {
-    const copy: BinarySearchNode<T> = new BinarySearchNode(
-      node.parent,
-      node.value,
-    );
-    copy.left = node.left;
-    copy.right = node.right;
-    return copy;
+    // New deep copy
+    // 1. Create a brand new node (with no parent at first)
+    const clone = new BinarySearchNode<T>(null, node.value);
+
+    // 2. Recursively clone the left subtree
+    if (node.left) {
+      clone.left = BinarySearchNode.from(node.left);
+      clone.left.parent = clone;
+    }
+
+    // 3. Recursively clone the right subtree
+    if (node.right) {
+      clone.right = BinarySearchNode.from(node.right);
+      clone.right.parent = clone;
+    }
+
+    // 4. We do NOT copy over 'parent' from the old node!  Instead, when the
+    //    parent's 'from()' call links the child, it sets child.parent = parent.
+    //    This ensures the copied tree has all new references.
+
+    return clone;
   }
 
   directionFromParent(): Direction | null {

--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -258,31 +258,13 @@ export class BinarySearchTree<T> implements Iterable<T> {
       if (options?.compare || options?.map) {
         unmappedValues = collection;
       } else {
-        const nodes: BinarySearchNode<U>[] = [];
+        // Just do a single deep clone from the root
         if (collection.#root) {
           result.#root = BinarySearchNode.from(
             collection.#root as unknown as BinarySearchNode<U>,
           );
-          nodes.push(result.#root);
         }
-        while (nodes.length) {
-          const node: BinarySearchNode<U> = nodes.pop()!;
-          const left: BinarySearchNode<U> | null = node.left
-            ? BinarySearchNode.from(node.left)
-            : null;
-          const right: BinarySearchNode<U> | null = node.right
-            ? BinarySearchNode.from(node.right)
-            : null;
-
-          if (left) {
-            left.parent = node;
-            nodes.push(left);
-          }
-          if (right) {
-            right.parent = node;
-            nodes.push(right);
-          }
-        }
+        // copy the size from the original
         result.#size = collection.#size;
       }
     } else {

--- a/data_structures/binary_search_tree_test.ts
+++ b/data_structures/binary_search_tree_test.ts
@@ -556,3 +556,36 @@ Deno.test("BinarySearchTree.clear()", () => {
   tree.clear();
   assert(tree.isEmpty());
 });
+
+Deno.test("BinarySearchTree.from() bug demo - removing in copy corrupts original", () => {
+  // 1. Build the original tree
+  const values = [3, 10, 13, 4, 6, 7, 1, 14];
+  const original = BinarySearchTree.from(values);
+  // original should have 8 elements and include 7
+
+  // 2. Create a copy without passing compare/map
+  const copy = BinarySearchTree.from(original);
+  // copy and original should be independent trees
+
+  // 3. Remove value 7 from the copy
+  const removedInCopy = 7;
+  const removeResult = copy.remove(removedInCopy);
+  // If all is well, removing 7 from copy should not affect original
+
+  // 4. Original tree should still find 7
+  const stillInOriginal = original.find(removedInCopy);
+
+  // Assertion: original should still contain 7
+  assertStrictEquals(
+    stillInOriginal !== null,
+    true,
+    `Expected original.find(${removedInCopy}) to not be null, but got null.`,
+  );
+
+  // Additionally, check if removeResult is true
+  assertStrictEquals(
+    removeResult,
+    true,
+    `Expected copy.remove(${removedInCopy}) to return true, but got false.`,
+  );
+});


### PR DESCRIPTION
… update BinarySearchTree.from() to ensure independent copies

---

Although this change fixes the tree replication issue, it also changes the original behavior of nodes. If a user implements other trees (such as AVL trees) based on this node. Then it may cause other problems. So this merge is only a reference and may not be merged