### PR TITLE
docs(log): mention potential deprecation of @std/log

### DIFF
--- a/log/mod.ts
+++ b/log/mod.ts
@@ -1,8 +1,12 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 /**
- * Logging library with the support for terminal and file outputs. Also provides
+ * Logging library with support for terminal and file outputs. Also provides
  * interfaces for building custom loggers.
+ *
+ * > [!IMPORTANT]
+ * > @std/log is [likely to be removed in the future](https://github.com/denoland/std/issues/6124).
+ * > Consider using [Open Telemetry](https://docs.deno.com/runtime/fundamentals/open_telemetry/).
  *
  * ## Loggers
  *


### PR DESCRIPTION
The description on JSR could be updated as well, to mention considering Open Telemetry per #6124.

![image](https://github.com/user-attachments/assets/f8002b65-b506-42bf-b7dc-a5502dfc23c3)
