### PR TITLE
feat(fs/unstable): add realPath and realPathSync

### DIFF
--- a/_tools/node_test_runner/run_test.mjs
+++ b/_tools/node_test_runner/run_test.mjs
@@ -50,6 +50,7 @@ import "../../collections/unzip_test.ts";
 import "../../collections/without_all_test.ts";
 import "../../collections/zip_test.ts";
 import "../../fs/unstable_read_dir_test.ts";
+import "../../fs/unstable_real_path_test.ts";
 import "../../fs/unstable_stat_test.ts";
 import "../../fs/unstable_symlink_test.ts";
 import "../../fs/unstable_lstat_test.ts";

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -16,6 +16,7 @@
     "./unstable-chmod": "./unstable_chmod.ts",
     "./unstable-lstat": "./unstable_lstat.ts",
     "./unstable-read-dir": "./unstable_read_dir.ts",
+    "./unstable-real-path": "./unstable_real_path.ts",
     "./unstable-stat": "./unstable_stat.ts",
     "./unstable-symlink": "./unstable_symlink.ts",
     "./unstable-types": "./unstable_types.ts",

--- a/fs/unstable_real_path.ts
+++ b/fs/unstable_real_path.ts
@@ -1,0 +1,79 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { getNodeFs, isDeno } from "./_utils.ts";
+import { mapError } from "./_map_error.ts";
+
+/**
+ * Resolves to the absolute normalized path, with symbolic links resolved.
+ *
+ * Requires `allow-read` permission for the target path.
+ *
+ * Also requires `allow-read` permission for the `CWD` if the target path is
+ * relative.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { realPath } from "@std/fs/unstable-real-path";
+ * import { symlink } from "@std/fs/unstable-symlink";
+ * // e.g. given /home/alice/file.txt and current directory /home/alice
+ * await symlink("file.txt", "symlink_file.txt");
+ * const fileRealPath = await realPath("./file.txt");
+ * const realSymLinkPath = await realPath("./symlink_file.txt");
+ * console.log(fileRealPath);  // outputs "/home/alice/file.txt"
+ * console.log(realSymLinkPath);  // outputs "/home/alice/file.txt"
+ * ```
+ *
+ * @tags allow-read
+ *
+ * @param path The path of the file or directory.
+ * @returns A promise fulfilling with the absolute `path` of the file.
+ */
+export async function realPath(path: string | URL): Promise<string> {
+  if (isDeno) {
+    return Deno.realPath(path);
+  } else {
+    try {
+      return await getNodeFs().promises.realpath(path);
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}
+
+/**
+ * Synchronously returns absolute normalized path, with symbolic links
+ * resolved.
+ *
+ * Requires `allow-read` permission for the target path.
+ *
+ * Also requires `allow-read` permission for the `CWD` if the target path is
+ * relative.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { realPathSync } from "@std/fs/unstable-real-path";
+ * import { symlinkSync } from "@std/fs/unstable-symlink";
+ * // e.g. given /home/alice/file.txt and current directory /home/alice
+ * symlinkSync("file.txt", "symlink_file.txt");
+ * const realPath = realPathSync("./file.txt");
+ * const realSymLinkPath = realPathSync("./symlink_file.txt");
+ * console.log(realPath);  // outputs "/home/alice/file.txt"
+ * console.log(realSymLinkPath);  // outputs "/home/alice/file.txt"
+ * ```
+ *
+ * @tags allow-read
+ *
+ * @param path The path of the file or directory.
+ * @returns The absolute `path` of the file.
+ */
+export function realPathSync(path: string | URL): string {
+  if (isDeno) {
+    return Deno.realPathSync(path);
+  } else {
+    try {
+      return getNodeFs().realpathSync(path);
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}

--- a/fs/unstable_real_path_test.ts
+++ b/fs/unstable_real_path_test.ts
@@ -1,0 +1,68 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { assert, assertMatch, assertRejects, assertThrows } from "@std/assert";
+import { realPath, realPathSync } from "./unstable_real_path.ts";
+import { NotFound } from "./unstable_errors.js";
+import { platform } from "node:os";
+
+Deno.test("realPath() returns the absolute path from a relative file path", async () => {
+  const testFileRelative = "fs/testdata/0.ts";
+  const testFileReal = await realPath(testFileRelative);
+  if (platform() === "win32") {
+    assertMatch(testFileReal, /^[A-Z]:\\/);
+    assert(testFileReal.endsWith(testFileRelative.replace(/\//g, "\\")));
+  } else {
+    assert(testFileReal.startsWith("/"));
+    assert(testFileReal.endsWith(testFileRelative));
+  }
+});
+
+Deno.test("realPath() returns the absolute path of the linked file via symlink", async () => {
+  // `fs/testdata/0-link` is symlinked to file `fs/testdata/0.ts`.
+  const testFileSymlink = "fs/testdata/0-link";
+  const testFileReal = await realPath(testFileSymlink);
+  if (platform() === "win32") {
+    assertMatch(testFileReal, /^[A-Z]:\\/);
+    assert(testFileReal.endsWith("/testdata/0.ts".replace(/\//g, "\\")));
+  } else {
+    assert(testFileReal.startsWith("/"));
+    assert(testFileReal.endsWith("fs/testdata/0.ts"));
+  }
+});
+
+Deno.test("realPath() rejects with NotFound for a non-existent file", async () => {
+  await assertRejects(async () => {
+    await realPath("non-existent-file.txt");
+  }, NotFound);
+});
+
+Deno.test("realPathSync() returns the absolute path of a relative file", () => {
+  const testFileRelative = "fs/testdata/0.ts";
+  const testFileReal = realPathSync(testFileRelative);
+  if (platform() === "win32") {
+    assertMatch(testFileReal, /^[A-Z]:\\/);
+    assert(testFileReal.endsWith(testFileRelative.replace(/\//g, "\\")));
+  } else {
+    assert(testFileReal.startsWith("/"));
+    assert(testFileReal.endsWith(testFileRelative));
+  }
+});
+
+Deno.test("realPathSync() returns the absolute path of the linked file via symlink", () => {
+  // `fs/testdata/0-link` is symlinked to file `fs/testdata/0.ts`.
+  const testFileSymlink = "fs/testdata/0-link";
+  const testFileReal = realPathSync(testFileSymlink);
+  if (platform() === "win32") {
+    assertMatch(testFileReal, /^[A-Z]:\\/);
+    assert(testFileReal.endsWith("/testdata/0.ts".replace(/\//g, "\\")));
+  } else {
+    assert(testFileReal.startsWith("/"));
+    assert(testFileReal.endsWith("/testdata/0.ts"));
+  }
+});
+
+Deno.test("realPathSync() throws with NotFound for a non-existent file", () => {
+  assertThrows(() => {
+    realPathSync("non-existent-file.txt");
+  }, NotFound);
+});


### PR DESCRIPTION
This PR adds the `realPath`and `realPathSync` APIs to `@std/fs`, which are functions intended to mirror `Deno.realPath` and `Deno.realPathSync`, respectively.

Towards #6255.