### PR TITLE
refactor(encoding): align error messages

### DIFF
--- a/encoding/_common16.ts
+++ b/encoding/_common16.ts
@@ -44,7 +44,9 @@ export function decode(
 ): number {
   if ((buffer.length - o) % 2 === 1) {
     throw new TypeError(
-      `Invalid Character (${String.fromCharCode(buffer[buffer.length - 1]!)})`,
+      `Cannot decode input as hex: Invalid character (${
+        String.fromCharCode(buffer[buffer.length - 1]!)
+      })`,
     );
   }
 
@@ -59,7 +61,11 @@ export function decode(
 function getByte(char: number, alphabet: Uint8Array): number {
   const byte = alphabet[char] ?? 16;
   if (byte === 16) { // alphabet.Hex.length
-    throw new TypeError(`Invalid Character (${String.fromCharCode(char)})`);
+    throw new TypeError(
+      `Cannot decode input as hex: Invalid character (${
+        String.fromCharCode(char)
+      })`,
+    );
   }
   return byte;
 }

--- a/encoding/_common16.ts
+++ b/encoding/_common16.ts
@@ -43,7 +43,7 @@ export function decode(
   alphabet: Uint8Array,
 ): number {
   if ((buffer.length - o) % 2 === 1) {
-    throw new TypeError(
+    throw new RangeError(
       `Cannot decode input as hex: Length (${
         buffer.length - o
       }) must be divisible by 2`,

--- a/encoding/_common32.ts
+++ b/encoding/_common32.ts
@@ -109,7 +109,9 @@ export function decode(
       for (let y = x + 1; y < buffer.length; ++y) {
         if (buffer[y] !== padding) {
           throw new TypeError(
-            `Invalid Character (${String.fromCharCode(buffer[y]!)})`,
+            `Cannot decode input as base32: Invalid character (${
+              String.fromCharCode(buffer[y]!)
+            })`,
           );
         }
       }
@@ -122,7 +124,7 @@ export function decode(
     case 3:
     case 1:
       throw new RangeError(
-        `Length (${
+        `Cannot decode input as base32: Length (${
           buffer.length - o
         }), excluding padding, must not have a remainder of 1, 3, or 6 when divided by 8`,
       );
@@ -195,7 +197,11 @@ export function decode(
 function getByte(char: number, alphabet: Uint8Array): number {
   const byte = alphabet[char] ?? 32;
   if (byte === 32) { // alphabet.Base32.length
-    throw new TypeError(`Invalid Character (${String.fromCharCode(char)})`);
+    throw new TypeError(
+      `Cannot decode input as base32: Invalid character (${
+        String.fromCharCode(char)
+      })`,
+    );
   }
   return byte;
 }

--- a/encoding/_common32.ts
+++ b/encoding/_common32.ts
@@ -121,10 +121,10 @@ export function decode(
     case 6:
     case 3:
     case 1:
-      throw new TypeError(
-        `Invalid Character (${
-          String.fromCharCode(buffer[buffer.length - 1]!)
-        })`,
+      throw new RangeError(
+        `Length (${
+          buffer.length - o
+        }), excluding padding, must not have a remainder of 1, 3, or 6 when divided by 8`,
       );
   }
 

--- a/encoding/_common64.ts
+++ b/encoding/_common64.ts
@@ -70,7 +70,9 @@ export function decode(
       for (let y = x + 1; y < buffer.length; ++y) {
         if (buffer[y] !== padding) {
           throw new TypeError(
-            `Invalid Character (${String.fromCharCode(buffer[y]!)})`,
+            `Cannot decode input as base64: Invalid character (${
+              String.fromCharCode(buffer[y]!)
+            })`,
           );
         }
       }
@@ -80,7 +82,7 @@ export function decode(
   }
   if ((buffer.length - o) % 4 === 1) {
     throw new RangeError(
-      `Length (${
+      `Cannot decode input as base64: Length (${
         buffer.length - o
       }), excluding padding, must not have a remainder of 1 when divided by 4`,
     );
@@ -118,7 +120,11 @@ export function decode(
 function getByte(char: number, alphabet: Uint8Array): number {
   const byte = alphabet[char] ?? 64;
   if (byte === 64) { // alphabet.Base64.length
-    throw new TypeError(`Invalid Character (${String.fromCharCode(char)})`);
+    throw new TypeError(
+      `Cannot decode input as base64: Invalid character (${
+        String.fromCharCode(char)
+      })`,
+    );
   }
   return byte;
 }

--- a/encoding/_common64.ts
+++ b/encoding/_common64.ts
@@ -79,8 +79,10 @@ export function decode(
     }
   }
   if ((buffer.length - o) % 4 === 1) {
-    throw new TypeError(
-      `Invalid Character (${String.fromCharCode(buffer[buffer.length - 1]!)})`,
+    throw new RangeError(
+      `Length (${
+        buffer.length - o
+      }), excluding padding, must not have a remainder of 1 when divided by 4`,
     );
   }
 

--- a/encoding/base32_test.ts
+++ b/encoding/base32_test.ts
@@ -50,7 +50,7 @@ Deno.test({
     assertThrows(
       () => decodeBase32("5HXR334AQYAAAA=========="),
       Error,
-      "Invalid Character (=)",
+      "Cannot decode input as base32: Invalid character (=)",
     );
   },
 });

--- a/encoding/base64url_test.ts
+++ b/encoding/base64url_test.ts
@@ -66,8 +66,8 @@ Deno.test("decodeBase64Url() throws on illegal base64url string", () => {
   for (const illegalBase64url of testsetIllegalBase64url) {
     assertThrows(
       () => decodeBase64Url(illegalBase64url),
-      TypeError,
-      "Invalid Character",
+      RangeError,
+      `Length (${illegalBase64url.length}), excluding padding, must not have a remainder of 1 when divided by 4`,
     );
   }
 });

--- a/encoding/base64url_test.ts
+++ b/encoding/base64url_test.ts
@@ -50,7 +50,7 @@ Deno.test("decodeBase64Url() throws on invalid input", () => {
     assertThrows(
       () => decodeBase64Url(invalidb64url),
       TypeError,
-      "Invalid Character",
+      "Cannot decode input as base64: Invalid character",
     );
   }
 });

--- a/encoding/hex_test.ts
+++ b/encoding/hex_test.ts
@@ -24,26 +24,26 @@ const errCases: [string, ErrorConstructor, string][] = [
   [
     "0",
     RangeError,
-    "Length (1) must be divisible by 2",
+    "Cannot decode input as hex: Length (1) must be divisible by 2",
   ],
   [
     "zd4aa",
     RangeError,
-    "Length (5) must be divisible by 2",
+    "Cannot decode input as hex: Length (5) must be divisible by 2",
   ],
-  ["d4az", TypeError, "Invalid Character (z)"],
+  ["d4az", TypeError, "Cannot decode input as hex: Invalid character (z)"],
   [
     "30313",
     RangeError,
-    "Length (5) must be divisible by 2",
+    "Cannot decode input as hex: Length (5) must be divisible by 2",
   ],
-  ["0g", TypeError, "Invalid Character (g)"],
-  ["00gg", TypeError, "Invalid Character (g)"],
-  ["0\x01", TypeError, "Invalid Character (\x01)"],
+  ["0g", TypeError, "Cannot decode input as hex: Invalid character (g)"],
+  ["00gg", TypeError, "Cannot decode input as hex: Invalid character (g)"],
+  ["0\x01", TypeError, "Cannot decode input as hex: Invalid character (\x01)"],
   [
     "ffeed",
     RangeError,
-    "Length (5) must be divisible by 2",
+    "Cannot decode input as hex: Length (5) must be divisible by 2",
   ],
 ];
 

--- a/encoding/unstable_base32.ts
+++ b/encoding/unstable_base32.ts
@@ -151,7 +151,9 @@ export function encodeRawBase32(
   format: Base32Format = "Base32",
 ): number {
   const max = calcMax(buffer.length - i);
-  if (max > buffer.length - o) throw new RangeError("Buffer too small");
+  if (max > buffer.length - o) {
+    throw new RangeError("Cannot encode buffer as base32: Buffer too small");
+  }
   return encode(buffer, i, o, alphabet[format], padding);
 }
 
@@ -241,7 +243,7 @@ export function decodeRawBase32(
 ): number {
   if (i < o) {
     throw new RangeError(
-      "Input (i) must be greater than or equal to output (o)",
+      "Cannot decode buffer as base32: Input (i) must be greater than or equal to output (o)",
     );
   }
   return decode(buffer, i, o, rAlphabet[format], padding);

--- a/encoding/unstable_base32_test.ts
+++ b/encoding/unstable_base32_test.ts
@@ -189,7 +189,7 @@ Deno.test("decodeBase32() invalid char after padding", () => {
       assertThrows(
         () => decodeBase32(input, format),
         TypeError,
-        "Invalid Character (.)",
+        "Cannot decode input as base32: Invalid character (.)",
         format,
       );
     }
@@ -232,7 +232,7 @@ Deno.test("decodeBase32() invalid char", () => {
       assertThrows(
         () => decodeBase32(input, format),
         TypeError,
-        "Invalid Character (.)",
+        "Cannot decode input as base32: Invalid character (.)",
         format,
       );
     }
@@ -295,6 +295,6 @@ Deno.test("decodeBase32() throws with invalid byte >= 128", () => {
   assertThrows(
     () => decodeBase32(input),
     TypeError,
-    "Invalid Character",
+    "Cannot decode input as base32: Invalid character",
   );
 });

--- a/encoding/unstable_base32_test.ts
+++ b/encoding/unstable_base32_test.ts
@@ -210,8 +210,8 @@ Deno.test("decodeBase32() invalid length", () => {
     ) {
       assertThrows(
         () => decodeBase32(input, format),
-        TypeError,
-        "Invalid Character (A)",
+        RangeError,
+        `Length (${input.length}), excluding padding, must not have a remainder of 1, 3, or 6 when divided by 8`,
         format,
       );
     }

--- a/encoding/unstable_base64.ts
+++ b/encoding/unstable_base64.ts
@@ -147,7 +147,9 @@ export function encodeRawBase64(
   format: Base64Format = "Base64",
 ): number {
   const max = calcMax(buffer.length - i);
-  if (max > buffer.length - o) throw new RangeError("Buffer too small");
+  if (max > buffer.length - o) {
+    throw new RangeError("Cannot encode buffer as base64: Buffer too small");
+  }
   o = encode(buffer, i, o, alphabet[format], padding);
   if (format === "Base64Url") {
     i = buffer.indexOf(padding, o - 2);
@@ -237,7 +239,7 @@ export function decodeRawBase64(
 ): number {
   if (i < o) {
     throw new RangeError(
-      "Input (i) must be greater than or equal to output (o)",
+      "Cannot decode buffer as base64: Input (i) must be greater than or equal to output (o)",
     );
   }
   return decode(buffer, i, o, rAlphabet[format], padding);

--- a/encoding/unstable_base64_test.ts
+++ b/encoding/unstable_base64_test.ts
@@ -132,7 +132,7 @@ Deno.test("decodeBase64() invalid char after padding", () => {
       assertThrows(
         () => decodeBase64(input, format),
         TypeError,
-        "Invalid Character (.)",
+        "Cannot decode input as base64: Invalid character (.)",
         format,
       );
     }
@@ -178,7 +178,7 @@ Deno.test("decodeBase64() invalid char", () => {
       assertThrows(
         () => decodeBase64(input, format),
         TypeError,
-        "Invalid Character (.)",
+        "Cannot decode input as base64: Invalid character (.)",
         format,
       );
     }
@@ -233,6 +233,6 @@ Deno.test("decodeBase64() throws with invalid byte >= 128", () => {
   assertThrows(
     () => decodeBase64(input),
     TypeError,
-    "Invalid Character",
+    "Cannot decode input as base64: Invalid character",
   );
 });

--- a/encoding/unstable_base64_test.ts
+++ b/encoding/unstable_base64_test.ts
@@ -157,8 +157,8 @@ Deno.test("decodeBase64() invalid length", () => {
     ) {
       assertThrows(
         () => decodeBase64(input, format),
-        TypeError,
-        "Invalid Character (a)",
+        RangeError,
+        `Length (${input.length}), excluding padding, must not have a remainder of 1 when divided by 4`,
         format,
       );
     }

--- a/encoding/unstable_hex.ts
+++ b/encoding/unstable_hex.ts
@@ -119,7 +119,9 @@ export function encodeRawHex(
   o: number,
 ): number {
   const max = calcMax(buffer.length - i);
-  if (max > buffer.length - o) throw new RangeError("Buffer too small");
+  if (max > buffer.length - o) {
+    throw new RangeError("Cannot encode buffer as hex: Buffer too small");
+  }
   return encode(buffer, i, o, alphabet);
 }
 
@@ -192,7 +194,7 @@ export function decodeRawHex(
 ): number {
   if (i < o) {
     throw new RangeError(
-      "Input (i) must be greater than or equal to output (o)",
+      "Cannot decode buffer as hex: Input (i) must be greater than or equal to output (o)",
     );
   }
   return decode(buffer, i, o, rAlphabet);

--- a/encoding/unstable_hex_test.ts
+++ b/encoding/unstable_hex_test.ts
@@ -96,7 +96,7 @@ Deno.test("decodeHex() invalid length", () => {
     assertThrows(
       () => decodeHex(output + "a"),
       TypeError,
-      "Invalid Character (a)",
+      "Cannot decode input as hex: Invalid character (a)",
     );
   }
 });
@@ -108,7 +108,7 @@ Deno.test("decodeHex() invalid char", () => {
     assertThrows(
       () => decodeHex(".".repeat(2) + output),
       TypeError,
-      "Invalid Character (.)",
+      "Cannot decode input as hex: Invalid character (.)",
     );
   }
 });
@@ -152,6 +152,6 @@ Deno.test("decodeHex() throws with invalid byte >= 128", () => {
   assertThrows(
     () => decodeHex(input),
     TypeError,
-    "Invalid Character",
+    "Cannot decode input as hex: Invalid character",
   );
 });

--- a/encoding/unstable_hex_test.ts
+++ b/encoding/unstable_hex_test.ts
@@ -95,7 +95,7 @@ Deno.test("decodeHex() invalid length", () => {
 
     assertThrows(
       () => decodeHex(output + "a"),
-      TypeError,
+      RangeError,
       `Cannot decode input as hex: Length (${
         output.length + 1
       }) must be divisible by 2`,


### PR DESCRIPTION
Jumping from this conversation: https://github.com/denoland/std/pull/6499#discussion_r2006977391

This pull request updates the error message when the input has an invalid length to properly decode