### PR TITLE
docs(fmt): fix `printf` module doc absense

### DIFF
--- a/fmt/printf.ts
+++ b/fmt/printf.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import { stripAnsiCode } from "./colors.ts";
-
 /**
  * {@linkcode sprintf} and {@linkcode printf} for printing formatted strings to
  * stdout.
@@ -159,6 +157,8 @@ import { stripAnsiCode } from "./colors.ts";
  *
  * @module
  */
+
+import { stripAnsiCode } from "./colors.ts";
 
 const State = {
   PASSTHROUGH: 0,


### PR DESCRIPTION
`@std/fmt/printf` module docs are currently absent: https://jsr.io/@std/fmt/doc/printf

It seems that the reason is that the `@module` JSDoc section happens to be after an import. So, I move the import below and it fixes the issue (checked locally with `deno doc`).

Anyway, I think `deno doc` should probably consider this case in some way - either force to put the module doc as the first item in the module, or to allow putting the module doc anywhere in the module.