### PR TITLE
refactor(cli/unstable): make `ProgressBar` `options` optional

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -55,7 +55,7 @@ export interface ProgressBarOptions {
   /**
    * The total size expected to receive.
    */
-  max: number;
+  max?: number;
   /**
    * The length that the progress bar should be, in characters.
    * @default {50}
@@ -151,11 +151,11 @@ export class ProgressBar {
    */
   constructor(
     writable: WritableStream<Uint8Array>,
-    options: ProgressBarOptions,
+    options: ProgressBarOptions = {},
   ) {
     this.#options = {
       value: options.value ?? 0,
-      max: options.max,
+      max: options.max ?? 1,
       barLength: options.barLength ?? 50,
       fillChar: options.fillChar ?? "#",
       emptyChar: options.emptyChar ?? "-",
@@ -166,16 +166,16 @@ export class ProgressBar {
       keepOpen: options.keepOpen ?? true,
     };
 
-    if (options.max < 2 ** 20) {
+    if (this.#options.max < 2 ** 20) {
       this.#unit = "KiB";
       this.#rate = 2 ** 10;
-    } else if (options.max < 2 ** 30) {
+    } else if (this.#options.max < 2 ** 30) {
       this.#unit = "MiB";
       this.#rate = 2 ** 20;
-    } else if (options.max < 2 ** 40) {
+    } else if (this.#options.max < 2 ** 40) {
       this.#unit = "GiB";
       this.#rate = 2 ** 30;
-    } else if (options.max < 2 ** 50) {
+    } else if (this.#options.max < 2 ** 50) {
       this.#unit = "TiB";
       this.#rate = 2 ** 40;
     } else {


### PR DESCRIPTION
This PR  make `ProgressBar` `options` an optional argument. This is done by setting `options.max` to `1` by default. This default value is taken from [HTMLProgressElement](https://developer.mozilla.org/de/docs/Web/HTML/Element/progress#attribute).