### PR TITLE
perf(encoding): improve base64 encode/decode performance

### DIFF
--- a/encoding/base64.ts
+++ b/encoding/base64.ts
@@ -22,76 +22,16 @@
  * @module
  */
 
-import { validateBinaryLike } from "./_validate_binary_like.ts";
+import { calcMax, decode, encode } from "./_common64.ts";
+import { detach } from "./_common_detach.ts";
 import type { Uint8Array_ } from "./_types.ts";
 export type { Uint8Array_ };
 
-const base64abc = [
-  "A",
-  "B",
-  "C",
-  "D",
-  "E",
-  "F",
-  "G",
-  "H",
-  "I",
-  "J",
-  "K",
-  "L",
-  "M",
-  "N",
-  "O",
-  "P",
-  "Q",
-  "R",
-  "S",
-  "T",
-  "U",
-  "V",
-  "W",
-  "X",
-  "Y",
-  "Z",
-  "a",
-  "b",
-  "c",
-  "d",
-  "e",
-  "f",
-  "g",
-  "h",
-  "i",
-  "j",
-  "k",
-  "l",
-  "m",
-  "n",
-  "o",
-  "p",
-  "q",
-  "r",
-  "s",
-  "t",
-  "u",
-  "v",
-  "w",
-  "x",
-  "y",
-  "z",
-  "0",
-  "1",
-  "2",
-  "3",
-  "4",
-  "5",
-  "6",
-  "7",
-  "8",
-  "9",
-  "+",
-  "/",
-];
+const padding = "=".charCodeAt(0);
+const alphabet = new TextEncoder()
+  .encode("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/");
+const rAlphabet = new Uint8Array(128).fill(64); // alphabet.length
+alphabet.forEach((byte, i) => rAlphabet[byte] = i);
 
 /**
  * Converts data into a base64-encoded string.
@@ -110,40 +50,16 @@ const base64abc = [
  * ```
  */
 export function encodeBase64(data: ArrayBuffer | Uint8Array | string): string {
-  // CREDIT: https://gist.github.com/enepomnyaschih/72c423f727d395eeaa09697058238727
-  const uint8 = validateBinaryLike(data);
-  let result = "";
-  let i;
-  const l = uint8.length;
-  for (i = 2; i < l; i += 3) {
-    result += base64abc[(uint8[i - 2]!) >> 2];
-    result += base64abc[
-      (((uint8[i - 2]!) & 0x03) << 4) |
-      ((uint8[i - 1]!) >> 4)
-    ];
-    result += base64abc[
-      (((uint8[i - 1]!) & 0x0f) << 2) |
-      ((uint8[i]!) >> 6)
-    ];
-    result += base64abc[(uint8[i]!) & 0x3f];
-  }
-  if (i === l + 1) {
-    // 1 octet yet to write
-    result += base64abc[(uint8[i - 2]!) >> 2];
-    result += base64abc[((uint8[i - 2]!) & 0x03) << 4];
-    result += "==";
-  }
-  if (i === l) {
-    // 2 octets yet to write
-    result += base64abc[(uint8[i - 2]!) >> 2];
-    result += base64abc[
-      (((uint8[i - 2]!) & 0x03) << 4) |
-      ((uint8[i - 1]!) >> 4)
-    ];
-    result += base64abc[((uint8[i - 1]!) & 0x0f) << 2];
-    result += "=";
-  }
-  return result;
+  if (typeof data === "string") {
+    data = new TextEncoder().encode(data) as Uint8Array_;
+  } else if (data instanceof ArrayBuffer) data = new Uint8Array(data).slice();
+  else data = data.slice();
+  const [output, i] = detach(
+    data as Uint8Array_,
+    calcMax((data as Uint8Array_).length),
+  );
+  encode(output, i, 0, alphabet, padding);
+  return new TextDecoder().decode(output);
 }
 
 /**
@@ -166,11 +82,8 @@ export function encodeBase64(data: ArrayBuffer | Uint8Array | string): string {
  * ```
  */
 export function decodeBase64(b64: string): Uint8Array_ {
-  const binString = atob(b64);
-  const size = binString.length;
-  const bytes = new Uint8Array(size);
-  for (let i = 0; i < size; i++) {
-    bytes[i] = binString.charCodeAt(i);
-  }
-  return bytes;
+  const output = new TextEncoder().encode(b64) as Uint8Array_;
+  // deno-lint-ignore no-explicit-any
+  return new Uint8Array((output.buffer as any)
+    .transfer(decode(output, 0, 0, rAlphabet, padding)));
 }

--- a/encoding/base64url_test.ts
+++ b/encoding/base64url_test.ts
@@ -50,7 +50,7 @@ Deno.test("decodeBase64Url() throws on invalid input", () => {
     assertThrows(
       () => decodeBase64Url(invalidb64url),
       TypeError,
-      "invalid character",
+      "Invalid Character",
     );
   }
 });
@@ -67,7 +67,7 @@ Deno.test("decodeBase64Url() throws on illegal base64url string", () => {
     assertThrows(
       () => decodeBase64Url(illegalBase64url),
       TypeError,
-      "Illegal base64url string",
+      "Invalid Character",
     );
   }
 });


### PR DESCRIPTION
Closes: https://github.com/denoland/std/issues/5944

This pull request brings the performance added in https://github.com/denoland/std/pull/6457 to the stable base64 and base64url functions, but in a non-breaking manner. The only difference a user would find is a difference in error message if providing an invalid encoded string.