### PR TITLE
BREAKING(tar/unstable): fix handling of mode, uid, and gid

### DIFF
--- a/tar/tar_stream_test.ts
+++ b/tar/tar_stream_test.ts
@@ -204,47 +204,32 @@ Deno.test("parsePath()", async () => {
 Deno.test("validTarStreamOptions()", () => {
   assertValidTarStreamOptions({});
 
-  assertValidTarStreamOptions({ mode: 0 });
+  assertValidTarStreamOptions({ mode: 0o0 });
   assertThrows(
-    () => assertValidTarStreamOptions({ mode: 8 }),
+    () => assertValidTarStreamOptions({ mode: 0o1111111 }),
     TypeError,
-    "Invalid Mode provided",
-  );
-  assertThrows(
-    () => assertValidTarStreamOptions({ mode: 1111111 }),
-    TypeError,
-    "Invalid Mode provided",
+    "Cannot add to the tar archive: Invalid Mode provided",
   );
 
-  assertValidTarStreamOptions({ uid: 0 });
+  assertValidTarStreamOptions({ uid: 0o0 });
   assertThrows(
-    () => assertValidTarStreamOptions({ uid: 8 }),
+    () => assertValidTarStreamOptions({ uid: 0o1111111 }),
     TypeError,
-    "Invalid UID provided",
-  );
-  assertThrows(
-    () => assertValidTarStreamOptions({ uid: 1111111 }),
-    TypeError,
-    "Invalid UID provided",
+    "Cannot add to the tar archive: Invalid UID provided",
   );
 
-  assertValidTarStreamOptions({ gid: 0 });
+  assertValidTarStreamOptions({ gid: 0o0 });
   assertThrows(
-    () => assertValidTarStreamOptions({ gid: 8 }),
+    () => assertValidTarStreamOptions({ gid: 0o1111111 }),
     TypeError,
-    "Invalid GID provided",
-  );
-  assertThrows(
-    () => assertValidTarStreamOptions({ gid: 1111111 }),
-    TypeError,
-    "Invalid GID provided",
+    "Cannot add to the tar archive: Invalid GID provided",
   );
 
-  assertValidTarStreamOptions({ mtime: 0 });
+  assertValidTarStreamOptions({ mtime: 0o0 });
   assertThrows(
     () => assertValidTarStreamOptions({ mtime: NaN }),
     TypeError,
-    "Invalid MTime provided",
+    "Cannot add to the tar archive: Invalid MTime provided",
   );
   assertValidTarStreamOptions({
     mtime: Math.floor(new Date().getTime() / 1000),
@@ -252,7 +237,7 @@ Deno.test("validTarStreamOptions()", () => {
   assertThrows(
     () => assertValidTarStreamOptions({ mtime: new Date().getTime() }),
     TypeError,
-    "Invalid MTime provided",
+    "Cannot add to the tar archive: Invalid MTime provided",
   );
 
   assertValidTarStreamOptions({ uname: "" });
@@ -260,12 +245,12 @@ Deno.test("validTarStreamOptions()", () => {
   assertThrows(
     () => assertValidTarStreamOptions({ uname: "å-abcdef" }),
     TypeError,
-    "Invalid UName provided",
+    "Cannot add to the tar archive: Invalid UName provided",
   );
   assertThrows(
     () => assertValidTarStreamOptions({ uname: "a".repeat(100) }),
     TypeError,
-    "Invalid UName provided",
+    "Cannot add to the tar archive: Invalid UName provided",
   );
 
   assertValidTarStreamOptions({ gname: "" });
@@ -273,12 +258,12 @@ Deno.test("validTarStreamOptions()", () => {
   assertThrows(
     () => assertValidTarStreamOptions({ gname: "å-abcdef" }),
     TypeError,
-    "Invalid GName provided",
+    "Cannot add to the tar archive: Invalid GName provided",
   );
   assertThrows(
     () => assertValidTarStreamOptions({ gname: "a".repeat(100) }),
     TypeError,
-    "Invalid GName provided",
+    "Cannot add to the tar archive: Invalid GName provided",
   );
 
   assertValidTarStreamOptions({ devmajor: "" });
@@ -286,7 +271,7 @@ Deno.test("validTarStreamOptions()", () => {
   assertThrows(
     () => assertValidTarStreamOptions({ devmajor: "123456789" }),
     TypeError,
-    "Invalid DevMajor provided",
+    "Cannot add to the tar archive: Invalid DevMajor provided",
   );
 
   assertValidTarStreamOptions({ devminor: "" });
@@ -294,19 +279,19 @@ Deno.test("validTarStreamOptions()", () => {
   assertThrows(
     () => assertValidTarStreamOptions({ devminor: "123456789" }),
     TypeError,
-    "Invalid DevMinor provided",
+    "Cannot add to the tar archive: Invalid DevMinor provided",
   );
 });
 
 Deno.test("TarStream() with invalid options", async () => {
   const readable = ReadableStream.from<TarStreamInput>([
-    { type: "directory", path: "potato", options: { mode: 9 } },
+    { type: "directory", path: "potato", options: { mode: 0o1111111 } },
   ]).pipeThrough(new TarStream());
 
   await assertRejects(
     () => Array.fromAsync(readable),
     TypeError,
-    "Invalid Mode provided",
+    "Cannot add to the tar archive: Invalid Mode provided",
   );
 });
 

--- a/tar/untar_stream.ts
+++ b/tar/untar_stream.ts
@@ -246,9 +246,9 @@ export class UntarStream
       // Decode Header
       let header: OldStyleFormat | PosixUstarFormat = {
         name: decoder.decode(value.subarray(0, 100)).split("\0")[0]!,
-        mode: parseInt(decoder.decode(value.subarray(100, 108 - 2))),
-        uid: parseInt(decoder.decode(value.subarray(108, 116 - 2))),
-        gid: parseInt(decoder.decode(value.subarray(116, 124 - 2))),
+        mode: parseInt(decoder.decode(value.subarray(100, 108)), 8),
+        uid: parseInt(decoder.decode(value.subarray(108, 116)), 8),
+        gid: parseInt(decoder.decode(value.subarray(116, 124)), 8),
         size: parseInt(decoder.decode(value.subarray(124, 136)).trimEnd(), 8),
         mtime: parseInt(decoder.decode(value.subarray(136, 148 - 1)), 8),
         typeflag: decoder.decode(value.subarray(156, 157)),

--- a/tar/untar_stream_test.ts
+++ b/tar/untar_stream_test.ts
@@ -18,9 +18,9 @@ Deno.test("expandTarArchiveCheckingHeaders", async () => {
       type: "directory",
       path: "./potato",
       options: {
-        mode: 111111,
-        uid: 12,
-        gid: 21,
+        mode: 0o111111,
+        uid: 0o12,
+        gid: 0o21,
         mtime: seconds,
         uname: "potato",
         gname: "cake",
@@ -46,9 +46,9 @@ Deno.test("expandTarArchiveCheckingHeaders", async () => {
   }
   assertEquals(headers, [{
     name: "./potato",
-    mode: 111111,
-    uid: 12,
-    gid: 21,
+    mode: 0o111111,
+    uid: 0o12,
+    gid: 0o21,
     mtime: seconds,
     uname: "potato",
     gname: "cake",
@@ -62,9 +62,9 @@ Deno.test("expandTarArchiveCheckingHeaders", async () => {
     prefix: "",
   }, {
     name: "./text.txt",
-    mode: 644,
-    uid: 0,
-    gid: 0,
+    mode: 0o644,
+    uid: 0o0,
+    gid: 0o0,
     mtime: seconds,
     uname: "",
     gname: "",


### PR DESCRIPTION
Closes: https://github.com/denoland/std/pull/6376

This pull request makes the changes discussed in the other linked pull request.

It changes mode, uid, and gid to accept and decode numbers in the octal format `0o775` instead of decimal format `775`. It also changes slightly the decoding segment of these three to be more compatible with other tar specs.