### PR TITLE
fix(front-matter): handle BOM when recognizing format

### DIFF
--- a/front_matter/_formats.ts
+++ b/front_matter/_formats.ts
@@ -8,13 +8,13 @@ export type Format = "yaml" | "toml" | "json";
 
 const BOM = "\\ufeff?";
 
-const YAML_HEADER = `(?:---yaml|= yaml =|---)`;
+const YAML_HEADER = `${BOM}(?:---yaml|= yaml =|---)`;
 const YAML_FOOTER = `(?:= yaml =|---)`;
 
-const TOML_HEADER = `(?:---toml|\\+\\+\\+|= toml =)`;
+const TOML_HEADER = `${BOM}(?:---toml|\\+\\+\\+|= toml =)`;
 const TOML_FOOTER = `(?:---|\\+\\+\\+|= toml =)`;
 
-const JSON_HEADER = `(?:---json|= json =)`;
+const JSON_HEADER = `${BOM}(?:---json|= json =)`;
 const JSON_FOOTER = `(?:---|= json =)`;
 
 const WHITESPACES = "\\s*";
@@ -23,29 +23,29 @@ const NEWLINE = "\\r?\\n";
 const FRONT_MATTER = "(?<frontMatter>.+?)";
 const BODY = "(?:\\r?\\n(?<body>.+))?";
 
-export const RECOGNIZE_YAML_REGEXP = new RegExp(
+const RECOGNIZE_YAML_REGEXP = new RegExp(
   `^${YAML_HEADER}${WHITESPACES}${NEWLINE}`,
   "i",
 );
-export const RECOGNIZE_TOML_REGEXP = new RegExp(
+const RECOGNIZE_TOML_REGEXP = new RegExp(
   `^${TOML_HEADER}${WHITESPACES}${NEWLINE}`,
   "i",
 );
-export const RECOGNIZE_JSON_REGEXP = new RegExp(
+const RECOGNIZE_JSON_REGEXP = new RegExp(
   `^${JSON_HEADER}${WHITESPACES}${NEWLINE}`,
   "i",
 );
 
 export const EXTRACT_YAML_REGEXP = new RegExp(
-  `^${BOM}${YAML_HEADER}${WHITESPACES}${NEWLINE}${WHITESPACES}(?:${FRONT_MATTER}${WHITESPACES}${NEWLINE})?${YAML_FOOTER}${WHITESPACES}${BODY}$`,
+  `^${YAML_HEADER}${WHITESPACES}${NEWLINE}${WHITESPACES}(?:${FRONT_MATTER}${WHITESPACES}${NEWLINE})?${YAML_FOOTER}${WHITESPACES}${BODY}$`,
   "is",
 );
 export const EXTRACT_TOML_REGEXP = new RegExp(
-  `^${BOM}${TOML_HEADER}${WHITESPACES}${NEWLINE}${WHITESPACES}(?:${FRONT_MATTER}${WHITESPACES}${NEWLINE})?${TOML_FOOTER}${WHITESPACES}${BODY}$`,
+  `^${TOML_HEADER}${WHITESPACES}${NEWLINE}${WHITESPACES}(?:${FRONT_MATTER}${WHITESPACES}${NEWLINE})?${TOML_FOOTER}${WHITESPACES}${BODY}$`,
   "is",
 );
 export const EXTRACT_JSON_REGEXP = new RegExp(
-  `^${BOM}${JSON_HEADER}${WHITESPACES}${NEWLINE}${WHITESPACES}(?:${FRONT_MATTER}${WHITESPACES}${NEWLINE})?${JSON_FOOTER}${WHITESPACES}${BODY}$`,
+  `^${JSON_HEADER}${WHITESPACES}${NEWLINE}${WHITESPACES}(?:${FRONT_MATTER}${WHITESPACES}${NEWLINE})?${JSON_FOOTER}${WHITESPACES}${BODY}$`,
   "is",
 );
 

--- a/front_matter/any_test.ts
+++ b/front_matter/any_test.ts
@@ -65,3 +65,19 @@ Hello, world!`;
     "Unsupported front matter format",
   );
 });
+
+Deno.test("extract() handles bom when recognizing format", () => {
+  const actual = extract(
+    `\ufeff---
+  foo: bar
+---
+Hello, world!
+`,
+  );
+  const expected = {
+    attrs: { foo: "bar" },
+    body: "Hello, world!\n",
+    frontMatter: "foo: bar",
+  };
+  assertEquals(actual, expected);
+});


### PR DESCRIPTION
This PR fixes a bug where trying recognize a format throws if the data starts with bom.