### PR TITLE
chore: use native type stripping of Node.js in node testing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,9 +97,6 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: npm install
-        working-directory: _tools/node_test_runner
-
       - name: Run tests
         run: deno task test:node
 

--- a/_tools/node_test_runner/deno_compat_hooks.mjs
+++ b/_tools/node_test_runner/deno_compat_hooks.mjs
@@ -1,6 +1,5 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import { transform } from "sucrase";
 import { readFile } from "node:fs/promises";
 import * as path from "node:path";
 import { pathToFileURL } from "node:url";
@@ -20,33 +19,4 @@ export async function resolve(specifier, context, nextResolve) {
   }
 
   return await nextResolve(specifier, context);
-}
-
-export async function load(specifier, context, nextLoad) {
-  const { format, source } = await nextLoad(specifier, context).catch(
-    async (error) => {
-      if (
-        error.code === "ERR_UNKNOWN_FILE_EXTENSION" &&
-        specifier.endsWith(".ts")
-      ) {
-        return await nextLoad(specifier, {
-          ...context,
-          format: "module",
-        });
-      } else {
-        throw error;
-      }
-    },
-  );
-
-  if (source && specifier.endsWith(".ts")) {
-    return {
-      format,
-      source: encoder.encode(
-        transform(decoder.decode(source), { transforms: ["typescript"] }).code,
-      ),
-    };
-  }
-
-  return { format, source };
 }

--- a/_tools/node_test_runner/package.json
+++ b/_tools/node_test_runner/package.json
@@ -3,5 +3,8 @@
   "private": true,
   "dependencies": {
     "@deno/shim-deno-test": "^0.5.0"
+  },
+  "engines": {
+    "node": ">=23.6.0"
   }
 }

--- a/_tools/node_test_runner/package.json
+++ b/_tools/node_test_runner/package.json
@@ -2,7 +2,6 @@
   "name": "node_test_runner",
   "private": true,
   "dependencies": {
-    "@deno/shim-deno-test": "^0.5.0",
-    "sucrase": "^3.35.0"
+    "@deno/shim-deno-test": "^0.5.0"
   }
 }

--- a/collections/max_with.ts
+++ b/collections/max_with.ts
@@ -36,7 +36,7 @@ export function maxWith<T>(
   let isFirst = true;
 
   for (const current of array) {
-    if (isFirst || comparator(current, <T> max) > 0) {
+    if (isFirst || comparator(current, max as T) > 0) {
       max = current;
       isFirst = false;
     }

--- a/collections/min_with.ts
+++ b/collections/min_with.ts
@@ -32,7 +32,7 @@ export function minWith<T>(
   let isFirst = true;
 
   for (const current of array) {
-    if (isFirst || comparator(current, <T> min) < 0) {
+    if (isFirst || comparator(current, min as T) < 0) {
       min = current;
       isFirst = false;
     }

--- a/deno.json
+++ b/deno.json
@@ -10,7 +10,7 @@
   "tasks": {
     "test": "deno test --unstable-http --unstable-webgpu --doc --allow-all --parallel --coverage --trace-leaks --clean",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | grep -v media_types/vendor/update.ts | xargs deno check --config browser-compat.tsconfig.json",
-    "test:node": "node --import ./_tools/node_test_runner/register_deno_shim.mjs ./_tools/node_test_runner/run_test.mjs",
+    "test:node": "(cd _tools/node_test_runner && npm install) && node --import ./_tools/node_test_runner/register_deno_shim.mjs ./_tools/node_test_runner/run_test.mjs",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:deprecations": "deno run --allow-read --allow-net --allow-env ./_tools/check_deprecation.ts",
     "lint:circular": "deno run --allow-env --allow-read --allow-write --allow-net=deno.land,jsr.io ./_tools/check_circular_package_dependencies.ts",


### PR DESCRIPTION
This PR starts using native type strip feature of Node.js to run tests in Node, and it fixes the CI on main.

This PR also does some clean ups.
- You can now directly execute `deno task test:node` without running `npm install` in `_tools/node_test_runner` dir beforehand.