### PR TITLE
fix(uuid): handle `rng` correctly in uuid v1

### DIFF
--- a/uuid/v1.ts
+++ b/uuid/v1.ts
@@ -105,7 +105,7 @@ export function generate(options: GenerateOptions = {}): string {
   if (node === undefined || clockseq === undefined) {
     // deno-lint-ignore no-explicit-any
     const seedBytes: any = options.random ??
-      options.rng ??
+      options.rng?.() ??
       crypto.getRandomValues(new Uint8Array(16));
 
     if (node === undefined) {

--- a/uuid/v1_test.ts
+++ b/uuid/v1_test.ts
@@ -72,3 +72,28 @@ Deno.test("generate() throws when create more than 10M uuids/sec", () => {
     "Can't create more than 10M uuids/sec",
   );
 });
+
+Deno.test("generate() uses random bytes from rng option", async () => {
+  const modUrl = new URL("v1.ts", import.meta.url);
+  // Eval in a new worker to avoid globally cached _nodeId and _clockseq values
+  const u = await evalInWorker(`(await import("${modUrl}")).generate({
+    rng() { return [0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0x11, 0x11]; }
+  })`) as string;
+
+  // Checks the above rng is used for random bits
+  assert(u.endsWith("9111-0123456789ab"));
+});
+
+/** Evaluate the given expression in a new worker.
+ * This is used for avoiding the globally cached values. */
+function evalInWorker(expr: string) {
+  return new Promise((resolve) => {
+    const worker = new Worker(
+      `data:text/javascript,postMessage(${expr})`,
+      { type: "module" },
+    );
+    worker.addEventListener("message", ({ data }) => {
+      resolve(data);
+    });
+  });
+}


### PR DESCRIPTION
Currently if the user specifies `rng` option, `generate` returns a broken string like `0b4e9750-ef65-11ef-8000-01undefinedundefinedundefinedundefinedundefined` because `rng` is not called as a function. This PR fixes it.