### PR TITLE
feat(collections): add index arg to methods

### DIFF
--- a/collections/distinct_by.ts
+++ b/collections/distinct_by.ts
@@ -29,12 +29,13 @@
  */
 export function distinctBy<T, D>(
   array: Iterable<T>,
-  discriminator: (el: T) => D,
+  discriminator: (el: T, index: number) => D,
 ): T[] {
   const keys = new Set<D>();
   const result: T[] = [];
+  let index = 0;
   for (const element of array) {
-    const key = discriminator(element);
+    const key = discriminator(element, index++);
     if (!keys.has(key)) {
       keys.add(key);
       result.push(element);

--- a/collections/distinct_by_test.ts
+++ b/collections/distinct_by_test.ts
@@ -5,7 +5,7 @@ import { distinctBy } from "./distinct_by.ts";
 
 function distinctByTest<I>(
   array: Array<I>,
-  selector: (element: I) => unknown,
+  selector: (element: I, index: number) => unknown,
   expected: Array<I>,
   message?: string,
 ) {
@@ -114,6 +114,17 @@ Deno.test({
       people,
       (it) => it.name.length,
       [kim, arthur, anna],
+    );
+  },
+});
+
+Deno.test({
+  name: "distinctBy() passes index to discriminator",
+  fn() {
+    distinctByTest(
+      [25, "asdf", true],
+      (_, index) => index > 1,
+      [25, true],
     );
   },
 });

--- a/collections/drop_last_while.ts
+++ b/collections/drop_last_while.ts
@@ -27,10 +27,10 @@
  */
 export function dropLastWhile<T>(
   array: readonly T[],
-  predicate: (el: T) => boolean,
+  predicate: (el: T, index: number) => boolean,
 ): T[] {
   let offset = array.length;
-  while (0 < offset && predicate(array[offset - 1] as T)) offset--;
+  while (0 < offset && predicate(array[offset - 1] as T, offset - 1)) offset--;
 
   return array.slice(0, offset);
 }

--- a/collections/drop_last_while_test.ts
+++ b/collections/drop_last_while_test.ts
@@ -50,3 +50,11 @@ Deno.test("dropLastWhile() returns empty array when all elements get dropped", (
 
   assertEquals(actual, []);
 });
+
+Deno.test("dropLastWhile() passes index to predicate", () => {
+  const array = [20, 30, 20];
+
+  const actual = dropLastWhile(array, (_, index) => index > 1);
+
+  assertEquals(actual, [20, 30]);
+});

--- a/collections/drop_while.ts
+++ b/collections/drop_while.ts
@@ -26,12 +26,12 @@
  */
 export function dropWhile<T>(
   array: readonly T[],
-  predicate: (el: T) => boolean,
+  predicate: (el: T, index: number) => boolean,
 ): T[] {
   let offset = 0;
   const length = array.length;
 
-  while (length > offset && predicate(array[offset] as T)) {
+  while (length > offset && predicate(array[offset] as T, offset)) {
     offset++;
   }
 

--- a/collections/drop_while_test.ts
+++ b/collections/drop_while_test.ts
@@ -55,3 +55,11 @@ Deno.test("dropWhile() returns the same array when all elements match the predic
 
   assertEquals(actual, []);
 });
+
+Deno.test("dropWhile() passes index to predicate", () => {
+  const array = [20, 30, 20];
+
+  const actual = dropWhile(array, (_, index) => index < 1);
+
+  assertEquals(actual, [30, 20]);
+});

--- a/collections/find_single.ts
+++ b/collections/find_single.ts
@@ -32,12 +32,13 @@
  */
 export function findSingle<T>(
   array: Iterable<T>,
-  predicate: (el: T) => boolean,
+  predicate: (el: T, index: number) => boolean,
 ): T | undefined {
   let match: T | undefined;
   let found = false;
+  let index = 0;
   for (const element of array) {
-    if (predicate(element)) {
+    if (predicate(element, index++)) {
       if (found) return undefined;
       found = true;
       match = element;

--- a/collections/find_single_test.ts
+++ b/collections/find_single_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "@std/assert";
 import { findSingle } from "./find_single.ts";
 
 function findSingleTest<I>(
-  input: [Array<I>, (element: I) => boolean],
+  input: [Array<I>, (element: I, index: number) => boolean],
   expected: I | undefined,
   message?: string,
 ) {
@@ -100,6 +100,16 @@ Deno.test({
     findSingleTest(
       [["zap", "foo", "bar", "zee"], (it) => it.startsWith("z")],
       undefined,
+    );
+  },
+});
+
+Deno.test({
+  name: "findSingle() passes index to predicate",
+  fn() {
+    findSingleTest(
+      [[9, 12, 13], (_, index) => index === 1],
+      12,
     );
   },
 });

--- a/collections/first_not_nullish_of.ts
+++ b/collections/first_not_nullish_of.ts
@@ -33,10 +33,11 @@
  */
 export function firstNotNullishOf<T, O>(
   array: Iterable<T>,
-  selector: (item: T) => O | undefined | null,
+  selector: (item: T, index: number) => O | undefined | null,
 ): NonNullable<O> | undefined {
+  let index = 0;
   for (const current of array) {
-    const selected = selector(current);
+    const selected = selector(current, index++);
 
     if (selected !== null && selected !== undefined) {
       return selected as NonNullable<O>;

--- a/collections/first_not_nullish_of_test.ts
+++ b/collections/first_not_nullish_of_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "@std/assert";
 import { firstNotNullishOf } from "./first_not_nullish_of.ts";
 
 function firstNotNullishOfTest<T, O>(
-  input: [Array<T>, (el: T) => O | undefined | null],
+  input: [Array<T>, (el: T, index: number) => O | undefined | null],
   expected: NonNullable<O> | undefined,
   message?: string,
 ) {
@@ -82,6 +82,16 @@ Deno.test({
         (it) => it.middle,
       ],
       "Hans",
+    );
+  },
+});
+
+Deno.test({
+  name: "firstNotNullishOf() passes index to selector",
+  fn() {
+    firstNotNullishOfTest(
+      [[1, 2, 3, 4], (it, index) => index < 1 ? null : it],
+      2,
     );
   },
 });

--- a/collections/join_to_string.ts
+++ b/collections/join_to_string.ts
@@ -77,7 +77,7 @@ export type JoinToStringOptions = {
  */
 export function joinToString<T>(
   array: Iterable<T>,
-  selector: (el: T) => string,
+  selector: (el: T, index: number) => string,
   options: Readonly<JoinToStringOptions> = {},
 ): string {
   const {
@@ -101,7 +101,7 @@ export function joinToString<T>(
       break;
     }
 
-    result += selector(el);
+    result += selector(el, index);
     index++;
   }
 

--- a/collections/join_to_string_test.ts
+++ b/collections/join_to_string_test.ts
@@ -144,3 +144,14 @@ Deno.test({
     assertEquals(out, "result: Kim and others are winners");
   },
 });
+
+Deno.test({
+  name: "joinToString() passes index to selector",
+  fn() {
+    const arr = ["Kim", "Anna", "Tim"];
+
+    const out = joinToString(arr, (it, index) => it + index);
+
+    assertEquals(out, "Kim0,Anna1,Tim2");
+  },
+});

--- a/collections/map_not_nullish.ts
+++ b/collections/map_not_nullish.ts
@@ -33,12 +33,13 @@
  */
 export function mapNotNullish<T, O>(
   array: Iterable<T>,
-  transformer: (el: T) => O,
+  transformer: (el: T, index: number) => O,
 ): NonNullable<O>[] {
   const result: NonNullable<O>[] = [];
+  let index = 0;
 
   for (const element of array) {
-    const transformedElement = transformer(element);
+    const transformedElement = transformer(element, index++);
 
     if (transformedElement !== undefined && transformedElement !== null) {
       result.push(transformedElement as NonNullable<O>);

--- a/collections/map_not_nullish_test.ts
+++ b/collections/map_not_nullish_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "@std/assert";
 import { mapNotNullish } from "./map_not_nullish.ts";
 
 function mapNotNullishTest<T, O>(
-  input: [Array<T>, (el: T) => O | undefined | null],
+  input: [Array<T>, (el: T, index: number) => O | undefined | null],
   expected: Array<O>,
   message?: string,
 ) {
@@ -87,6 +87,19 @@ Deno.test({
         (it) => it.middle,
       ],
       ["Hans", "Marija"],
+    );
+  },
+});
+
+Deno.test({
+  name: "mapNotNullish() passes index to transformer",
+  fn() {
+    mapNotNullishTest(
+      [
+        [1, 2, 3, 4],
+        (it, index) => index === 1 ? null : it + index,
+      ],
+      [1, 5, 7],
     );
   },
 });

--- a/collections/max_by.ts
+++ b/collections/max_by.ts
@@ -31,7 +31,7 @@
  */
 export function maxBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => number,
+  selector: (el: T, index: number) => number,
 ): T | undefined;
 /**
  * Returns the first element that is the largest value of the given function or
@@ -63,7 +63,7 @@ export function maxBy<T>(
  */
 export function maxBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => string,
+  selector: (el: T, index: number) => string,
 ): T | undefined;
 /**
  * Returns the first element that is the largest value of the given function or
@@ -95,7 +95,7 @@ export function maxBy<T>(
  */
 export function maxBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => bigint,
+  selector: (el: T, index: number) => bigint,
 ): T | undefined;
 /**
  * Returns the first element that is the largest value of the given function or
@@ -127,21 +127,22 @@ export function maxBy<T>(
  */
 export function maxBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => Date,
+  selector: (el: T, index: number) => Date,
 ): T | undefined;
 export function maxBy<T>(
   array: Iterable<T>,
   selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+    | ((el: T, index: number) => number)
+    | ((el: T, index: number) => string)
+    | ((el: T, index: number) => bigint)
+    | ((el: T, index: number) => Date),
 ): T | undefined {
   let max: T | undefined;
   let maxValue: ReturnType<typeof selector> | undefined;
+  let index = 0;
 
   for (const current of array) {
-    const currentValue = selector(current);
+    const currentValue = selector(current, index++);
 
     if (maxValue === undefined || currentValue > maxValue) {
       max = current;

--- a/collections/max_by_test.ts
+++ b/collections/max_by_test.ts
@@ -136,3 +136,14 @@ Deno.test({
     assertEquals(maxBy(input, (it) => new Date(it)), "February 1, 2022");
   },
 });
+
+Deno.test({
+  name: "maxBy() passes index to selector",
+  fn() {
+    const input = [4, 3, 2, 1];
+
+    const max = maxBy(input, (_, index) => index);
+
+    assertEquals(max, 1);
+  },
+});

--- a/collections/max_of.ts
+++ b/collections/max_of.ts
@@ -32,7 +32,7 @@
  */
 export function maxOf<T>(
   array: Iterable<T>,
-  selector: (el: T) => number,
+  selector: (el: T, index: number) => number,
 ): number | undefined;
 /**
  * Applies the given selector to all elements of the provided collection and
@@ -65,16 +65,22 @@ export function maxOf<T>(
  */
 export function maxOf<T>(
   array: Iterable<T>,
-  selector: (el: T) => bigint,
+  selector: (el: T, index: number) => bigint,
 ): bigint | undefined;
-export function maxOf<T, S extends ((el: T) => number) | ((el: T) => bigint)>(
+export function maxOf<
+  T,
+  S extends
+    | ((el: T, index: number) => number)
+    | ((el: T, index: number) => bigint),
+>(
   array: Iterable<T>,
   selector: S,
 ): ReturnType<S> | undefined {
   let maximumValue: ReturnType<S> | undefined;
+  let index = 0;
 
   for (const element of array) {
-    const currentValue = selector(element) as ReturnType<S>;
+    const currentValue = selector(element, index++) as ReturnType<S>;
 
     if (maximumValue === undefined || currentValue > maximumValue) {
       maximumValue = currentValue;

--- a/collections/max_of_test.ts
+++ b/collections/max_of_test.ts
@@ -100,3 +100,14 @@ Deno.test("maxOf() handles infinity", () => {
 
   assertEquals(actual, Infinity);
 });
+
+Deno.test({
+  name: "maxBy() passes index to selector",
+  fn() {
+    const input = [4, 3, 2, 1];
+
+    const max = maxOf(input, (it, index) => it * index);
+
+    assertEquals(max, 4);
+  },
+});

--- a/collections/min_by.ts
+++ b/collections/min_by.ts
@@ -31,7 +31,7 @@
  */
 export function minBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => number,
+  selector: (el: T, index: number) => number,
 ): T | undefined;
 /**
  * Returns the first element that is the smallest value of the given function or
@@ -63,7 +63,7 @@ export function minBy<T>(
  */
 export function minBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => string,
+  selector: (el: T, index: number) => string,
 ): T | undefined;
 /**
  * Returns the first element that is the smallest value of the given function or
@@ -95,7 +95,7 @@ export function minBy<T>(
  */
 export function minBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => bigint,
+  selector: (el: T, index: number) => bigint,
 ): T | undefined;
 /**
  * Returns the first element that is the smallest value of the given function or
@@ -125,21 +125,22 @@ export function minBy<T>(
  */
 export function minBy<T>(
   array: Iterable<T>,
-  selector: (el: T) => Date,
+  selector: (el: T, index: number) => Date,
 ): T | undefined;
 export function minBy<T>(
   array: Iterable<T>,
   selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+    | ((el: T, index: number) => number)
+    | ((el: T, index: number) => string)
+    | ((el: T, index: number) => bigint)
+    | ((el: T, index: number) => Date),
 ): T | undefined {
   let min: T | undefined;
   let minValue: ReturnType<typeof selector> | undefined;
+  let index = 0;
 
   for (const current of array) {
-    const currentValue = selector(current);
+    const currentValue = selector(current, index++);
 
     if (minValue === undefined || currentValue < minValue) {
       min = current;

--- a/collections/min_by_test.ts
+++ b/collections/min_by_test.ts
@@ -137,3 +137,14 @@ Deno.test({
     assertEquals(minBy(input, (it) => new Date(it)), "December 17, 1995");
   },
 });
+
+Deno.test({
+  name: "minBy() passes index to selector",
+  fn() {
+    const input = [4, 3, 2, 1];
+
+    const max = minBy(input, (_, index) => index);
+
+    assertEquals(max, 4);
+  },
+});

--- a/collections/min_of.ts
+++ b/collections/min_of.ts
@@ -32,7 +32,7 @@
  */
 export function minOf<T>(
   array: Iterable<T>,
-  selector: (el: T) => number,
+  selector: (el: T, index: number) => number,
 ): number | undefined;
 /**
  * Applies the given selector to all elements of the given collection and
@@ -65,16 +65,22 @@ export function minOf<T>(
  */
 export function minOf<T>(
   array: Iterable<T>,
-  selector: (el: T) => bigint,
+  selector: (el: T, index: number) => bigint,
 ): bigint | undefined;
-export function minOf<T, S extends ((el: T) => number) | ((el: T) => bigint)>(
+export function minOf<
+  T,
+  S extends
+    | ((el: T, index: number) => number)
+    | ((el: T, index: number) => bigint),
+>(
   array: Iterable<T>,
   selector: S,
 ): ReturnType<S> | undefined {
   let minimumValue: ReturnType<S> | undefined;
+  let index = 0;
 
   for (const element of array) {
-    const currentValue = selector(element) as ReturnType<S>;
+    const currentValue = selector(element, index++) as ReturnType<S>;
 
     if (minimumValue === undefined || currentValue < minimumValue) {
       minimumValue = currentValue;

--- a/collections/min_of_test.ts
+++ b/collections/min_of_test.ts
@@ -100,3 +100,14 @@ Deno.test("minOf() handles minus infinity", () => {
 
   assertEquals(actual, -Infinity);
 });
+
+Deno.test({
+  name: "minOf() passes index to selector",
+  fn() {
+    const input = [4, 3, 2, 1];
+
+    const max = minOf(input, (it, index) => it * index);
+
+    assertEquals(max, 0);
+  },
+});

--- a/collections/partition.ts
+++ b/collections/partition.ts
@@ -29,7 +29,7 @@
  */
 export function partition<T>(
   array: Iterable<T>,
-  predicate: (el: T) => boolean,
+  predicate: (el: T, index: number) => boolean,
 ): [T[], T[]];
 /**
  * Returns a tuple of two arrays with the first one containing all elements in
@@ -64,17 +64,18 @@ export function partition<T>(
  */
 export function partition<T, U extends T>(
   array: Iterable<T>,
-  predicate: (el: T) => el is U,
+  predicate: (el: T, index: number) => el is U,
 ): [U[], Exclude<T, U>[]];
 export function partition(
   array: Iterable<unknown>,
-  predicate: (el: unknown) => boolean,
+  predicate: (el: unknown, index: number) => boolean,
 ): [unknown[], unknown[]] {
   const matches: Array<unknown> = [];
   const rest: Array<unknown> = [];
+  let index = 0;
 
   for (const element of array) {
-    if (predicate(element)) {
+    if (predicate(element, index++)) {
       matches.push(element);
     } else {
       rest.push(element);

--- a/collections/partition_test.ts
+++ b/collections/partition_test.ts
@@ -4,7 +4,7 @@ import { assertEquals } from "@std/assert";
 import { partition } from "./partition.ts";
 
 function partitionTest<I>(
-  input: [Array<I>, (element: I) => boolean],
+  input: [Array<I>, (element: I, index: number) => boolean],
   expected: [Array<I>, Array<I>],
   message?: string,
 ) {
@@ -70,6 +70,16 @@ Deno.test({
     partitionTest(
       [["foo", "bar", ""], (it) => it.length > 0],
       [["foo", "bar"], [""]],
+    );
+  },
+});
+
+Deno.test({
+  name: "partition() passes index to predicate",
+  fn() {
+    partitionTest(
+      [[2, 4, 6], (_, index) => index % 2 === 0],
+      [[2, 6], [4]],
     );
   },
 });

--- a/collections/permutations.ts
+++ b/collections/permutations.ts
@@ -2,7 +2,7 @@
 // This module is browser compatible.
 
 /**
- * Builds all possible orders of all elements in the given array
+ * Builds all possible orders of all elements in the given array.
  * Ignores equality of elements, meaning this will always return the same
  * number of permutations for a given length of input.
  *

--- a/collections/sort_by.ts
+++ b/collections/sort_by.ts
@@ -60,7 +60,7 @@ export type SortByOptions = {
  */
 export function sortBy<T>(
   array: readonly T[],
-  selector: (el: T) => number,
+  selector: (el: T, index: number) => number,
   options?: SortByOptions,
 ): T[];
 /**
@@ -98,7 +98,7 @@ export function sortBy<T>(
  */
 export function sortBy<T>(
   array: readonly T[],
-  selector: (el: T) => string,
+  selector: (el: T, index: number) => string,
   options?: SortByOptions,
 ): T[];
 /**
@@ -138,7 +138,7 @@ export function sortBy<T>(
 
 export function sortBy<T>(
   array: readonly T[],
-  selector: (el: T) => bigint,
+  selector: (el: T, index: number) => bigint,
   options?: SortByOptions,
 ): T[];
 /**
@@ -177,16 +177,16 @@ export function sortBy<T>(
  */
 export function sortBy<T>(
   array: readonly T[],
-  selector: (el: T) => Date,
+  selector: (el: T, index: number) => Date,
   options?: SortByOptions,
 ): T[];
 export function sortBy<T>(
   array: readonly T[],
   selector:
-    | ((el: T) => number)
-    | ((el: T) => string)
-    | ((el: T) => bigint)
-    | ((el: T) => Date),
+    | ((el: T, index: number) => number)
+    | ((el: T, index: number) => string)
+    | ((el: T, index: number) => bigint)
+    | ((el: T, index: number) => Date),
   options?: SortByOptions,
 ): T[] {
   const len = array.length;
@@ -196,7 +196,7 @@ export function sortBy<T>(
 
   array.forEach((element, index) => {
     indexes[index] = index;
-    const selected = selector(element);
+    const selected = selector(element, index);
     selectors[index] = Number.isNaN(selected) ? null : selected;
   });
 

--- a/collections/sort_by_test.ts
+++ b/collections/sort_by_test.ts
@@ -474,3 +474,10 @@ Deno.test({
     ]);
   },
 });
+
+Deno.test({
+  name: "sortBy() passes index to selector",
+  fn() {
+    assertEquals(sortBy([2, 3, 1], (_, index) => -index), [1, 3, 2]);
+  },
+});

--- a/collections/sum_of.ts
+++ b/collections/sum_of.ts
@@ -30,12 +30,13 @@
  */
 export function sumOf<T>(
   array: Iterable<T>,
-  selector: (el: T) => number,
+  selector: (el: T, index: number) => number,
 ): number {
   let sum = 0;
+  let index = 0;
 
   for (const i of array) {
-    sum += selector(i);
+    sum += selector(i, index++);
   }
 
   return sum;

--- a/collections/sum_of_test.ts
+++ b/collections/sum_of_test.ts
@@ -130,3 +130,11 @@ Deno.test("sumOf() handles Infinity", () => {
 
   assertEquals(actual, Infinity);
 });
+
+Deno.test("sumOf() passes index to selector", () => {
+  const array = [1, 2, 3];
+
+  const actual = sumOf(array, (_, index) => index);
+
+  assertEquals(actual, 3);
+});

--- a/collections/take_last_while.ts
+++ b/collections/take_last_while.ts
@@ -28,10 +28,10 @@
  */
 export function takeLastWhile<T>(
   array: readonly T[],
-  predicate: (el: T) => boolean,
+  predicate: (el: T, index: number) => boolean,
 ): T[] {
   let offset = array.length;
-  while (0 < offset && predicate(array[offset - 1] as T)) offset--;
+  while (0 < offset && predicate(array[offset - 1] as T, offset - 1)) offset--;
 
   return array.slice(offset, array.length);
 }

--- a/collections/take_last_while_test.ts
+++ b/collections/take_last_while_test.ts
@@ -55,3 +55,11 @@ Deno.test("takeLastWhile() returns the same array when all elements match the pr
 
   assertEquals(actual, [1, 2, 3, 4]);
 });
+
+Deno.test("takeLastWhile() passes the index to the predicate", () => {
+  const arr = [1, 2, 3, 4];
+
+  const actual = takeLastWhile(arr, (_, index) => index > 1);
+
+  assertEquals(actual, [3, 4]);
+});

--- a/collections/take_while.ts
+++ b/collections/take_while.ts
@@ -31,12 +31,12 @@
  */
 export function takeWhile<T>(
   array: readonly T[],
-  predicate: (el: T) => boolean,
+  predicate: (el: T, index: number) => boolean,
 ): T[] {
   let offset = 0;
   const length = array.length;
 
-  while (length > offset && predicate(array[offset] as T)) {
+  while (length > offset && predicate(array[offset] as T, offset)) {
     offset++;
   }
 

--- a/collections/take_while_test.ts
+++ b/collections/take_while_test.ts
@@ -144,3 +144,11 @@ Deno.test("(unstable) takeWhile() handles a Map", () => {
     ["c", 3],
   ]);
 });
+
+Deno.test("takeWhile() passes the index to the predicate", () => {
+  const arr = [1, 2, 3, 4];
+
+  const actual = takeWhile(arr, (_, index) => index < 1);
+
+  assertEquals(actual, [1]);
+});


### PR DESCRIPTION
Adds an `index` arg to collections' predicate/selector/transformer/discriminator method. I added it only to collection helpers that operate on iterables because collection helpers that operate on records don't seem as likely to need access to the key index. Please let me know if I missed any.

Closes #6288