### PR TITLE
refactor(cli/unstable): clean up `start` end `stop` methods of `Spinner`, add test cases for multiple start/stop calls

### DIFF
--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -139,8 +139,7 @@ export class Spinner {
 
   #interval: number;
   #color: Color | undefined;
-  #intervalId: number | undefined;
-  #active = false;
+  #intervalId: number | null = null;
   #output: typeof Deno.stdout | typeof Deno.stderr;
 
   /**
@@ -216,11 +215,10 @@ export class Spinner {
    * ```
    */
   start() {
-    if (this.#active || this.#output.writable.locked) {
+    if (this.#intervalId !== null || this.#output.writable.locked) {
       return;
     }
 
-    this.#active = true;
     let i = 0;
     const noColor = Deno.noColor;
 
@@ -260,10 +258,9 @@ export class Spinner {
    * ```
    */
   stop() {
-    if (this.#intervalId && this.#active) {
-      clearInterval(this.#intervalId);
-      this.#output.writeSync(LINE_CLEAR); // Clear the current line
-      this.#active = false;
-    }
+    if (this.#intervalId === null) return;
+    clearInterval(this.#intervalId);
+    this.#intervalId = null;
+    this.#output.writeSync(LINE_CLEAR); // Clear the current line
   }
 }

--- a/cli/unstable_spinner_test.ts
+++ b/cli/unstable_spinner_test.ts
@@ -621,3 +621,27 @@ Deno.test("Spinner.message can be updated", async () => {
     restore();
   }
 });
+
+Deno.test("Spinner handles multiple start() calls", () => {
+  try {
+    const spinner = new Spinner();
+
+    spinner.start();
+    spinner.start();
+    spinner.stop();
+  } finally {
+    restore();
+  }
+});
+
+Deno.test("Spinner handles multiple stop() calls", () => {
+  try {
+    const spinner = new Spinner();
+
+    spinner.start();
+    spinner.stop();
+    spinner.stop();
+  } finally {
+    restore();
+  }
+});

--- a/cli/unstable_spinner_test.ts
+++ b/cli/unstable_spinner_test.ts
@@ -623,25 +623,17 @@ Deno.test("Spinner.message can be updated", async () => {
 });
 
 Deno.test("Spinner handles multiple start() calls", () => {
-  try {
-    const spinner = new Spinner();
+  const spinner = new Spinner();
 
-    spinner.start();
-    spinner.start();
-    spinner.stop();
-  } finally {
-    restore();
-  }
+  spinner.start();
+  spinner.start();
+  spinner.stop();
 });
 
 Deno.test("Spinner handles multiple stop() calls", () => {
-  try {
-    const spinner = new Spinner();
+  const spinner = new Spinner();
 
-    spinner.start();
-    spinner.stop();
-    spinner.stop();
-  } finally {
-    restore();
-  }
+  spinner.start();
+  spinner.stop();
+  spinner.stop();
 });


### PR DESCRIPTION
This PR adds test for multiple `start()` and `stop()` calls.
In addition, it removes the `#active` property and replaces it with `this.#intervalId === null` check. This should work identically.