### PR TITLE
docs(expect): correct minor typo

### DIFF
--- a/expect/mod.ts
+++ b/expect/mod.ts
@@ -71,7 +71,7 @@
  *
  * Only these functions are still not available:
  * - Matchers:
- *   - `toMatchSnapShot`
+ *   - `toMatchSnapshot`
  *   - `toMatchInlineSnapshot`
  *   - `toThrowErrorMatchingSnapshot`
  *   - `toThrowErrorMatchingInlineSnapshot`


### PR DESCRIPTION
The jest function is `toMatchSnapshot`, not `toMatchSnapShot`.