### PR TITLE
Make debounce work with asynchronous function

### DIFF
--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -17,6 +17,8 @@ export interface DebouncedFunction<Fn extends (...args: any[]) => any> {
   readonly pending: boolean;
 }
 
+type Resolver<T> = (value: PromiseLike<T> | T) => void;
+
 /**
  * Creates a debounced function that delays the given `func`
  * by a given `wait` time in milliseconds. If the method is called

--- a/async/debounce.ts
+++ b/async/debounce.ts
@@ -1,14 +1,16 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 // This module is browser compatible.
 
+type DebouncableFunc = (...args: any[]) => void | Promise<void>;
+
 /**
  * A debounced function that will be delayed by a given `wait`
  * time in milliseconds. If the method is called again before
  * the timeout expires, the previous call will be aborted.
  */
 // deno-lint-ignore no-explicit-any
-export interface DebouncedFunction<Fn extends (...args: any[]) => any> {
-  Fn;
+export interface DebouncedFunction<T extends DebouncableFunc> {
+  T;
   /** Clears the debounce timeout and omits calling the debounced function. */
   clear(): void;
   /** Clears the debounce timeout and calls the debounced function immediately. */
@@ -16,8 +18,6 @@ export interface DebouncedFunction<Fn extends (...args: any[]) => any> {
   /** Returns a boolean whether a debounce call is pending or not. */
   readonly pending: boolean;
 }
-
-type Resolver<T> = (value: PromiseLike<T> | T) => void;
 
 /**
  * Creates a debounced function that delays the given `func`
@@ -42,52 +42,105 @@ type Resolver<T> = (value: PromiseLike<T> | T) => void;
  * // output: Function debounced after 200ms with baz
  * ```
  *
- * @typeParam Fn The provided function.
+ * @typeParam T The provided function.
  * @param fn The function to debounce.
  * @param wait The time in milliseconds to delay the function.
  * @returns The debounced function.
  */
 // deno-lint-ignore no-explicit-any
-export function debounce<Fn extends (...args: any[]) => any>(
-  fn: Fn,
+export function debounce<T extends DebouncableFunc>(
+  fn: T,
   wait: number,
-): DebouncedFunction<Fn> {
+): DebouncedFunction<T> {
   let timeout: number | null = null;
   let flush: (() => void) | null = null;
-  let pendingPromises: Resolver<ReturnType<Fn>>[] = [];
 
-  const clear = () => {
-    if (typeof timeout !== "number") return;
-    clearTimeout(timeout);
-    timeout = null;
-    flush = null;
-    pendingPromises = [];
+  const debounced: DebouncedFunction<T> = ((...args) => {
+    debounced.clear();
+    flush = () => {
+      debounced.clear();
+      fn(...args);
+    };
+    timeout = Number(setTimeout(flush, wait));
+  }) as DebouncedFunction<T>;
+
+  debounced.clear = () => {
+    if (typeof timeout === "number") {
+      clearTimeout(timeout);
+      timeout = null;
+      flush = null;
+    }
   };
 
-  flush = () => {
+  debounced.flush = () => {
     flush?.();
   };
 
-  return Object.assign(
-    (...args) => {
-      promise = new Promise((resolve, reject) => {
-        debounced.clear();
-        flush = async () => {
-          debounced.clear();
-          const clearablePromises = pendingPromises;
-          pendingPromises = []
-          const res = await fn.call(debounced, ...args);
-          clearablePromises.forEach((resolver) => resolver(res));
-        };
-        timeout = Number(setTimeout(flush, wait));
-      });
-      pendingPromises.push(resolve);
-      return promise
-    },
-    {
-      get pending() {
-        return typeof timeout === "number";
+  Object.defineProperty(debounced, "pending", {
+    get: () => typeof timeout === "number",
+  });
+
+  return debounced;
+}
+
+/**
+ * Creates a debounced async function that delays the given `func`
+ * by a given `wait` time in milliseconds. If the method is called
+ * again before the timeout expires, the previous call is aborted.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { debounceAsync } from "@std/async/debounce";
+ *
+ * const submitSearch = debounceAsync(
+ *   (term: string) => {
+ *     const req = await fetch(`https://api.github.com/search/issues?q=${term}`);
+ *     return await req.json();
+ *   },
+ *   200,
+ * );
+ *
+ * let promise: ReturnType<submitSearch> | undefined:
+ * const [promise] = ['d', 'de', 'den', 'deno'].map((query) => {
+ *   promise = submitSearch(query);
+ *   await delay(5);
+ * });
+ * const result = await promise;
+ * // wait 200ms ...
+ * // output: Function debounced after 200ms with result of 'deno' query
+ * ```
+ *
+ * @typeParam F The function to debounce.
+ * @param fn The function to debounce.
+ * @param wait The time in milliseconds to delay the function.
+ * @returns The debounced function.
+ */
+export function debounceAsync<F extends (...a: any[]) => Promise<any>>(fn: F, wait: number): F {
+  let timeout: number | undefined;
+  let pendingPromiseTuple: PromiseWithResolvers<ReturnType<F>> | undefined;
+
+  const clear = () => {
+    if (typeof timeout !== 'number') return;
+    clearTimeout(timeout);
+    timeout = undefined;
+  };
+
+  return ((...args) => {
+    const p = pendingPromiseTuple ?? Promise.withResolvers();
+    pendingPromiseTuple = p;
+    const { promise, resolve, reject } = pendingPromiseTuple;
+    clear();
+    const flush = async () => {
+      clear();
+      pendingPromiseTuple = undefined;
+      try {
+        const res = await fn(...args);
+        resolve(res);
+      } catch (error) {
+        reject(error);
       }
-    }
-  ) as DebouncedFunction<Fn>;
+    };
+    timeout = Number(setTimeout(flush, wait));
+    return promise;
+  }) as F;
 }


### PR DESCRIPTION
## Motivation

The async package provides helper functions for asynchronous operations, yet the debounce function does not work with asynchronous functions. Since these functions are commonly the most valuable functions to debounce, It makes sense to design debounce to support asynchrony.

This also allows us to return a value from debounce.

## Solution

* Simplified the types for debuts: it's now able to infer the arguments and return type of the wrapped function.
* Every function call saves a resolver in an array: Every call to a debounced function will resolve the same result at the same time.

**Caveat:** I wrote this in the GitHub editor quickly before bed, it probably has a type error I missed somewhere -- will fix it tomorrow, but worth a general review in the meantime so I can include the feedback when I look at it tomorrow evening (Australian timezone).