### PR TITLE
refactor(cli/unstable): Declare `ProgressBar` options as separate properties

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -135,7 +135,15 @@ export interface ProgressBarOptions {
  * bar.end();
  */
 export class ProgressBar {
-  #options: Required<ProgressBarOptions>;
+  #value: number;
+  #max: number;
+  #barLength: number;
+  #fillChar: string;
+  #emptyChar: string;
+  #clear: boolean;
+  #fmt: (fmt: ProgressBarFormatter) => string;
+  #keepOpen: boolean;
+
   #unit: string;
   #rate: number;
   #writer: WritableStreamDefaultWriter;
@@ -143,6 +151,7 @@ export class ProgressBar {
   #startTime: number;
   #lastTime: number;
   #lastValue: number;
+
   /**
    * Constructs a new instance.
    *
@@ -153,29 +162,36 @@ export class ProgressBar {
     writable: WritableStream<Uint8Array>,
     options: ProgressBarOptions,
   ) {
-    this.#options = {
-      value: options.value ?? 0,
-      max: options.max,
-      barLength: options.barLength ?? 50,
-      fillChar: options.fillChar ?? "#",
-      emptyChar: options.emptyChar ?? "-",
-      clear: options.clear ?? false,
-      fmt: options.fmt ?? function (x) {
-        return x.styledTime() + x.progressBar + x.styledData();
-      },
-      keepOpen: options.keepOpen ?? true,
-    };
+    const {
+      value = 0,
+      max,
+      barLength = 50,
+      fillChar = "#",
+      emptyChar = "-",
+      clear = false,
+      fmt = (x) => x.styledTime() + x.progressBar + x.styledData(),
+      keepOpen = true,
+    } = options;
 
-    if (options.max < 2 ** 20) {
+    this.#value = value;
+    this.#max = max;
+    this.#barLength = barLength;
+    this.#fillChar = fillChar;
+    this.#emptyChar = emptyChar;
+    this.#clear = clear;
+    this.#fmt = fmt;
+    this.#keepOpen = keepOpen;
+
+    if (max < 2 ** 20) {
       this.#unit = "KiB";
       this.#rate = 2 ** 10;
-    } else if (options.max < 2 ** 30) {
+    } else if (max < 2 ** 30) {
       this.#unit = "MiB";
       this.#rate = 2 ** 20;
-    } else if (options.max < 2 ** 40) {
+    } else if (max < 2 ** 40) {
       this.#unit = "GiB";
       this.#rate = 2 ** 30;
-    } else if (options.max < 2 ** 50) {
+    } else if (max < 2 ** 50) {
       this.#unit = "TiB";
       this.#rate = 2 ** 40;
     } else {
@@ -185,20 +201,20 @@ export class ProgressBar {
 
     const stream = new TextEncoderStream();
     stream.readable
-      .pipeTo(writable, { preventClose: this.#options.keepOpen })
+      .pipeTo(writable, { preventClose: this.#keepOpen })
       .catch(() => clearInterval(this.#id));
     this.#writer = stream.writable.getWriter();
     this.#id = setInterval(() => this.#print(), 1000);
     this.#startTime = performance.now();
     this.#lastTime = this.#startTime;
-    this.#lastValue = this.#options.value;
+    this.#lastValue = this.#value;
   }
 
   async #print(): Promise<void> {
     const currentTime = performance.now();
-    const size = this.#options.value /
-        this.#options.max *
-        this.#options.barLength | 0;
+    const size = this.#value /
+        this.#max *
+        this.#barLength | 0;
     const unit = this.#unit;
     const rate = this.#rate;
     const x: ProgressBarFormatter = {
@@ -223,18 +239,18 @@ export class ProgressBar {
           "] ";
       },
       progressBar: "[" +
-        this.#options.fillChar.repeat(size) +
-        this.#options.emptyChar.repeat(this.#options.barLength - size) +
+        this.#fillChar.repeat(size) +
+        this.#emptyChar.repeat(this.#barLength - size) +
         "] ",
       time: currentTime - this.#startTime,
       previousTime: this.#lastTime - this.#startTime,
-      value: this.#options.value,
+      value: this.#value,
       previousValue: this.#lastValue,
-      max: this.#options.max,
+      max: this.#max,
     };
     this.#lastTime = currentTime;
-    this.#lastValue = this.#options.value;
-    await this.#writer.write("\r\u001b[K" + this.#options.fmt(x))
+    this.#lastValue = this.#value;
+    await this.#writer.write("\r\u001b[K" + this.#fmt(x))
       .catch(() => {});
   }
 
@@ -244,7 +260,7 @@ export class ProgressBar {
    * @param x The amount of progress that has been made.
    */
   add(x: number): void {
-    this.#options.value += x;
+    this.#value += x;
   }
 
   /**
@@ -253,7 +269,7 @@ export class ProgressBar {
   async end(): Promise<void> {
     clearInterval(this.#id);
     await this.#print()
-      .then(() => this.#writer.write(this.#options.clear ? "\r\u001b[K" : "\n"))
+      .then(() => this.#writer.write(this.#clear ? "\r\u001b[K" : "\n"))
       .then(() => this.#writer.close())
       .catch(() => {});
   }


### PR DESCRIPTION
Ref: https://github.com/denoland/std/pull/6408#issuecomment-2661534263

This PR removes `ProgressBar` `#options` property in favour of separate private properties.