### PR TITLE
feat(cli/unstable): support stderr on spinner

### DIFF
--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -80,7 +80,7 @@ export interface SpinnerOptions {
    *
    * @default {Deno.stdout}
    */
-  stream?: typeof Deno.stderr | typeof Deno.stdout;
+  output?: typeof Deno.stderr | typeof Deno.stdout;
 }
 
 /**
@@ -101,7 +101,7 @@ export interface SpinnerOptions {
  * }, 3_000);
  *
  * // You can also use the spinner with `Deno.stderr`
- * const spinner2 = new Spinner({ message: "Loading...", color: "yellow", stream: Deno.stderr });
+ * const spinner2 = new Spinner({ message: "Loading...", color: "yellow", output: Deno.stderr });
  * spinner.start();
  *
  * setTimeout(() => {
@@ -141,7 +141,7 @@ export class Spinner {
   #color: Color | undefined;
   #intervalId: number | undefined;
   #active = false;
-  #stream: typeof Deno.stdout | typeof Deno.stderr;
+  #output: typeof Deno.stdout | typeof Deno.stderr;
 
   /**
    * Creates a new spinner.
@@ -158,7 +158,7 @@ export class Spinner {
     this.#spinner = spinner;
     this.message = message;
     this.#interval = interval;
-    this.#stream = options?.stream ?? Deno.stdout;
+    this.#output = options?.output ?? Deno.stdout;
     this.color = color;
   }
 
@@ -216,7 +216,7 @@ export class Spinner {
    * ```
    */
   start() {
-    if (this.#active || this.#stream.writable.locked) {
+    if (this.#active || this.#output.writable.locked) {
       return;
     }
 
@@ -236,7 +236,7 @@ export class Spinner {
       const writeData = new Uint8Array(LINE_CLEAR.length + frame.length);
       writeData.set(LINE_CLEAR);
       writeData.set(frame, LINE_CLEAR.length);
-      this.#stream.writeSync(writeData);
+      this.#output.writeSync(writeData);
       i = (i + 1) % this.#spinner.length;
     };
 
@@ -262,7 +262,7 @@ export class Spinner {
   stop() {
     if (this.#intervalId && this.#active) {
       clearInterval(this.#intervalId);
-      this.#stream.writeSync(LINE_CLEAR); // Clear the current line
+      this.#output.writeSync(LINE_CLEAR); // Clear the current line
       this.#active = false;
     }
   }

--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -83,8 +83,7 @@ export interface SpinnerOptions {
   stream?: typeof Deno.stderr | typeof Deno.stdout;
 }
 
-/**nnnn
- * that
+/**
  * A spinner that can be used to indicate that something is loading.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.

--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -83,7 +83,8 @@ export interface SpinnerOptions {
   stream?: typeof Deno.stderr | typeof Deno.stdout;
 }
 
-/**
+/**nnnn
+ * that
  * A spinner that can be used to indicate that something is loading.
  *
  * @experimental **UNSTABLE**: New API, yet to be vetted.
@@ -98,6 +99,15 @@ export interface SpinnerOptions {
  * setTimeout(() => {
  *  spinner.stop();
  *  console.log("Finished loading!");
+ * }, 3_000);
+ *
+ * // You can also use the spinner with `Deno.stderr`
+ * const spinner2 = new Spinner({ message: "Loading...", color: "yellow", stream: Deno.stderr });
+ * spinner.start();
+ *
+ * setTimeout(() => {
+ *  spinner.stop();
+ *  console.error"Finished loading!");
  * }, 3_000);
  * ```
  */

--- a/cli/unstable_spinner_test.ts
+++ b/cli/unstable_spinner_test.ts
@@ -166,6 +166,39 @@ Deno.test("Spinner constructor accepts interval", async () => {
   }
 });
 
+Deno.test("Spinner constructor accepts stream", async () => {
+  try {
+    stub(Deno.stdin, "setRaw");
+
+    const expectedOutput = [
+      "\r\x1b[K⠋\x1b[0m ",
+      "\r\x1b[K⠙\x1b[0m ",
+      "\r\x1b[K⠹\x1b[0m ",
+      "\r\x1b[K",
+    ];
+
+    const actualOutput: string[] = [];
+
+    stub(
+      Deno.stderr,
+      "writeSync",
+      (data: Uint8Array) => {
+        const output = decoder.decode(data);
+        actualOutput.push(output);
+        return data.length;
+      },
+    );
+
+    const spinner = new Spinner({ interval: 300, stream: Deno.stderr });
+    spinner.start();
+    await delay(1000); // 100ms buffer
+    spinner.stop();
+    assertEquals(actualOutput, expectedOutput);
+  } finally {
+    restore();
+  }
+});
+
 Deno.test("Spinner constructor accepts each color", async (t) => {
   await t.step("black", async () => {
     try {

--- a/cli/unstable_spinner_test.ts
+++ b/cli/unstable_spinner_test.ts
@@ -166,7 +166,7 @@ Deno.test("Spinner constructor accepts interval", async () => {
   }
 });
 
-Deno.test("Spinner constructor accepts stream", async () => {
+Deno.test("Spinner constructor accepts output", async () => {
   try {
     stub(Deno.stdin, "setRaw");
 
@@ -189,7 +189,7 @@ Deno.test("Spinner constructor accepts stream", async () => {
       },
     );
 
-    const spinner = new Spinner({ interval: 300, stream: Deno.stderr });
+    const spinner = new Spinner({ interval: 300, output: Deno.stderr });
     spinner.start();
     await delay(1000); // 100ms buffer
     spinner.stop();


### PR DESCRIPTION
Related to #5495

Adds support to the `@std/cli/unstable_spinner` to write to `stderr` instead of the default `stdout`.

The current Spinner is unusable when piping to another command (e.g. `deno_cli | less` for paging). and will cause garbled data to the pipe/console. Using `stderr` is the standard approach for informational text since by default it is not passed along to the piped commands stdin.

NOTE: I personally would be happy to make this the default. I'm curious if folks would be open to this considering it's currently unstable.

An alternative could be to check if the terminal is interactive or not and change the default based on this.