### PR TITLE
fix(cli): update interval in ProgressBar

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -188,7 +188,7 @@ export class ProgressBar {
       .pipeTo(writable, { preventClose: this.#options.keepOpen })
       .catch(() => clearInterval(this.#id));
     this.#writer = stream.writable.getWriter();
-    this.#id = setInterval(() => this.#print(), 200);
+    this.#id = setInterval(() => this.#print(), 1000);
     this.#startTime = performance.now();
     this.#lastTime = this.#startTime;
     this.#lastValue = this.#options.value;


### PR DESCRIPTION
This pull request fixes the simple issue of the interval having the wrong delay of 200ms instead of 1000ms.