### PR TITLE
fix(assert,expect,internal,testing): improve handling of escaped chars in diff_str

### DIFF
--- a/internal/diff_str.ts
+++ b/internal/diff_str.ts
@@ -32,7 +32,7 @@ export function unescape(string: string): string {
     );
 }
 
-const WHITESPACE_SYMBOLS = /([^\S\r\n]+|[()[\]{}'"\r\n]|\b)/;
+const WHITESPACE_SYMBOLS = /([^\S\r\n]+|\\[bftvrn]|[()[\]{}'"\r\n]|\b)/;
 
 /**
  * Tokenizes a string into an array of tokens.

--- a/internal/diff_str.ts
+++ b/internal/diff_str.ts
@@ -21,6 +21,7 @@ import { diff } from "./diff.ts";
  */
 export function unescape(string: string): string {
   return string
+    .replaceAll("\\", "\\\\")
     .replaceAll("\b", "\\b")
     .replaceAll("\f", "\\f")
     .replaceAll("\t", "\\t")
@@ -32,7 +33,8 @@ export function unescape(string: string): string {
     );
 }
 
-const WHITESPACE_SYMBOLS = /([^\S\r\n]+|\\[bftvrn]|[()[\]{}'"\r\n]|\b)/;
+const WHITESPACE_SYMBOLS =
+  /((?:\\[bftv]|[^\S\r\n])+|\\[rn\\]|[()[\]{}'"\r\n]|\b)/;
 
 /**
  * Tokenizes a string into an array of tokens.

--- a/internal/diff_str_test.ts
+++ b/internal/diff_str_test.ts
@@ -79,6 +79,35 @@ Deno.test({
 });
 
 Deno.test({
+  name: 'diff() "a b" vs "a  b" (diffstr)',
+  fn() {
+    const diffResult = diffStr("a b", "a  b");
+    assertEquals(diffResult, [
+      {
+        details: [
+          { type: "common", value: "a" },
+          { type: "removed", value: " " },
+          { type: "common", value: "b" },
+          { type: "common", value: "\n" },
+        ],
+        type: "removed",
+        value: "a b\n",
+      },
+      {
+        details: [
+          { type: "common", value: "a" },
+          { type: "added", value: "  " },
+          { type: "common", value: "b" },
+          { type: "common", value: "\n" },
+        ],
+        type: "added",
+        value: "a  b\n",
+      },
+    ]);
+  },
+});
+
+Deno.test({
   name: `diff() "3.14" vs "2.71" (diffStr)`,
   fn() {
     const diffResult = diffStr("3.14", "2.71");
@@ -219,6 +248,35 @@ Deno.test({
 });
 
 Deno.test({
+  name: `diff() single line, "a\\\\tb" vs "a\tb" (diffStr)`,
+  fn() {
+    const diffResult = diffStr("a\\tb", "a\tb");
+    assertEquals(diffResult, [
+      {
+        type: "removed",
+        value: "a\\\\tb\n",
+        details: [
+          { type: "common", value: "a" },
+          { type: "removed", value: "\\\\" },
+          { type: "removed", value: "tb" },
+          { type: "common", value: "\n" },
+        ],
+      },
+      {
+        type: "added",
+        value: "a\\tb\n",
+        details: [
+          { type: "common", value: "a" },
+          { type: "added", value: "\\t" },
+          { type: "added", value: "b" },
+          { type: "common", value: "\n" },
+        ],
+      },
+    ]);
+  },
+});
+
+Deno.test({
   name: `diff() "\\b\\f\\r\\t\\v\\n" vs "\\r\\n" (diffStr)`,
   fn() {
     const diffResult = diffStr("\b\f\r\t\v\n", "\r\n");
@@ -227,11 +285,9 @@ Deno.test({
         type: "removed",
         value: "\\b\\f\\r\\t\\v\\n\n",
         details: [
-          { type: "removed", value: "\\b" },
-          { type: "removed", value: "\\f" },
+          { type: "removed", value: "\\b\\f" },
           { type: "common", value: "\\r" },
-          { type: "removed", value: "\\t" },
-          { type: "removed", value: "\\v" },
+          { type: "removed", value: "\\t\\v" },
           { type: "common", value: "\\n" },
           { type: "common", value: "\n" },
         ],

--- a/internal/diff_str_test.ts
+++ b/internal/diff_str_test.ts
@@ -43,8 +43,7 @@ Deno.test({
         value: "x\\n\n",
         details: [
           { type: "added", value: "x" },
-          { type: "common", value: "\\" },
-          { type: "common", value: "n" },
+          { type: "common", value: "\\n" },
           { type: "common", value: "\n" },
         ],
       },
@@ -53,8 +52,7 @@ Deno.test({
         value: "d\\n\n",
         details: [
           { type: "common", value: "d" },
-          { type: "added", value: "\\" },
-          { type: "added", value: "n" },
+          { type: "added", value: "\\n" },
           { type: "common", value: "\n" },
         ],
       },
@@ -64,8 +62,7 @@ Deno.test({
         value: "c\\n\n",
         details: [
           { type: "removed", value: "c" },
-          { type: "common", value: "\\" },
-          { type: "common", value: "n" },
+          { type: "common", value: "\\n" },
           { type: "common", value: "\n" },
         ],
       },
@@ -193,6 +190,35 @@ Deno.test({
 });
 
 Deno.test({
+  name: `diff() single line, "a\tb" vs "a\fb" (diffStr)`,
+  fn() {
+    const diffResult = diffStr("a\tb", "a\fb");
+    assertEquals(diffResult, [
+      {
+        type: "removed",
+        value: "a\\tb\n",
+        details: [
+          { type: "common", value: "a" },
+          { type: "removed", value: "\\t" },
+          { type: "common", value: "b" },
+          { type: "common", value: "\n" },
+        ],
+      },
+      {
+        type: "added",
+        value: "a\\fb\n",
+        details: [
+          { type: "common", value: "a" },
+          { type: "added", value: "\\f" },
+          { type: "common", value: "b" },
+          { type: "common", value: "\n" },
+        ],
+      },
+    ]);
+  },
+});
+
+Deno.test({
   name: `diff() "\\b\\f\\r\\t\\v\\n" vs "\\r\\n" (diffStr)`,
   fn() {
     const diffResult = diffStr("\b\f\r\t\v\n", "\r\n");
@@ -201,18 +227,12 @@ Deno.test({
         type: "removed",
         value: "\\b\\f\\r\\t\\v\\n\n",
         details: [
-          { type: "common", value: "\\" },
-          { type: "removed", value: "b" },
-          { type: "removed", value: "\\" },
-          { type: "removed", value: "f" },
-          { type: "removed", value: "\\" },
-          { type: "common", value: "r" },
-          { type: "common", value: "\\" },
-          { type: "removed", value: "t" },
-          { type: "removed", value: "\\" },
-          { type: "removed", value: "v" },
-          { type: "removed", value: "\\" },
-          { type: "common", value: "n" },
+          { type: "removed", value: "\\b" },
+          { type: "removed", value: "\\f" },
+          { type: "common", value: "\\r" },
+          { type: "removed", value: "\\t" },
+          { type: "removed", value: "\\v" },
+          { type: "common", value: "\\n" },
           { type: "common", value: "\n" },
         ],
       },
@@ -220,10 +240,8 @@ Deno.test({
         type: "added",
         value: "\\r\\n\r\n",
         details: [
-          { type: "common", value: "\\" },
-          { type: "common", value: "r" },
-          { type: "common", value: "\\" },
-          { type: "common", value: "n" },
+          { type: "common", value: "\\r" },
+          { type: "common", value: "\\n" },
           { type: "added", value: "\r" },
           { type: "common", value: "\n" },
         ],


### PR DESCRIPTION
- Fixes #6326
- Fixes `a\\tb` vs `a\tb`: previously these would be detected as `!==` and cause `assertEquals` to reject, but `diff_str` found no difference
- Combines escaped spaces: `"  "` (double space) is currently treated as one token. This change makes `"\t\f"` also be treated as one token instead of four
  - Adds one test and updates another because the space-combining was previously untested