### PR TITLE
fix(assert): fail type check for `assertArrayIncludes` when element type of `expected` not assignable to `actual` (#6427)

### DIFF
--- a/assert/array_includes.ts
+++ b/assert/array_includes.ts
@@ -29,7 +29,7 @@ export type ArrayLikeArg<T> = ArrayLike<T> & object;
  */
 export function assertArrayIncludes<T>(
   actual: ArrayLikeArg<T>,
-  expected: ArrayLikeArg<T>,
+  expected: NoInfer<ArrayLikeArg<T>>,
   msg?: string,
 ) {
   const missing: unknown[] = [];

--- a/assert/array_includes_test.ts
+++ b/assert/array_includes_test.ts
@@ -82,3 +82,12 @@ Deno.test("assertArrayIncludes() type-checks failing cases", () => {
   // @ts-expect-error both args - 'string' is not assignable to 'ArrayLikeArg<string>'.
   assertThrows(() => assertArrayIncludes("a", "b"));
 });
+
+// https://github.com/denoland/std/issues/6427
+Deno.test("assertArrayIncludes() fails type checking when element type of expected not assignable to actual", () => {
+  const ones: 1[] = [1];
+  const twos: 2[] = [2];
+
+  // @ts-expect-error Argument of type '2[]' is not assignable to parameter of type 'ArrayLikeArg<1>'.
+  assertThrows(() => assertArrayIncludes(ones, twos));
+});

--- a/collections/mod.ts
+++ b/collections/mod.ts
@@ -18,7 +18,7 @@
  *
  * assertEquals(intersect(lisaInterests, kimInterests), ["Cooking", "Music"]);
  *
- * assertArrayIncludes(lisaInterests, [sample(lisaInterests)]);
+ * assertArrayIncludes(lisaInterests, [sample(lisaInterests)!]);
  *
  * const cat = { name: "Lulu", age: 3, breed: "Ragdoll" };
  *

--- a/collections/sample.ts
+++ b/collections/sample.ts
@@ -25,7 +25,7 @@ function randomInteger(lower: number, upper: number): number {
  * import { assertArrayIncludes } from "@std/assert";
  *
  * const numbers = [1, 2, 3, 4];
- * const random = sample(numbers);
+ * const random = sample(numbers)!;
  *
  * assertArrayIncludes(numbers, [random]);
  * ```

--- a/collections/unstable_sample.ts
+++ b/collections/unstable_sample.ts
@@ -18,7 +18,7 @@
  * import { assertArrayIncludes } from "@std/assert";
  *
  * const numbers = [1, 2, 3, 4];
- * const random = sample(numbers);
+ * const random = sample(numbers)!;
  *
  * assertArrayIncludes(numbers, [random]);
  * ```

--- a/random/sample.ts
+++ b/random/sample.ts
@@ -38,7 +38,7 @@ export type SampleOptions = RandomOptions & {
  * import { assertArrayIncludes } from "@std/assert";
  *
  * const numbers = [1, 2, 3, 4];
- * const sampled = sample(numbers);
+ * const sampled = sample(numbers)!;
  *
  * assertArrayIncludes(numbers, [sampled]);
  * ```

--- a/random/sample_test.ts
+++ b/random/sample_test.ts
@@ -31,7 +31,7 @@ Deno.test({
   name: "sample() handles array of numbers",
   fn() {
     const input = [1, 2, 3];
-    const actual = sample(input);
+    const actual = sample(input)!;
 
     assertArrayIncludes(input, [actual]);
   },
@@ -50,7 +50,7 @@ Deno.test({
         age: 24,
       },
     ];
-    const actual = sample(input);
+    const actual = sample(input)!;
 
     assertArrayIncludes(input, [actual]);
   },


### PR DESCRIPTION
Fixes https://github.com/denoland/std/issues/6427