### PR TITLE
chore: ignore jsonc/testdata from typo check

### DIFF
--- a/.github/typos.toml
+++ b/.github/typos.toml
@@ -16,5 +16,6 @@ extend-exclude = [
   "media_types/vendor",
   "http/testdata",
   "http/user_agent.ts",
+  "jsonc/testdata",
   "ulid/*.ts"
 ]


### PR DESCRIPTION
CI started failing at typo in `jsonc/testdata/test262/JSON/parse/15.12.1.1-g2-3.js`. https://github.com/denoland/std/actions/runs/13319999611/job/37206312707

The file is test fixture, and we can skip checking typo in there