### PR TITLE
test(cli/unstable): make `ProgressBar` tests run faster

### DIFF
--- a/cli/unstable_progress_bar_test.ts
+++ b/cli/unstable_progress_bar_test.ts
@@ -9,7 +9,7 @@ async function* getData(
 ): AsyncGenerator<Uint8Array> {
   for (let i = 0; i < loops; ++i) {
     yield new Uint8Array(bufferSize);
-    await new Promise((a) => setTimeout(a, Math.random() * 500 + 500));
+    await new Promise((a) => setTimeout(a, Math.random() * 100));
   }
 }
 


### PR DESCRIPTION
The `ProgressBar` tests are really due to big `setTimeout` intervals.
This PR lowers the timeout interval for tests that simulate getting async data.