### PR TITLE
feat(fs/unstable): add writeTextFile and writeTextFileSync

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -82,6 +82,7 @@ const ENTRY_POINTS = [
   "../fs/unstable_types.ts",
   "../fs/unstable_umask.ts",
   "../fs/unstable_utime.ts",
+  "../fs/unstable_write_file.ts",
   "../html/mod.ts",
   "../html/unstable_is_valid_custom_element_name.ts",
   "../http/mod.ts",

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -83,6 +83,7 @@ const ENTRY_POINTS = [
   "../fs/unstable_umask.ts",
   "../fs/unstable_utime.ts",
   "../fs/unstable_write_file.ts",
+  "../fs/unstable_write_text_file.ts",
   "../html/mod.ts",
   "../html/unstable_is_valid_custom_element_name.ts",
   "../http/mod.ts",

--- a/_tools/node_test_runner/run_test.mjs
+++ b/_tools/node_test_runner/run_test.mjs
@@ -63,6 +63,7 @@ import "../../fs/unstable_stat_test.ts";
 import "../../fs/unstable_symlink_test.ts";
 import "../../fs/unstable_truncate_test.ts";
 import "../../fs/unstable_write_file_test.ts";
+import "../../fs/unstable_write_text_file_test.ts";
 import "../../fs/unstable_lstat_test.ts";
 import "../../fs/unstable_chmod_test.ts";
 import "../../fs/unstable_umask_test.ts";

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -33,6 +33,7 @@
     "./unstable-types": "./unstable_types.ts",
     "./unstable-umask": "./unstable_umask.ts",
     "./unstable-write-file": "./unstable_write_file.ts",
+    "./unstable-write-text-file": "./unstable_write_text_file.ts",
     "./walk": "./walk.ts"
   }
 }

--- a/fs/unstable_write_text_file.ts
+++ b/fs/unstable_write_text_file.ts
@@ -1,0 +1,103 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { getNodeFs, isDeno } from "./_utils.ts";
+import { getWriteFsFlag } from "./_get_fs_flag.ts";
+import { mapError } from "./_map_error.ts";
+import type { WriteFileOptions } from "./unstable_types.ts";
+
+/**
+ * Write string `data` to the given `path`, by default creating a new file if
+ * needed, else overwriting.
+ *
+ * Requires `allow-write` permission, and `allow-read` if `options.create` is
+ * `false`.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { writeTextFile } from "@std/fs/unstable-write-text-file";
+ * await writeTextFile("hello1.txt", "Hello world\n");  // overwrite "hello1.txt" or create it
+ * ```
+ *
+ * @tags allow-read, allow-write
+ *
+ * @param path The path of the file that `data` is written to.
+ * @param data A UTF-8 string or a stream of UTF-8 strings.
+ * @param options Options for writing files. See {@linkcode WriteFileOptions}.
+ */
+export async function writeTextFile(
+  path: string | URL,
+  data: string | ReadableStream<string>,
+  options?: WriteFileOptions,
+): Promise<void> {
+  if (isDeno) {
+    await Deno.writeTextFile(path, data, { ...options });
+  } else {
+    const {
+      append = false,
+      create = true,
+      createNew = false,
+      mode,
+      signal,
+    } = options ?? {};
+
+    const flag = getWriteFsFlag({ append, create, createNew });
+    try {
+      await getNodeFs().promises.writeFile(path, data, {
+        encoding: "utf-8",
+        flag,
+        signal,
+      });
+      if (mode != null) {
+        await getNodeFs().promises.chmod(path, mode);
+      }
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}
+
+/**
+ * Synchronously write string `data` to the given `path`, by default creating
+ * a new file if needed, else overwriting.
+ *
+ * Requires `allow-write` permission, and `allow-read` if `options.create` is
+ * `false`.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { writeTextFileSync } from "@std/fs/unstable-write-text-file";
+ * writeTextFileSync("hello1.txt", "Hello world\n");  // overwrite "hello1.txt" or create it
+ * ```
+ *
+ * @tags allow-read, allow-write
+ *
+ * @param path The path of the file that `data` is written to.
+ * @param data A UTF-8 string.
+ * @param options Options for writing files. See {@linkcode WriteFileOptions}.
+ */
+export function writeTextFileSync(
+  path: string | URL,
+  data: string,
+  options?: WriteFileOptions,
+): void {
+  if (isDeno) {
+    Deno.writeTextFileSync(path, data, { ...options });
+  } else {
+    const {
+      append = false,
+      create = true,
+      createNew = false,
+      mode,
+    } = options ?? {};
+
+    const flag = getWriteFsFlag({ append, create, createNew });
+    try {
+      getNodeFs().writeFileSync(path, data, { encoding: "utf-8", flag });
+      if (mode != null) {
+        getNodeFs().chmodSync(path, mode);
+      }
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}

--- a/fs/unstable_write_text_file_test.ts
+++ b/fs/unstable_write_text_file_test.ts
@@ -1,0 +1,328 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import {
+  assert,
+  assertEquals,
+  assertExists,
+  assertRejects,
+  assertThrows,
+  unreachable,
+} from "@std/assert";
+import { isDeno } from "./_utils.ts";
+import {
+  writeTextFile,
+  writeTextFileSync,
+} from "./unstable_write_text_file.ts";
+import { AlreadyExists, NotFound } from "./unstable_errors.js";
+import { makeTempDir, makeTempDirSync } from "./unstable_make_temp_dir.ts";
+import { readTextFile, readTextFileSync } from "./unstable_read_text_file.ts";
+import { stat, statSync } from "./unstable_stat.ts";
+import { remove, removeSync } from "./unstable_remove.ts";
+import { join } from "node:path";
+import { platform } from "node:os";
+
+function assertMissing(path: string | URL) {
+  if (pathExists(path)) {
+    throw new Error(`File: ${path} exists`);
+  }
+}
+
+function pathExists(path: string | URL): boolean {
+  try {
+    statSync(path);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+Deno.test("writeTextFile() succeeds in writing to a file", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  await writeTextFile(testFile, "Hello");
+  const data = await readTextFile(testFile);
+  assertEquals(data, "Hello");
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() writes with a ReadableStream object", async () => {
+  const readStream = new ReadableStream({
+    pull(controller) {
+      controller.enqueue("Hello");
+      controller.enqueue(", Standard");
+      controller.enqueue(" Library");
+      controller.close();
+    },
+  });
+
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  await writeTextFile(testFile, readStream);
+  const data = await readTextFile(testFile);
+  assertEquals(data, "Hello, Standard Library");
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() handles 'append' to a file", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  await writeTextFile(testFile, "Hello");
+  const readBefore = await readTextFile(testFile);
+  assertEquals(readBefore, "Hello");
+
+  await writeTextFile(testFile, ", Standard Library", { append: true });
+  const readAfter = await readTextFile(testFile);
+  assertEquals(readAfter, "Hello, Standard Library");
+
+  // Turn off append to overwrite file.
+  await writeTextFile(testFile, "Standard Library", { append: false });
+  const readAfterOverwrite = await readTextFile(testFile);
+  assertEquals(readAfterOverwrite, "Standard Library");
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() handles 'create' for a file", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  await assertRejects(async () => {
+    await writeTextFile(testFile, "Hello", { create: false });
+  }, NotFound);
+
+  await writeTextFile(testFile, "Hello", { create: true });
+  const readData = await readTextFile(testFile);
+  assertEquals(readData, "Hello");
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() handles 'createNew' for a file", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  await writeTextFile(testFile, "Hello", { createNew: true });
+  const readData = await readTextFile(testFile);
+  assertEquals(readData, "Hello");
+
+  await assertRejects(async () => {
+    await writeTextFile(testFile, "Hello", { createNew: true });
+  }, AlreadyExists);
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test({
+  name: "writeTextFile() can change the mode of a file",
+  ignore: platform() === "win32",
+  fn: async () => {
+    const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+    const testFile = join(tempDirPath, "testFile.txt");
+
+    await writeTextFile(testFile, "Hello");
+    const fileStatBefore = await stat(testFile);
+    assertExists(fileStatBefore.mode, "mode is null");
+    assertEquals(fileStatBefore.mode & 0o777, 0o644);
+
+    await writeTextFile(testFile, "Hello", { mode: 0o222 });
+    const fileStatAfter = await stat(testFile);
+    assertExists(fileStatAfter.mode, "mode is null");
+    assertEquals(fileStatAfter.mode & 0o777, 0o222);
+
+    await remove(tempDirPath, { recursive: true });
+  },
+});
+
+Deno.test("writeTextFile() handles an AbortSignal", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+  const ac = new AbortController();
+  queueMicrotask(() => ac.abort());
+
+  const error = await assertRejects(async () => {
+    await writeTextFile(testFile, "Hello", { signal: ac.signal });
+  }, Error);
+  assertEquals(error.name, "AbortError");
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() handles an AbortSignal with a reason", async () => {
+  const ac = new AbortController();
+  const reasonErr = new Error();
+  queueMicrotask(() => ac.abort(reasonErr));
+
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  const error = await assertRejects(async () => {
+    await writeTextFile(testFile, "Hello", { signal: ac.signal });
+  }, Error);
+
+  if (isDeno) {
+    assertEquals(error, ac.signal.reason);
+  } else {
+    assertEquals(error.cause, ac.signal.reason);
+  }
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() handles an AbortSignal with a primitive reason", async () => {
+  const ac = new AbortController();
+  const reasonErr = "This is a primitive string.";
+  queueMicrotask(() => ac.abort(reasonErr));
+
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  try {
+    await writeTextFile(testFile, "Hello", { signal: ac.signal });
+  } catch (error) {
+    if (isDeno) {
+      assertEquals(error, ac.signal.reason);
+    } else {
+      const errorValue = error as Error;
+      assertEquals(errorValue.cause, ac.signal.reason);
+    }
+  }
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() writes to a file successfully with an attached AbortSignal", async () => {
+  const ac = new AbortController();
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  await writeTextFile(testFile, "Hello", { signal: ac.signal });
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() handles an AbortSignal invoked prior to writing the file", async () => {
+  const ac = new AbortController();
+  ac.abort();
+
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  try {
+    await writeTextFile(testFile, "Hello", { signal: ac.signal });
+    unreachable();
+  } catch (error) {
+    assert(error instanceof Error);
+    assert(error.name === "AbortError");
+  }
+  assertMissing(testFile);
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFile() rejects with a NotFound when writing to a nonexistent path", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "writeTextFile_" });
+  const testPath = join(tempDirPath, "dir/testFile.txt");
+
+  await assertRejects(async () => {
+    await writeTextFile(testPath, "Hello, Standard Library");
+  }, NotFound);
+
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFileSync() succeeds in writing to a file", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "writeTextFileSync_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  writeTextFileSync(testFile, "Hello");
+  const data = readTextFileSync(testFile);
+  assertEquals(data, "Hello");
+
+  removeSync(tempDirPath, { recursive: true });
+});
+
+Deno.test({
+  name: "writeTextFileSync() can change the mode of a file",
+  ignore: platform() === "win32",
+  fn: () => {
+    const tempDirPath = makeTempDirSync({ prefix: "writeTextFileSync_" });
+    const testFile = join(tempDirPath, "testFile.txt");
+
+    writeTextFileSync(testFile, "Hello");
+    const fileStatBefore = statSync(testFile);
+    assertExists(fileStatBefore.mode, "mode is null");
+    assertEquals(fileStatBefore.mode & 0o777, 0o644);
+
+    writeTextFileSync(testFile, "Hello", { mode: 0o222 });
+    const fileStatAfter = statSync(testFile);
+    assertExists(fileStatAfter.mode, "mode is null");
+    assertEquals(fileStatAfter.mode & 0o777, 0o222);
+
+    removeSync(tempDirPath, { recursive: true });
+  },
+});
+
+Deno.test("writeTextFileSync() handles 'append' to a file", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "writeTextFileSync_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  writeTextFileSync(testFile, "Hello");
+  const readBefore = readTextFileSync(testFile);
+  assertEquals(readBefore, "Hello");
+
+  writeTextFileSync(testFile, ", Standard Library", { append: true });
+  const readAfter = readTextFileSync(testFile);
+  assertEquals(readAfter, "Hello, Standard Library");
+
+  // Turn off append to overwrite file.
+  writeTextFileSync(testFile, "Standard Library", { append: false });
+  const readAfterOverwrite = readTextFileSync(testFile);
+  assertEquals(readAfterOverwrite, "Standard Library");
+
+  removeSync(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFileSync() handles 'create' for a file", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "writeTextFileSync_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  assertThrows(() => {
+    writeTextFileSync(testFile, "Hello", { create: false });
+  }, NotFound);
+
+  writeTextFileSync(testFile, "Hello", { create: true });
+  const readData = readTextFileSync(testFile);
+  assertEquals(readData, "Hello");
+
+  removeSync(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFileSync() handles 'createNew' for a file", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "writeTextFileSync_" });
+  const testFile = join(tempDirPath, "testFile.txt");
+
+  writeTextFileSync(testFile, "Hello", { createNew: true });
+  const readData = readTextFileSync(testFile);
+  assertEquals(readData, "Hello");
+
+  assertThrows(() => {
+    writeTextFileSync(testFile, "Hello", { createNew: true });
+  }, AlreadyExists);
+
+  removeSync(tempDirPath, { recursive: true });
+});
+
+Deno.test("writeTextFileSync() throws with a NotFound when writing to a nonexistent path", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "writeTextFileSync_" });
+  const testPath = join(tempDirPath, "dir/testFile.txt");
+
+  assertThrows(() => {
+    writeTextFileSync(testPath, "Hello, Standard Library");
+  }, NotFound);
+
+  removeSync(tempDirPath, { recursive: true });
+});


### PR DESCRIPTION
This PR adds `writeTextFile` and `writeTextFileSync` APIs to `@std/fs` package. These functions mirror the `Deno.writeTextFile` and `Deno.writeTextFileSync` APIs.

Also, the `unstable_write_file.ts` is added to the doc checker in this PR.

Towards #6255.