### PR TITLE
feat(fs/unstable): add utime and utimeSync

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -78,6 +78,7 @@ const ENTRY_POINTS = [
   "../fs/unstable_symlink.ts",
   "../fs/unstable_truncate.ts",
   "../fs/unstable_types.ts",
+  "../fs/unstable_utime.ts",
   "../html/mod.ts",
   "../html/unstable_is_valid_custom_element_name.ts",
   "../http/mod.ts",

--- a/_tools/node_test_runner/run_test.mjs
+++ b/_tools/node_test_runner/run_test.mjs
@@ -63,6 +63,7 @@ import "../../fs/unstable_symlink_test.ts";
 import "../../fs/unstable_truncate_test.ts";
 import "../../fs/unstable_lstat_test.ts";
 import "../../fs/unstable_chmod_test.ts";
+import "../../fs/unstable_utime_test.ts";
 
 for (const testDef of testDefinitions) {
   test(testDef.name, testDef.fn);

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -26,6 +26,7 @@
     "./unstable-real-path": "./unstable_real_path.ts",
     "./unstable-rename": "./unstable_rename.ts",
     "./unstable-stat": "./unstable_stat.ts",
+    "./unstable-utime": "./unstable_utime.ts",
     "./unstable-symlink": "./unstable_symlink.ts",
     "./unstable-truncate": "./unstable_truncate.ts",
     "./unstable-types": "./unstable_types.ts",

--- a/fs/unstable_utime.ts
+++ b/fs/unstable_utime.ts
@@ -38,7 +38,7 @@ export async function utime(
     await Deno.utime(path, atime, mtime);
   } else {
     try {
-      await getNodeFs().promises.utime(path, atime, mtime);
+      await getNodeFs().promises.utimes(path, atime, mtime);
       return;
     } catch (error) {
       throw mapError(error);
@@ -81,7 +81,7 @@ export function utimeSync(
     return Deno.utimeSync(path, atime, mtime);
   } else {
     try {
-      getNodeFs().utimeSync(path, atime, mtime);
+      getNodeFs().utimesSync(path, atime, mtime);
     } catch (error) {
       throw mapError(error);
     }

--- a/fs/unstable_utime.ts
+++ b/fs/unstable_utime.ts
@@ -28,6 +28,9 @@ import { mapError } from "./_map_error.ts";
  * ```
  * @tags allow-write
  * @category File System
+ * @param path The path for the file to be updated
+ * @param atime The new access time
+ * @param mtime The new modified time
  */
 export async function utime(
   path: string | URL,
@@ -71,6 +74,9 @@ export async function utime(
  * ```
  * @tags allow-write
  * @category File System
+ * @param path The path for the file to be updated
+ * @param atime The new access time
+ * @param mtime The new modified time
  */
 export function utimeSync(
   path: string | URL,

--- a/fs/unstable_utime.ts
+++ b/fs/unstable_utime.ts
@@ -28,9 +28,9 @@ import { mapError } from "./_map_error.ts";
  * ```
  * @tags allow-write
  * @category File System
- * @param path The path for the file to be updated
+ * @param path The path to the file to be updated
  * @param atime The new access time
- * @param mtime The new modified time
+ * @param mtime The new modification time
  */
 export async function utime(
   path: string | URL,
@@ -74,9 +74,9 @@ export async function utime(
  * ```
  * @tags allow-write
  * @category File System
- * @param path The path for the file to be updated
+ * @param path The path to the file to be updated
  * @param atime The new access time
- * @param mtime The new modified time
+ * @param mtime The new modification time
  */
 export function utimeSync(
   path: string | URL,

--- a/fs/unstable_utime.ts
+++ b/fs/unstable_utime.ts
@@ -1,0 +1,89 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { getNodeFs, isDeno } from "./_utils.ts";
+import { mapError } from "./_map_error.ts";
+
+/** Changes the access (`atime`) and modification (`mtime`) times of a file
+ * system object referenced by `path`. Given times are either in seconds
+ * (UNIX epoch time) or as `Date` objects.
+ *
+ * Requires `allow-write` permission for the target path
+ *
+ * @example Usage
+ *
+ * ```ts
+ * import { assert } from "@std/assert"
+ * import { utime } from "@std/fs/unstable-utime";
+ * import { stat } from "@std/fs/unstable-stat"
+ *
+ * const newAccessDate = new Date()
+ * const newModifiedDate = new Date()
+ *
+ * const fileBefore = await Deno.stat("README.md")
+ * await Deno.utime("README.md", newAccessDate, newModifiedDate)
+ * const fileAfter = await Deno.stat("README.md")
+ *
+ * assert(fileBefore.atime !== fileAfter.atime)
+ * assert(fileBefore.mtime !== fileAfter.mtime)
+ * ```
+ * @tags allow-write
+ * @category File System
+ */
+export async function utime(
+  path: string | URL,
+  atime: number | Date,
+  mtime: number | Date,
+): Promise<void> {
+  if (isDeno) {
+    await Deno.utime(path, atime, mtime);
+  } else {
+    try {
+      await getNodeFs().promises.utime(path, atime, mtime);
+      return;
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}
+
+/** Synchronously changes the access (`atime`) and modification (`mtime`)
+ * times of the file stream resource. Given times are either in seconds
+ * (UNIX epoch time) or as `Date` objects.
+ *
+ * Requires `allow-write` permission for the target path
+ *
+ * @example Usage
+ *
+ * ```ts
+ * import { assert } from "@std/assert"
+ * import { utimeSync } from "@std/fs/unstable-utime";
+ * import { stat } from "@std/fs/unstable-stat"
+ *
+ * const newAccessDate = new Date()
+ * const newModifiedDate = new Date()
+ *
+ * const fileBefore = await Deno.stat("README.md")
+ * Deno.utimeSync("README.md", newAccessDate, newModifiedDate)
+ * const fileAfter = await Deno.stat("README.md")
+ *
+ * assert(fileBefore.atime !== fileAfter.atime)
+ * assert(fileBefore.mtime !== fileAfter.mtime)
+ * ```
+ * @tags allow-write
+ * @category File System
+ */
+export function utimeSync(
+  path: string | URL,
+  atime: number | Date,
+  mtime: number | Date,
+): void {
+  if (isDeno) {
+    return Deno.utimeSync(path, atime, mtime);
+  } else {
+    try {
+      getNodeFs().utimeSync(path, atime, mtime);
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}

--- a/fs/unstable_utime_test.ts
+++ b/fs/unstable_utime_test.ts
@@ -19,10 +19,10 @@ Deno.test("utime() change atime and mtime date", async () => {
   assert(fileBefore.mtime != fileAfter.mtime);
 });
 
-Deno.test("utime() fail on NotFound file", () => {
+Deno.test("utime() fail on NotFound file", async () => {
   const randomFile = "foo.txt";
 
-  assertRejects(async () => {
+  await assertRejects(async () => {
     await utime(randomFile, now, now);
   }, NotFound);
 });

--- a/fs/unstable_utime_test.ts
+++ b/fs/unstable_utime_test.ts
@@ -1,0 +1,47 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+import { assert, assertRejects, assertThrows } from "@std/assert";
+import { utime, utimeSync } from "./unstable_utime.ts";
+import { NotFound } from "./unstable_errors.js";
+
+import { statSync } from "node:fs";
+
+const now = new Date();
+const filePath = "fs/testdata/copy_file.txt";
+
+Deno.test("utime() change atime and mtime date", async () => {
+  const fileBefore = statSync(filePath);
+
+  await utime(filePath, now, now);
+
+  const fileAfter = statSync(filePath);
+
+  assert(fileBefore.atime != fileAfter.atime);
+  assert(fileBefore.mtime != fileAfter.mtime);
+});
+
+Deno.test("utime() fail on NotFound file", () => {
+  const randomFile = "foo.txt";
+
+  assertRejects(async () => {
+    await utime(randomFile, now, now);
+  }, NotFound);
+});
+
+Deno.test("utimeSync() change atime and mtime data", () => {
+  const fileBefore = statSync(filePath);
+
+  utimeSync(filePath, now, now);
+
+  const fileAfter = statSync(filePath);
+
+  assert(fileBefore.atime != fileAfter.atime);
+  assert(fileBefore.mtime != fileAfter.mtime);
+});
+
+Deno.test("utimeSync() fail on NotFound file", () => {
+  const randomFile = "foo.txt";
+
+  assertThrows(() => {
+    utimeSync(randomFile, now, now);
+  }, NotFound);
+});


### PR DESCRIPTION
This PR is part of the #6255 and adds the `utime` and `utimeSync` to the API
