### PR TITLE
test(async/unstable): add `retry()` test with default options

### DIFF
--- a/async/retry.ts
+++ b/async/retry.ts
@@ -119,7 +119,7 @@ export interface RetryOptions {
  */
 export async function retry<T>(
   fn: (() => Promise<T>) | (() => T),
-  options?: RetryOptions,
+  options: RetryOptions = {},
 ): Promise<T> {
   const {
     multiplier = 2,
@@ -127,7 +127,7 @@ export async function retry<T>(
     maxAttempts = 5,
     minTimeout = 1000,
     jitter = 1,
-  } = options ?? {};
+  } = options;
 
   if (maxTimeout <= 0) {
     throw new TypeError(

--- a/async/retry_test.ts
+++ b/async/retry_test.ts
@@ -151,3 +151,9 @@ Deno.test("retry() checks backoff function timings", async (t) => {
 
   Math.random = originalMathRandom;
 });
+
+Deno.test("retry() with default options", async () => {
+  const threeErrors = generateErroringFunction(3);
+  const result = await retry(threeErrors);
+  assertEquals(result, 3);
+});


### PR DESCRIPTION
This PR adds a test that doesn't pass any options to `retry()`.