### PR TITLE
fix(encoding): decoding base64 with invalid bytes >= 128

### DIFF
--- a/encoding/_common64.ts
+++ b/encoding/_common64.ts
@@ -114,7 +114,7 @@ export function decode(
 }
 
 function getByte(char: number, alphabet: Uint8Array): number {
-  const byte = alphabet[char]!;
+  const byte = alphabet[char] ?? 64;
   if (byte === 64) { // alphabet.Base64.length
     throw new TypeError(`Invalid Character (${String.fromCharCode(char)})`);
   }

--- a/encoding/unstable_base32_test.ts
+++ b/encoding/unstable_base32_test.ts
@@ -289,3 +289,12 @@ Deno.test("decodeRawBase32() with invalid offsets", () => {
     }
   }
 });
+
+Deno.test("decodeBase32() throws with invalid byte >= 128", () => {
+  const input = new TextDecoder().decode(new Uint8Array(5).fill(200));
+  assertThrows(
+    () => decodeBase32(input),
+    TypeError,
+    "Invalid Character",
+  );
+});

--- a/encoding/unstable_base64_test.ts
+++ b/encoding/unstable_base64_test.ts
@@ -227,3 +227,12 @@ Deno.test("decodeRawBase64() with invalid offsets", () => {
     }
   }
 });
+
+Deno.test("decodeBase64() throws with invalid byte >= 128", () => {
+  const input = new TextDecoder().decode(new Uint8Array(4).fill(200));
+  assertThrows(
+    () => decodeBase64(input),
+    TypeError,
+    "Invalid Character",
+  );
+});


### PR DESCRIPTION
This pull request fixes a simple bug where when decoding base64 the functions wouldn't throw when encountering an invalid byte between 128 - 256. Since the `rAlphabet` varaible only goes up to 128, any bytes not matching this range would return undefined and then later be interpreted as a 0 byte when it was meant to throw an error.