### PR TITLE
test(async): fix flaky `pooledMap()` test

### DIFF
--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -10,7 +10,7 @@ import {
 } from "@std/assert";
 
 Deno.test("pooledMap()", async () => {
-  const start = new Date();
+  const start = performance.now();
   const results = pooledMap(
     2,
     [1, 2, 3],
@@ -18,7 +18,7 @@ Deno.test("pooledMap()", async () => {
   );
   const array = await Array.fromAsync(results);
   assertEquals(array, [1, 2, 3]);
-  const diff = new Date().getTime() - start.getTime();
+  const diff = performance.now() - start;
 
   assertGreaterOrEqual(diff, 600);
   assertLess(diff, 900);

--- a/async/pool_test.ts
+++ b/async/pool_test.ts
@@ -2,8 +2,9 @@
 import { delay } from "./delay.ts";
 import { pooledMap } from "./pool.ts";
 import {
-  assert,
   assertEquals,
+  assertGreaterOrEqual,
+  assertLess,
   assertRejects,
   assertStringIncludes,
 } from "@std/assert";
@@ -13,13 +14,14 @@ Deno.test("pooledMap()", async () => {
   const results = pooledMap(
     2,
     [1, 2, 3],
-    (i) => new Promise<number>((r) => setTimeout(() => r(i), 100)),
+    (i) => new Promise<number>((r) => setTimeout(() => r(i), 300)),
   );
   const array = await Array.fromAsync(results);
   assertEquals(array, [1, 2, 3]);
   const diff = new Date().getTime() - start.getTime();
-  assert(diff >= 200);
-  assert(diff < 300);
+
+  assertGreaterOrEqual(diff, 600);
+  assertLess(diff, 900);
 });
 
 Deno.test("pooledMap() handles errors", async () => {


### PR DESCRIPTION
ref: https://github.com/denoland/std/issues/6287

This PR increases `setTimeout` intervals and therefore adds more leeway to checks.