### PR TITLE
refactor(front-matter): use relative path for importing module in the same package

### DIFF
--- a/front_matter/any.ts
+++ b/front_matter/any.ts
@@ -1,9 +1,9 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 import { recognize } from "./_shared.ts";
-import { extract as extractToml } from "@std/front-matter/toml";
-import { extract as extractYaml } from "@std/front-matter/yaml";
-import { extract as extractJson } from "@std/front-matter/json";
+import { extract as extractToml } from "./toml.ts";
+import { extract as extractYaml } from "./yaml.ts";
+import { extract as extractJson } from "./json.ts";
 import type { Extract } from "./types.ts";
 import type { Format } from "./test.ts";
 import { EXTRACT_REGEXP_MAP } from "./_formats.ts";


### PR DESCRIPTION
It looks like `deno publish` is not happy with these imports. See https://github.com/denoland/std/actions/runs/13324576250/job/37215539410

This PR replaces paths to relative ones to fix the publish pipeline.