### PR TITLE
feat(fs/unstable): add makeTempFile and makeTempFileSync

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -68,6 +68,7 @@ const ENTRY_POINTS = [
   "../fs/unstable_link.ts",
   "../fs/unstable_lstat.ts",
   "../fs/unstable_make_temp_dir.ts",
+  "../fs/unstable_make_temp_file.ts",
   "../fs/unstable_mkdir.ts",
   "../fs/unstable_read_dir.ts",
   "../fs/unstable_read_file.ts",

--- a/_tools/node_test_runner/run_test.mjs
+++ b/_tools/node_test_runner/run_test.mjs
@@ -51,6 +51,7 @@ import "../../collections/zip_test.ts";
 import "../../fs/unstable_copy_file_test.ts";
 import "../../fs/unstable_link_test.ts";
 import "../../fs/unstable_make_temp_dir_test.ts";
+import "../../fs/unstable_make_temp_file_test.ts";
 import "../../fs/unstable_mkdir_test.ts";
 import "../../fs/unstable_read_dir_test.ts";
 import "../../fs/unstable_read_file_test.ts";

--- a/fs/_utils.ts
+++ b/fs/_utils.ts
@@ -48,3 +48,13 @@ export function getNodePath() {
 export function getNodeProcess() {
   return (globalThis as any).process.getBuiltinModule("node:process");
 }
+
+/**
+ * Used for naming temporary files. See {@linkcode makeTempFile} and
+ * {@linkcode makeTempFileSync}.
+ * @returns A randomized 6-digit hexadecimal string.
+ */
+export function randomId(): string {
+  const n = (Math.random() * 0xfffff * 1_000_000).toString(16);
+  return "".concat(n.slice(0, 6));
+}

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -18,6 +18,7 @@
     "./unstable-link": "./unstable_link.ts",
     "./unstable-lstat": "./unstable_lstat.ts",
     "./unstable-make-temp-dir": "./unstable_make_temp_dir.ts",
+    "./unstable-make-temp-file": "./unstable_make_temp_file.ts",
     "./unstable-mkdir": "./unstable_mkdir.ts",
     "./unstable-read-dir": "./unstable_read_dir.ts",
     "./unstable-read-file": "./unstable_read_file.ts",

--- a/fs/unstable_make_temp_file.ts
+++ b/fs/unstable_make_temp_file.ts
@@ -1,0 +1,156 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { getNodeOs, getNodePath, isDeno, randomId } from "./_utils.ts";
+import { mapError } from "./_map_error.ts";
+import type { MakeTempOptions } from "./unstable_types.ts";
+import {
+  writeTextFile,
+  writeTextFileSync,
+} from "./unstable_write_text_file.ts";
+
+/**
+ * Creates a new temporary file in the default directory for temporary files,
+ * unless `dir` is specified.
+ *
+ * Other options include prefixing and suffixing the directory name with
+ * `prefix` and `suffix` respectively.
+ *
+ * This call resolves to the full path to the newly created file.
+ *
+ * Multiple programs calling this function simultaneously will create different
+ * files. It is the caller's responsibility to remove the file when no longer
+ * needed.
+ *
+ * Requires `allow-write` permission.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { makeTempFile } from "@std/fs/unstable-make-temp-file";
+ * const tmpFileName0 = await makeTempFile();  // e.g. /tmp/419e0bf2
+ * const tmpFileName1 = await makeTempFile({ prefix: 'my_temp' });  // e.g. /tmp/my_temp754d3098
+ * ```
+ *
+ * @tags allow-write
+ *
+ * @param options The options specified when creating a temporary file.
+ * @returns A Promise that resolves to a file path to the temporary file.
+ */
+export async function makeTempFile(options?: MakeTempOptions): Promise<string> {
+  if (isDeno) {
+    return Deno.makeTempFile({ ...options });
+  } else {
+    const {
+      dir,
+      prefix,
+      suffix,
+    } = options ?? {};
+    try {
+      const { tmpdir } = getNodeOs();
+      const { join } = getNodePath();
+
+      let tempFilePath;
+      if (!options) {
+        tempFilePath = join(tmpdir(), randomId());
+        await writeTextFile(tempFilePath, "", { mode: 0o600 });
+        return tempFilePath;
+      }
+
+      tempFilePath = tmpdir();
+      if (dir != null) {
+        tempFilePath = typeof dir === "string" ? dir : ".";
+        if (tempFilePath === "") {
+          tempFilePath = ".";
+        }
+      }
+
+      if (prefix != null && typeof prefix === "string") {
+        tempFilePath = join(tempFilePath, prefix + randomId());
+      } else {
+        tempFilePath = join(tempFilePath, randomId());
+      }
+
+      if (suffix != null && typeof suffix === "string") {
+        tempFilePath += suffix;
+      }
+
+      await writeTextFile(tempFilePath, "", { mode: 0o600 });
+      return tempFilePath;
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}
+
+/**
+ * Synchronously creates a new temporary file in the default directory for
+ * temporary files, unless `dir` is specified.
+ *
+ * Other options include prefixing and suffixing the directory name with
+ * `prefix` and `suffix` respectively.
+ *
+ * The full path to the newly created file is returned.
+ *
+ * Multiple programs calling this function simultaneously will create different
+ * files. It is the caller's responsibility to remove the file when no longer
+ * needed.
+ *
+ * Requires `allow-write` permission.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { makeTempFileSync } from "@std/fs/unstable-make-temp-file";
+ * const tempFileName0 = makeTempFileSync(); // e.g. /tmp/419e0bf2
+ * const tempFileName1 = makeTempFileSync({ prefix: 'my_temp' });  // e.g. /tmp/my_temp754d3098
+ * ```
+ *
+ * @tags allow-write
+ *
+ * @param options The options specified when creating a temporary file.
+ * @returns The file path to the temporary file.
+ */
+export function makeTempFileSync(options?: MakeTempOptions): string {
+  if (isDeno) {
+    return Deno.makeTempFileSync({ ...options });
+  } else {
+    const {
+      dir,
+      prefix,
+      suffix,
+    } = options ?? {};
+
+    try {
+      const { tmpdir } = getNodeOs();
+      const { join } = getNodePath();
+
+      let tempFilePath;
+      if (!options) {
+        tempFilePath = join(tmpdir(), randomId());
+        writeTextFileSync(tempFilePath, "", { mode: 0o600 });
+        return tempFilePath;
+      }
+
+      tempFilePath = tmpdir();
+      if (dir != null) {
+        tempFilePath = typeof dir === "string" ? dir : ".";
+        if (tempFilePath === "") {
+          tempFilePath = ".";
+        }
+      }
+
+      if (prefix != null && typeof prefix === "string") {
+        tempFilePath = join(tempFilePath, prefix + randomId());
+      } else {
+        tempFilePath = join(tempFilePath, randomId());
+      }
+
+      if (suffix != null && typeof suffix === "string") {
+        tempFilePath += suffix;
+      }
+
+      writeTextFileSync(tempFilePath, "", { mode: 0o600 });
+      return tempFilePath;
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}

--- a/fs/unstable_make_temp_file_test.ts
+++ b/fs/unstable_make_temp_file_test.ts
@@ -1,0 +1,85 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { assert, assertRejects, assertThrows } from "@std/assert";
+import { makeTempFile, makeTempFileSync } from "./unstable_make_temp_file.ts";
+import { NotFound } from "./unstable_errors.js";
+import { makeTempDir, makeTempDirSync } from "./unstable_make_temp_dir.ts";
+import { remove, removeSync } from "./unstable_remove.ts";
+
+Deno.test("makeTempFile() creates temporary files in the default temp directory path", async () => {
+  const tempFile1 = await makeTempFile({
+    prefix: "standard",
+    suffix: "library",
+  });
+  const tempFile2 = await makeTempFile({
+    prefix: "standard",
+    suffix: "library",
+  });
+
+  try {
+    assert(tempFile1 !== tempFile2);
+
+    for (const file of [tempFile1, tempFile2]) {
+      const tempFileName = file.replace(/^.*[\\\/]/, "");
+      assert(tempFileName.startsWith("standard"));
+      assert(tempFileName.endsWith("library"));
+    }
+  } finally {
+    await remove(tempFile1);
+    await remove(tempFile2);
+  }
+});
+
+Deno.test("makeTempFile() creates temporary files in the 'dir' option", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "makeTempFile_" });
+  const tempFile = await makeTempFile({ dir: tempDirPath });
+
+  try {
+    assert(tempFile.startsWith(tempDirPath));
+    assert(/^[\\\/]/.test(tempFile.slice(tempDirPath.length)));
+  } finally {
+    await remove(tempDirPath, { recursive: true });
+  }
+});
+
+Deno.test("makeTempFile() rejects with NotFound when passing a 'dir' path that does not exist", async () => {
+  await assertRejects(async () => {
+    await makeTempFile({ dir: "/non-existent-dir" });
+  }, NotFound);
+});
+
+Deno.test("makeTempFileSync() creates temporary files in the default temp directory path", () => {
+  const tempFile1 = makeTempFileSync({ prefix: "standard", suffix: "library" });
+  const tempFile2 = makeTempFileSync({ prefix: "standard", suffix: "library" });
+
+  try {
+    assert(tempFile1 !== tempFile2);
+
+    for (const file of [tempFile1, tempFile2]) {
+      const tempFileName = file.replace(/^.*[\\\/]/, "");
+      assert(tempFileName.startsWith("standard"));
+      assert(tempFileName.endsWith("library"));
+    }
+  } finally {
+    removeSync(tempFile1);
+    removeSync(tempFile2);
+  }
+});
+
+Deno.test("makeTempFileSync() creates temporary files in the 'dir' option", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "makeTempFileSync_" });
+  const tempFile = makeTempFileSync({ dir: tempDirPath });
+
+  try {
+    assert(tempFile.startsWith(tempDirPath));
+    assert(/^[\\\/]/.test(tempFile.slice(tempDirPath.length)));
+  } finally {
+    removeSync(tempDirPath, { recursive: true });
+  }
+});
+
+Deno.test("makeTempFileSync() throws with NotFound when passing a 'dir' path that does not exist", () => {
+  assertThrows(() => {
+    makeTempFileSync({ dir: "/non-existent-dir" });
+  }, NotFound);
+});


### PR DESCRIPTION
This PR adds the `makeTempFile` and `makeTempFileSync` APIs to the `@std/fs` package which are intended to mirror `Deno.makeTempFile` and `Deno.makeTempFileSync` APIs.  This PR also adds `randomId` as a utility function to help generate 6-digit hexadecimal file names when using these APIs under a Node.js runtime.

Towards #6255.