### PR TITLE
fix(assert): make prototype of Object.prototype not equal undefined prototype

### DIFF
--- a/assert/equal.ts
+++ b/assert/equal.ts
@@ -9,9 +9,7 @@ function isKeyedCollection(x: unknown): x is KeyedCollection {
 function prototypesEqual(a: object, b: object) {
   const pa = Object.getPrototypeOf(a);
   const pb = Object.getPrototypeOf(b);
-  return pa === pb ||
-    pa === Object.prototype && pb === null ||
-    pa === null && pb === Object.prototype;
+  return pa === pb;
 }
 
 function isBasicObjectOrArray(obj: object) {

--- a/assert/equal_test.ts
+++ b/assert/equal_test.ts
@@ -383,6 +383,18 @@ Deno.test("equal() with constructor and prototype", async (t) => {
   });
 });
 
+Deno.test("equal() considers object with prototype Object.prototype not equal to object with no prototype", () => {
+  const a = Object.create(Object.prototype);
+  const b = Object.create(null);
+  assertFalse(equal(a, b));
+  assertFalse(equal(b, a));
+
+  // ensure the only difference is the prototype
+  Object.setPrototypeOf(b, Object.prototype);
+  assert(equal(a, b));
+  assert(equal(b, a));
+});
+
 Deno.test("equal() with dynamic properties defined on the prototype", async (t) => {
   await t.step("built-in web APIs", async (t) => {
     await t.step("URLPattern", () => {


### PR DESCRIPTION
Fixes #6334

These were previously hardcoded to be equal, and I'm not completely sure why. I hope I'm not missing something.

It's not mentioned in the PR when it was added (#6153). I suspect it was a port of the old system, where constructors were checked rather than prototypes: Undefined constructor could equal Object constructor. But undefined prototype should not equal Object prototype.