### PR TITLE
perf(front-matter): replace `replace()` with `trim()`

### DIFF
--- a/front_matter/_shared.ts
+++ b/front_matter/_shared.ts
@@ -15,7 +15,7 @@ export function extractAndParse<T>(
   if (!match || match.index !== 0) {
     throw new TypeError("Unexpected end of input");
   }
-  const frontMatter = match.at(-1)?.replace(/^\s+|\s+$/g, "") ?? "";
+  const frontMatter = match.at(-1)?.trim() ?? "";
   const attrs = parse(frontMatter) as T;
   const body = input.replace(match[0], "");
   return { frontMatter, body, attrs };


### PR DESCRIPTION
This PR replaces `replace(/^\s+|\s+$/g, "")` with `trim()`.

Turns out `trim()` is faster than `replace()`. Here's a benchmark:

```sh
CPU | Apple M1
Runtime | Deno 2.1.9 (aarch64-apple-darwin)

benchmark                time/iter (avg)        iter/s      (min … max)           p75      p99     p995
------------------------ ----------------------------- --------------------- --------------------------
replace() 100 chars             275.3 ns     3,633,000 (268.9 ns … 308.3 ns) 277.5 ns 304.7 ns 308.3 ns
replace() 1000 chars              3.0 µs       331,700 (  3.0 µs …   3.1 µs)   3.0 µs   3.1 µs   3.1 µs
replace() 10000 chars            30.5 µs        32,770 ( 30.2 µs …  82.5 µs)  30.5 µs  33.0 µs  34.0 µs
replace() 100000 chars          306.8 µs         3,259 (303.2 µs … 488.3 µs) 307.0 µs 332.8 µs 344.2 µs
trim() 100 chars                 27.9 ns    35,830,000 ( 26.7 ns …  45.5 ns)  27.4 ns  33.2 ns  35.0 ns
trim() 1000 chars                30.6 ns    32,710,000 ( 29.7 ns …  39.1 ns)  30.0 ns  35.5 ns  36.9 ns
trim() 10000 chars               31.2 ns    32,040,000 ( 26.9 ns …  39.1 ns)  31.0 ns  36.5 ns  37.1 ns
trim() 100000 chars              30.5 ns    32,780,000 ( 29.7 ns …  39.4 ns)  30.0 ns  35.5 ns  36.7 ns
```
