### PR TITLE
docs(expect): fix typo on objectContaining example

### DIFF
--- a/expect/expect.ts
+++ b/expect/expect.ts
@@ -545,7 +545,7 @@ expect.assertions = assertions as (num: number) => void;
  * import { expect } from "@std/expect";
  *
  * Deno.test("example", () => {
- *   expect({ bar: 'baz' }).toEqual(expect.objectContaining({ bar: 'bar'}));
+ *   expect({ bar: 'baz' }).toEqual(expect.objectContaining({ bar: 'baz'}));
  *   expect({ bar: 'baz' }).not.toEqual(expect.objectContaining({ foo: 'bar'}));
  * });
  * ```


### PR DESCRIPTION
Hi, I was reading the documentation for `expect.objectContaining` and noticed a mistake in the example.

The first expectation is incorrect because the expected value for the key bar does not match the actual value. I've updated the example to reflect the correct behavior.