### PR TITLE
docs(expect,text): remove no-eval directives that appear to be unneccessary

### DIFF
--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -608,7 +608,7 @@ expect.not = {
  * The last module added is the first module tested.
  *
  * @example
- * ```ts no-eval
+ * ```ts
  * import { expect } from "@std/expect";
  * import serializerAnsi from "npm:jest-snapshot-serializer-ansi";
  *

--- a/text/unstable_slugify.ts
+++ b/text/unstable_slugify.ts
@@ -86,7 +86,7 @@ export const NON_ASCII = /[^0-9a-zA-Z\-]/g;
  * ```
  *
  * @example With transliteration using a third-party library
- * ```ts no-eval no-assert
+ * ```ts no-assert
  * import { NON_ASCII, slugify } from "@std/text/unstable-slugify";
  * // example third-party transliteration library
  * import transliterate from "npm:any-ascii";


### PR DESCRIPTION
Per #5728, we want to review the usage of `no-eval`.

These examples pass with `no-eval` removed, so we might as well remove them.

```
$ deno task test text/unstable_slugify.ts                                                                                                                                                                                                                                                                          
Task test deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks --clean "text/unstable_slugify.ts"
Check file:///home/fin/src/std/text/unstable_slugify.ts
Check file:///home/fin/src/std/text/unstable_slugify.ts$25-31.ts
Check file:///home/fin/src/std/text/unstable_slugify.ts$37-43.ts
Check file:///home/fin/src/std/text/unstable_slugify.ts$49-55.ts
Check file:///home/fin/src/std/text/unstable_slugify.ts$61-67.ts
Check file:///home/fin/src/std/text/unstable_slugify.ts$80-87.ts
Check file:///home/fin/src/std/text/unstable_slugify.ts$89-97.ts
./text/unstable_slugify.ts$61-67.ts => file:///home/fin/src/std/text/unstable_slugify.ts$61-67.ts ... ok (1ms)
./text/unstable_slugify.ts$37-43.ts => file:///home/fin/src/std/text/unstable_slugify.ts$37-43.ts ... ok (3ms)
./text/unstable_slugify.ts$49-55.ts => file:///home/fin/src/std/text/unstable_slugify.ts$49-55.ts ... ok (9ms)
./text/unstable_slugify.ts$80-87.ts => file:///home/fin/src/std/text/unstable_slugify.ts$80-87.ts ... ok (9ms)
./text/unstable_slugify.ts$25-31.ts => file:///home/fin/src/std/text/unstable_slugify.ts$25-31.ts ... ok (13ms)
./text/unstable_slugify.ts$89-97.ts => file:///home/fin/src/std/text/unstable_slugify.ts$89-97.ts ... ok (8ms)

ok | 6 passed | 0 failed (63ms)
```

```$ deno task test expect/expect.ts                                                                                                                                                                                                                                                                                  
Task test deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks --clean "expect/expect.ts"
Check file:///home/fin/src/std/expect/expect.ts
Check file:///home/fin/src/std/expect/expect.ts$122-133.ts
Check file:///home/fin/src/std/expect/expect.ts$251-296.ts
Check file:///home/fin/src/std/expect/expect.ts$305-355.ts
Check file:///home/fin/src/std/expect/expect.ts$362-371.ts
Check file:///home/fin/src/std/expect/expect.ts$381-395.ts
Check file:///home/fin/src/std/expect/expect.ts$411-421.ts
Check file:///home/fin/src/std/expect/expect.ts$436-449.ts
Check file:///home/fin/src/std/expect/expect.ts$459-470.ts
Check file:///home/fin/src/std/expect/expect.ts$485-495.ts
Check file:///home/fin/src/std/expect/expect.ts$506-516.ts
Check file:///home/fin/src/std/expect/expect.ts$525-535.ts
Check file:///home/fin/src/std/expect/expect.ts$544-552.ts
Check file:///home/fin/src/std/expect/expect.ts$573-596.ts
Check file:///home/fin/src/std/expect/expect.ts$611-617.ts
./expect/expect.ts$305-355.ts => file:///home/fin/src/std/expect/expect.ts$305-355.ts ... ok (2ms)
./expect/expect.ts$411-421.ts => file:///home/fin/src/std/expect/expect.ts$411-421.ts ... ok (1ms)
./expect/expect.ts$362-371.ts => file:///home/fin/src/std/expect/expect.ts$362-371.ts ... ok (1ms)
./expect/expect.ts$381-395.ts => file:///home/fin/src/std/expect/expect.ts$381-395.ts ... ok (1ms)
./expect/expect.ts$459-470.ts => file:///home/fin/src/std/expect/expect.ts$459-470.ts ... ok (3ms)
./expect/expect.ts$506-516.ts => file:///home/fin/src/std/expect/expect.ts$506-516.ts ... ok (4ms)
./expect/expect.ts$122-133.ts => file:///home/fin/src/std/expect/expect.ts$122-133.ts ... ok (2ms)
./expect/expect.ts$544-552.ts => file:///home/fin/src/std/expect/expect.ts$544-552.ts ... ok (2ms)
./expect/expect.ts$611-617.ts => file:///home/fin/src/std/expect/expect.ts$611-617.ts ... ok (2ms)
./expect/expect.ts$251-296.ts => file:///home/fin/src/std/expect/expect.ts$251-296.ts ... ok (1ms)
./expect/expect.ts$436-449.ts => file:///home/fin/src/std/expect/expect.ts$436-449.ts ... ok (3ms)
./expect/expect.ts$485-495.ts => file:///home/fin/src/std/expect/expect.ts$485-495.ts ... ok (2ms)
./expect/expect.ts$573-596.ts => file:///home/fin/src/std/expect/expect.ts$573-596.ts ... ok (3ms)
./expect/expect.ts$525-535.ts => file:///home/fin/src/std/expect/expect.ts$525-535.ts ... ok (6ms)

ok | 14 passed | 0 failed (242ms)
```