### PR TITLE
feat(fs/unstable): add mkdir and mkdirSync

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -66,6 +66,7 @@ const ENTRY_POINTS = [
   "../fs/unstable_link.ts",
   "../fs/unstable_lstat.ts",
   "../fs/unstable_make_temp_dir.ts",
+  "../fs/unstable_mkdir.ts",
   "../fs/unstable_read_dir.ts",
   "../fs/unstable_read_file.ts",
   "../fs/unstable_read_link.ts",

--- a/_tools/node_test_runner/run_test.mjs
+++ b/_tools/node_test_runner/run_test.mjs
@@ -51,6 +51,7 @@ import "../../collections/without_all_test.ts";
 import "../../collections/zip_test.ts";
 import "../../fs/unstable_link_test.ts";
 import "../../fs/unstable_make_temp_dir_test.ts";
+import "../../fs/unstable_mkdir_test.ts";
 import "../../fs/unstable_read_dir_test.ts";
 import "../../fs/unstable_read_file_test.ts";
 import "../../fs/unstable_read_link_test.ts";

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -17,6 +17,7 @@
     "./unstable-link": "./unstable_link.ts",
     "./unstable-lstat": "./unstable_lstat.ts",
     "./unstable-make-temp-dir": "./unstable_make_temp_dir.ts",
+    "./unstable-mkdir": "./unstable_mkdir.ts",
     "./unstable-read-dir": "./unstable_read_dir.ts",
     "./unstable-read-file": "./unstable_read_file.ts",
     "./unstable-read-link": "./unstable_read_link.ts",

--- a/fs/unstable_mkdir.ts
+++ b/fs/unstable_mkdir.ts
@@ -1,0 +1,98 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { getNodeFs, isDeno } from "./_utils.ts";
+import { mapError } from "./_map_error.ts";
+
+/** 
+ * Options which can be set when using {@linkcode mkdir} and
+ * {@linkcode mkdirSync}.
+ */
+export interface MkdirOptions {
+  /**
+   * If set to `true`, means that any intermediate directories will also be
+   * created (as with the shell command `mkdir -p`).
+   *
+   * Intermediate directories are created with the same permissions.
+   *
+   * When recursive is set to `true`, succeeds silently (without changing any
+   * permissions) if a directory already exists at the path, or if the path
+   * is a symlink to an existing directory.
+   *
+   * @default {false}
+   */
+  recursive?: boolean;
+  /**
+   * Permissions to use when creating the directory (defaults to `0o777`,
+   * before the process's umask).
+   *
+   * Ignored on Windows.
+   */
+  mode?: number;
+}
+
+/**
+ * Creates a new directory with the specified path.
+ *
+ * Defaults to throwing error if the directory already exists.
+ *
+ * Requires `allow-write` permission.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { mkdir } from "@std/fs/unstable-mkdir";
+ * await mkdir("new_dir");
+ * await mkdir("nested/directories", { recursive: true });
+ * await mkdir("restricted_access_dir", { mode: 0o700 });
+ * ```
+ *
+ * @tags allow-write
+ *
+ * @param path The path to the new directory.
+ * @param options Options for creating directories.
+ */
+export async function mkdir(
+  path: string | URL,
+  options?: MkdirOptions,
+): Promise<void> {
+  if (isDeno) {
+    await Deno.mkdir(path, { ...options });
+  } else {
+    try {
+      await getNodeFs().promises.mkdir(path, { ...options });
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}
+
+/**
+ * Synchronously creates a new directory with the specified path.
+ *
+ * Defaults to throwing error if the directory already exists.
+ *
+ * Requires `allow-write` permission.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { mkdirSync } from "@std/fs/unstable-mkdir";
+ * mkdirSync("new_dir");
+ * mkdirSync("nested/directories", { recursive: true });
+ * mkdirSync("restricted_access_dir", { mode: 0o700 });
+ * ```
+ *
+ * @tags allow-write
+ *
+ * @param path The path to the new directory.
+ * @param options Options for creating directories.
+ */
+export function mkdirSync(path: string | URL, options?: MkdirOptions) {
+  if (isDeno) {
+    Deno.mkdirSync(path, { ...options });
+  } else {
+    try {
+      getNodeFs().mkdirSync(path, { ...options });
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}

--- a/fs/unstable_mkdir.ts
+++ b/fs/unstable_mkdir.ts
@@ -3,7 +3,7 @@
 import { getNodeFs, isDeno } from "./_utils.ts";
 import { mapError } from "./_map_error.ts";
 
-/** 
+/**
  * Options which can be set when using {@linkcode mkdir} and
  * {@linkcode mkdirSync}.
  */

--- a/fs/unstable_mkdir_test.ts
+++ b/fs/unstable_mkdir_test.ts
@@ -1,0 +1,216 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+} from "@std/assert";
+import { AlreadyExists } from "./unstable_errors.js";
+import { mkdir, mkdirSync } from "./unstable_mkdir.ts";
+import { makeTempDir, makeTempDirSync } from "./unstable_make_temp_dir.ts";
+import { lstatSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { rm, symlink, writeFile } from "node:fs/promises";
+import { platform } from "node:os";
+import { join } from "node:path";
+import { umask } from "node:process";
+
+function assertDirectory(path: string, expectMode?: number) {
+  const dirStat = lstatSync(path);
+  assert(dirStat.isDirectory());
+  if (platform() !== "win32" && expectMode !== undefined) {
+    assertExists(dirStat.mode);
+    assertEquals(dirStat.mode & 0o777, expectMode & ~umask(0o022));
+  }
+}
+
+Deno.test("mkdir() creates a directory with the default mode", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "mkdir_" });
+  const testDir = join(tempDirPath, "testDir");
+
+  await mkdir(testDir);
+  assertDirectory(testDir, 0o755);
+
+  await rm(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test("mkdir() creates a directory with a user-defined mode", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "mkdir_" });
+  const testDir = join(tempDirPath, "testDir");
+
+  await mkdir(testDir, { mode: 0o700 });
+  assertDirectory(testDir, 0o700);
+
+  await rm(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test("mkdir() recursively creates directories with the default mode", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "mkdir_" });
+  const recurPath = join(tempDirPath, "nested/dir");
+  const nestedDir = join(tempDirPath, "nested");
+
+  await mkdir(recurPath, { recursive: true });
+  assertDirectory(recurPath, 0o755);
+  assertDirectory(nestedDir, 0o755);
+
+  await rm(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test("mkdir() allows creating the same directory with the recursive flag", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "mkdir_" });
+  const testDir = join(tempDirPath, "dir");
+
+  await mkdir(testDir);
+  await mkdir(testDir, { recursive: true });
+  await mkdir(testDir, { recursive: true, mode: 0o731 });
+
+  // The directory retains the same mode when initially created.
+  assertDirectory(testDir, 0o755);
+
+  await rm(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test("mkdir() rejects with AlreadyExists when creating an existing directory", async () => {
+  await assertRejects(async () => {
+    await mkdir(".");
+  }, AlreadyExists);
+});
+
+Deno.test("mkdir() rejects with AlreadyExists when creating a directory that is the same name as a regular file", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "mkdir_" });
+  const testFile = join(tempDirPath, "a-file.txt");
+  await writeFile(testFile, "Hello, Standard Library");
+
+  await assertRejects(async () => {
+    await mkdir(testFile, { recursive: false });
+  }, AlreadyExists);
+
+  await assertRejects(async () => {
+    await mkdir(testFile, { recursive: true });
+  }, AlreadyExists);
+
+  await rm(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test({
+  name:
+    "mkdir() rejects with AlreadyExists when creating a directory on symlinks",
+  ignore: platform() === "win32",
+  fn: async () => {
+    const tempDirPath = await makeTempDir({ prefix: "mkdir_" });
+    const testDir = join(tempDirPath, "dir");
+    const noFile = join(tempDirPath, "nonexistent");
+    const testDirLink = join(tempDirPath, "testDirLink");
+    const noFileLink = join(tempDirPath, "noFileSymlink");
+
+    await mkdir(testDir);
+    await symlink(testDir, testDirLink);
+    await symlink(noFile, noFileLink);
+
+    await assertRejects(async () => {
+      await mkdir(noFileLink);
+    }, AlreadyExists);
+
+    await assertRejects(async () => {
+      await mkdir(testDirLink);
+    }, AlreadyExists);
+
+    await rm(tempDirPath, { recursive: true, force: true });
+  },
+});
+
+Deno.test("mkdirSync() creates a directory with the default mode", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "mkdirSync_" });
+  const testDir = join(tempDirPath, "testDir");
+
+  mkdirSync(testDir);
+  assertDirectory(testDir, 0o755);
+
+  rmSync(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test("mkdirSync() creates a directory with a user-defined mode", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "mkdirSync_" });
+  const testDir = join(tempDirPath, "testDir");
+
+  mkdirSync(testDir, { mode: 0o700 });
+  assertDirectory(testDir, 0o700);
+
+  rmSync(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test("mkdirSync() recursively creates directories with the default mode", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "mkdirSync_" });
+  const recurPath = join(tempDirPath, "nested/dir");
+  const nestedDir = join(tempDirPath, "nested");
+
+  mkdirSync(recurPath, { recursive: true });
+  assertDirectory(recurPath, 0o755);
+  assertDirectory(nestedDir, 0o755);
+
+  rmSync(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test("mkdirSync() allows creating the same directory with the recursive flag", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "mkdirSync_" });
+  const testDir = join(tempDirPath, "dir");
+
+  mkdirSync(testDir);
+  mkdirSync(testDir, { recursive: true });
+  mkdirSync(testDir, { recursive: true, mode: 0o731 });
+
+  // The directory retains the same mode when initially created.
+  assertDirectory(testDir, 0o755);
+
+  rmSync(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test("mkdirSync() throws with AlreadyExists when creating an existing directory", () => {
+  assertThrows(() => {
+    mkdirSync(".");
+  }, AlreadyExists);
+});
+
+Deno.test("mkdirSync() throws with AlreadyExists when creating a directory that is the same name as a regular file", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "mkdirSync_" });
+  const testFile = join(tempDirPath, "a-file.txt");
+  writeFileSync(testFile, "Hello, Standard Library");
+
+  assertThrows(() => {
+    mkdirSync(testFile, { recursive: false });
+  }, AlreadyExists);
+
+  assertThrows(() => {
+    mkdirSync(testFile, { recursive: true });
+  }, AlreadyExists);
+
+  rmSync(tempDirPath, { recursive: true, force: true });
+});
+
+Deno.test({
+  name:
+    "mkdir() throws with AlreadyExists when creating a directory on symlinks",
+  ignore: platform() === "win32",
+  fn: () => {
+    const tempDirPath = makeTempDirSync({ prefix: "mkdirSync_" });
+    const testDir = join(tempDirPath, "dir");
+    const noFile = join(tempDirPath, "nonexistent");
+    const testDirLink = join(tempDirPath, "testDirLink");
+    const noFileLink = join(tempDirPath, "noFileSymlink");
+
+    mkdirSync(testDir);
+    symlinkSync(testDir, testDirLink);
+    symlinkSync(noFile, noFileLink);
+
+    assertThrows(() => {
+      mkdirSync(noFileLink);
+    }, AlreadyExists);
+
+    assertThrows(() => {
+      mkdirSync(testDirLink);
+    }, AlreadyExists);
+
+    rmSync(tempDirPath, { recursive: true, force: true });
+  },
+});


### PR DESCRIPTION
This PR adds `mkdir` and `mkdirSync` APIs to the `@std/fs` package which are intended to mirror `Deno.mkdir` and `Deno.mkdirSync` functions.

Towards #6255.