### PR TITLE
refactor(datetime): refactor DateTimeFormatter

### DIFF
--- a/datetime/_date_time_formatter.ts
+++ b/datetime/_date_time_formatter.ts
@@ -5,7 +5,7 @@ function digits(value: string | number, count = 2): string {
   return String(value).padStart(count, "0");
 }
 
-// as declared as in namespace Intl
+// as declared in namespace Intl
 type DateTimeFormatPartTypes =
   | "day"
   | "dayPeriod"
@@ -37,130 +37,130 @@ type FormatPart = {
   hour12?: boolean;
 };
 
+const SYMBOL_REGEXP = /^(?<symbol>([a-zA-Z])\2*)/;
 const QUOTED_LITERAL_REGEXP = /^(')(?<value>\\.|[^\']*)\1/;
 const LITERAL_REGEXP = /^(?<value>.+?\s*)/;
-const SYMBOL_REGEXP = /^(?<symbol>([a-zA-Z])\2*)/;
 
 // according to unicode symbols (http://www.unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table)
+function symbolToFormatPart(symbol: string): FormatPart {
+  switch (symbol) {
+    // case "GGGGG":
+    //   return { type: "era", value: "narrow" };
+    // case "GGGG":
+    //   return { type: "era", value: "long" };
+    // case "GGG":
+    // case "GG":
+    // case "G":
+    //   return { type: "era", value: "short" };
+    case "yyyy":
+      return { type: "year", value: "numeric" };
+    case "yy":
+      return { type: "year", value: "2-digit" };
+    case "MMMMM":
+      return { type: "month", value: "narrow" };
+    case "MMMM":
+      return { type: "month", value: "long" };
+    case "MMM":
+      return { type: "month", value: "short" };
+    case "MM":
+      return { type: "month", value: "2-digit" };
+    case "M":
+      return { type: "month", value: "numeric" };
+    case "dd":
+      return { type: "day", value: "2-digit" };
+    case "d":
+      return { type: "day", value: "numeric" };
+    // case "EEEEEE":
+    //   return { type: "weekday", value: "short" };
+    // case "EEEEE":
+    //   return { type: "weekday", value: "narrow" };
+    // case "EEEE":
+    //   return { type: "weekday", value: "long" };
+    // case "EEE":
+    // case "EE":
+    // case "E":
+    //   return { type: "weekday", value: "short" };
+    case "aaaaa":
+      return { type: "dayPeriod", value: "narrow" };
+    case "aaaa":
+      return { type: "dayPeriod", value: "long" };
+    case "aaa":
+    case "aa":
+    case "a":
+      return { type: "dayPeriod", value: "short" };
+    case "HH":
+      return { type: "hour", value: "2-digit" };
+    case "H":
+      return { type: "hour", value: "numeric" };
+    case "hh":
+      return { type: "hour", value: "2-digit", hour12: true };
+    case "h":
+      return { type: "hour", value: "numeric", hour12: true };
+    case "mm":
+      return { type: "minute", value: "2-digit" };
+    case "m":
+      return { type: "minute", value: "numeric" };
+    case "ss":
+      return { type: "second", value: "2-digit" };
+    case "s":
+      return { type: "second", value: "numeric" };
+    case "SSS":
+      return { type: "fractionalSecond", value: 3 };
+    case "SS":
+      return { type: "fractionalSecond", value: 2 };
+    case "S":
+      return { type: "fractionalSecond", value: 1 };
+    // case "zzzz":
+    //   return { type: "timeZoneName", value: "long" };
+    // case "zzz":
+    // case "zz":
+    // case "z":
+    //   return { type: "timeZoneName", value: "short" };
+    // case "ZZZZ":
+    // case "OOOO":
+    //   return { type: "timeZoneName", value: "longOffset" };
+    // case "O":
+    //   return { type: "timeZoneName", value: "shortOffset" };
+    // case "vvvv":
+    //   return { type: "timeZoneName", value: "longGeneric" };
+    // case "v":
+    //   return { type: "timeZoneName", value: "shortGeneric" };
+    default:
+      throw new Error(
+        `ParserError: Cannot parse format symbol "${symbol}"`,
+      );
+  }
+}
+
 function formatToFormatParts(format: string) {
   const formatParts: FormatPart[] = [];
   let index = 0;
   while (index < format.length) {
     const substring = format.slice(index);
-    const symbol = SYMBOL_REGEXP.exec(substring)?.groups?.symbol;
-    switch (symbol) {
-      case "yyyy":
-        formatParts.push({ type: "year", value: "numeric" });
-        index += symbol.length;
-        continue;
-      case "yy":
-        formatParts.push({ type: "year", value: "2-digit" });
-        index += symbol.length;
-        continue;
-      case "MM":
-        formatParts.push({ type: "month", value: "2-digit" });
-        index += symbol.length;
-        continue;
-      case "M":
-        formatParts.push({ type: "month", value: "numeric" });
-        index += symbol.length;
-        continue;
-      case "dd":
-        formatParts.push({ type: "day", value: "2-digit" });
-        index += symbol.length;
-        continue;
-      case "d":
-        formatParts.push({ type: "day", value: "numeric" });
-        index += symbol.length;
-        continue;
-      case "HH":
-        formatParts.push({ type: "hour", value: "2-digit" });
-        index += symbol.length;
-        continue;
-      case "H":
-        formatParts.push({ type: "hour", value: "numeric" });
-        index += symbol.length;
-        continue;
-      case "hh":
-        formatParts.push({ type: "hour", value: "2-digit", hour12: true });
-        index += symbol.length;
-        continue;
-      case "h":
-        formatParts.push({ type: "hour", value: "numeric", hour12: true });
-        index += symbol.length;
-        continue;
-      case "mm":
-        formatParts.push({ type: "minute", value: "2-digit" });
-        index += symbol.length;
-        continue;
-      case "m":
-        formatParts.push({ type: "minute", value: "numeric" });
-        index += symbol.length;
-        continue;
-      case "ss":
-        formatParts.push({ type: "second", value: "2-digit" });
-        index += symbol.length;
-        continue;
-      case "s":
-        formatParts.push({ type: "second", value: "numeric" });
-        index += symbol.length;
-        continue;
-      case "SSS":
-        formatParts.push({ type: "fractionalSecond", value: 3 });
-        index += symbol.length;
-        continue;
-      case "SS":
-        formatParts.push({ type: "fractionalSecond", value: 2 });
-        index += symbol.length;
-        continue;
-      case "S":
-        formatParts.push({ type: "fractionalSecond", value: 1 });
-        index += symbol.length;
-        continue;
-      case "a":
-        formatParts.push({ type: "dayPeriod", value: 1 });
-        index += symbol.length;
-        continue;
+
+    const symbolMatch = SYMBOL_REGEXP.exec(substring);
+    if (symbolMatch) {
+      const symbol = symbolMatch.groups!.symbol!;
+      formatParts.push(symbolToFormatPart(symbol));
+      index += symbol.length;
+      continue;
     }
 
     const quotedLiteralMatch = QUOTED_LITERAL_REGEXP.exec(substring);
     if (quotedLiteralMatch) {
-      const value = quotedLiteralMatch.groups!.value as string;
+      const value = quotedLiteralMatch.groups!.value!;
       formatParts.push({ type: "literal", value });
       index += quotedLiteralMatch[0].length;
       continue;
     }
 
-    const literalGroups = LITERAL_REGEXP.exec(substring)!.groups!;
-    const value = literalGroups.value as string;
+    const literalMatch = LITERAL_REGEXP.exec(substring)!;
+    const value = literalMatch.groups!.value!;
     formatParts.push({ type: "literal", value });
     index += value.length;
   }
 
   return formatParts;
-}
-
-function sortDateTimeFormatParts(
-  parts: DateTimeFormatPart[],
-): DateTimeFormatPart[] {
-  let result: DateTimeFormatPart[] = [];
-  const typeArray = [
-    "year",
-    "month",
-    "day",
-    "hour",
-    "minute",
-    "second",
-    "fractionalSecond",
-  ];
-  for (const type of typeArray) {
-    const current = parts.findIndex((el) => el.type === type);
-    if (current !== -1) {
-      result = result.concat(parts.splice(current, 1));
-    }
-  }
-  result = result.concat(parts);
-  return result;
 }
 
 export class DateTimeFormatter {
@@ -192,7 +192,7 @@ export class DateTimeFormatter {
             }
             default:
               throw new Error(
-                `FormatterError: value "${part.value}" is not supported`,
+                `FormatterError: DateTimeFormatPartType "year" does not support value ${part.value}`,
               );
           }
           break;
@@ -210,7 +210,7 @@ export class DateTimeFormatter {
             }
             default:
               throw new Error(
-                `FormatterError: value "${part.value}" is not supported`,
+                `FormatterError: DateTimeFormatPartType "month" does not support value ${part.value}`,
               );
           }
           break;
@@ -228,7 +228,7 @@ export class DateTimeFormatter {
             }
             default:
               throw new Error(
-                `FormatterError: value "${part.value}" is not supported`,
+                `FormatterError: DateTimeFormatPartType "day" does not support value ${part.value}`,
               );
           }
           break;
@@ -250,7 +250,7 @@ export class DateTimeFormatter {
             }
             default:
               throw new Error(
-                `FormatterError: value "${part.value}" is not supported`,
+                `FormatterError: DateTimeFormatPartType "hour" does not support value ${part.value}`,
               );
           }
           break;
@@ -268,7 +268,7 @@ export class DateTimeFormatter {
             }
             default:
               throw new Error(
-                `FormatterError: value "${part.value}" is not supported`,
+                `FormatterError: DateTimeFormatPartType "minute" does not support value ${part.value}`,
               );
           }
           break;
@@ -286,7 +286,7 @@ export class DateTimeFormatter {
             }
             default:
               throw new Error(
-                `FormatterError: value "${part.value}" is not supported`,
+                `FormatterError: DateTimeFormatPartType "second" does not support value ${part.value}`,
               );
           }
           break;
@@ -295,16 +295,32 @@ export class DateTimeFormatter {
           const value = utc
             ? date.getUTCMilliseconds()
             : date.getMilliseconds();
-          string += digits(value, Number(part.value));
+          string += digits(value, 3).slice(0, Number(part.value));
           break;
         }
-        // FIXME(bartlomieju)
         case "timeZoneName": {
-          // string += utc ? "Z" : part.value
-          break;
+          if (utc) {
+            string += "Z";
+            break;
+          }
+
+          // TODO(WWRS): add support for time zones
+          throw new Error(`FormatterError: Time zone is not supported`);
         }
         case "dayPeriod": {
-          string += date.getHours() >= 12 ? "PM" : "AM";
+          switch (part.value) {
+            case "short":
+            case "long":
+              string += date.getHours() >= 12 ? "PM" : "AM";
+              break;
+            case "narrow":
+              string += date.getHours() >= 12 ? "P" : "A";
+              break;
+            default:
+              throw new Error(
+                `FormatterError: DateTimeFormatPartType "dayPeriod" does not support value ${part.value}`,
+              );
+          }
           break;
         }
         case "literal": {
@@ -324,25 +340,28 @@ export class DateTimeFormatter {
     const parts: DateTimeFormatPart[] = [];
 
     for (const part of this.#formatParts) {
-      const type = part.type;
-      let length = 0;
-      let value = "";
+      let value: string | undefined;
+      // The number of chars consumed in the parse, defaults to `value.length`
+      let parsedLength: number | undefined;
+
       switch (part.type) {
         case "year": {
           switch (part.value) {
             case "numeric": {
-              value = /^\d{1,4}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{4}/.exec(string)?.[0];
               break;
             }
             case "2-digit": {
-              value = /^\d{1,2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{2}/.exec(string)?.[0];
+              if (value !== undefined) {
+                parsedLength = 2;
+                value = `20${value}`;
+              }
               break;
             }
             default:
               throw new Error(
-                `ParserError: value "${part.value}" is not supported`,
+                `ParserError: DateTimeFormatPartType "year" does not support value ${part.value}`,
               );
           }
           break;
@@ -350,33 +369,28 @@ export class DateTimeFormatter {
         case "month": {
           switch (part.value) {
             case "numeric": {
-              value = /^\d{1,2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{1,2}/.exec(string)?.[0];
               break;
             }
             case "2-digit": {
-              value = /^\d{2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{2}/.exec(string)?.[0];
               break;
             }
             case "narrow": {
-              value = /^[a-zA-Z]+/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^[a-zA-Z]+/.exec(string)?.[0];
               break;
             }
             case "short": {
-              value = /^[a-zA-Z]+/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^[a-zA-Z]+/.exec(string)?.[0];
               break;
             }
             case "long": {
-              value = /^[a-zA-Z]+/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^[a-zA-Z]+/.exec(string)?.[0];
               break;
             }
             default:
               throw new Error(
-                `ParserError: value "${part.value}" is not supported`,
+                `ParserError: DateTimeFormatPartType "month" does not support value ${part.value}`,
               );
           }
           break;
@@ -384,18 +398,16 @@ export class DateTimeFormatter {
         case "day": {
           switch (part.value) {
             case "numeric": {
-              value = /^\d{1,2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{1,2}/.exec(string)?.[0];
               break;
             }
             case "2-digit": {
-              value = /^\d{2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{2}/.exec(string)?.[0];
               break;
             }
             default:
               throw new Error(
-                `ParserError: value "${part.value}" is not supported`,
+                `ParserError: DateTimeFormatPartType "day" does not support value ${part.value}`,
               );
           }
           break;
@@ -403,33 +415,26 @@ export class DateTimeFormatter {
         case "hour": {
           switch (part.value) {
             case "numeric": {
-              value = /^\d{1,2}/.exec(string)?.[0] as string;
-              length = value?.length;
-              if (part.hour12 && parseInt(value) > 12) {
-                // TODO(iuioiua): Replace with throwing an error
-                // deno-lint-ignore no-console
-                console.error(
-                  `Trying to parse hour greater than 12, use 'H' instead of 'h'.`,
+              value = /^\d{1,2}/.exec(string)?.[0];
+              if (part.hour12 && value && parseInt(value) > 12) {
+                throw new Error(
+                  `Cannot parse hour greater than 12 with format "h", use "H": hour is ${value}`,
                 );
               }
               break;
             }
             case "2-digit": {
-              value = /^\d{2}/.exec(string)?.[0] as string;
-              length = value?.length;
-              if (part.hour12 && parseInt(value) > 12) {
-                // TODO(iuioiua): Replace with throwing an error
-                // deno-lint-ignore no-console
-                console.error(
-                  `Trying to parse hour greater than 12, use 'HH' instead of 'hh'.`,
+              value = /^\d{2}/.exec(string)?.[0];
+              if (part.hour12 && value && parseInt(value) > 12) {
+                throw new Error(
+                  `Cannot parse hour greater than 12 with format "hh", use "HH": hour is ${value}`,
                 );
               }
               break;
             }
             default:
-              // TODO(iuioiua): Correct error type and message
               throw new Error(
-                `ParserError: value "${part.value}" is not supported`,
+                `ParserError: DateTimeFormatPartType "hour" does not support value "${part.value}"`,
               );
           }
           break;
@@ -437,18 +442,16 @@ export class DateTimeFormatter {
         case "minute": {
           switch (part.value) {
             case "numeric": {
-              value = /^\d{1,2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{1,2}/.exec(string)?.[0];
               break;
             }
             case "2-digit": {
-              value = /^\d{2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{2}/.exec(string)?.[0];
               break;
             }
             default:
               throw new Error(
-                `ParserError: value "${part.value}" is not supported`,
+                `ParserError: DateTimeFormatPartType "minute" does not support value ${part.value}`,
               );
           }
           break;
@@ -456,100 +459,93 @@ export class DateTimeFormatter {
         case "second": {
           switch (part.value) {
             case "numeric": {
-              value = /^\d{1,2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{1,2}/.exec(string)?.[0];
               break;
             }
             case "2-digit": {
-              value = /^\d{2}/.exec(string)?.[0] as string;
-              length = value?.length;
+              value = /^\d{2}/.exec(string)?.[0];
               break;
             }
             default:
               throw new Error(
-                `ParserError: value "${part.value}" is not supported`,
+                `ParserError: DateTimeFormatPartType "second" does not support value ${part.value}`,
               );
           }
           break;
         }
         case "fractionalSecond": {
-          value = new RegExp(`^\\d{${part.value}}`).exec(string)
-            ?.[0] as string;
-          length = value?.length;
+          const re = new RegExp(`^\\d{${part.value}}`);
+          value = re.exec(string)?.[0];
           break;
         }
         case "timeZoneName": {
-          value = part.value as string;
-          length = value?.length;
+          // TODO(WWRS): validate time zone name
+          value = String(part.value);
           break;
         }
         case "dayPeriod": {
-          value = /^[AP](?:\.M\.|M\.?)/i.exec(string)?.[0] as string;
-          switch (value.toUpperCase()) {
+          value = /^[AP](?:\.M\.|M\.?)/i.exec(string)?.[0];
+          parsedLength = value?.length;
+          switch (value?.toUpperCase()) {
             case "AM":
-              value = "AM";
-              length = 2;
-              break;
             case "AM.":
-              value = "AM";
-              length = 3;
-              break;
             case "A.M.":
               value = "AM";
-              length = 4;
               break;
             case "PM":
-              value = "PM";
-              length = 2;
-              break;
             case "PM.":
-              value = "PM";
-              length = 3;
-              break;
             case "P.M.":
               value = "PM";
-              length = 4;
               break;
             default:
-              throw new Error(`DayPeriod '${value}' is not supported.`);
+              throw new Error(
+                `ParserError: Could not parse dayPeriod from "${value}"`,
+              );
           }
           break;
         }
         case "literal": {
-          if (!string.startsWith(part.value as string)) {
+          if (typeof part.value !== "string") {
             throw new Error(
-              `Literal "${part.value}" not found "${string.slice(0, 25)}"`,
+              `ParserError: DateTimeFormatPartType "literal" does not support value ${part.value}`,
             );
           }
-          value = part.value as string;
-          length = value?.length;
+          if (!string.startsWith(part.value)) {
+            throw new Error(
+              `ParserError: DateTimeFormatPartType "literal" expected value "${part.value}" at the start of remaining input, but found "${
+                string.slice(0, 25)
+              }"`,
+            );
+          }
+          value = part.value;
           break;
         }
 
         default:
           throw new Error(
-            `Cannot format the date, the value (${part.value}) of the type (${part.type}) is given`,
+            `ParserError: Unknown type: "${part.type}" (value is ${part.value})`,
           );
       }
 
       if (!value) {
         throw new Error(
-          `Cannot format value: The value is not valid for part { ${type} ${value} } ${
-            string.slice(
-              0,
-              25,
-            )
+          `ParserError: Did not produce a value for type: ${part.type}, remaining input ${
+            string.length === 0
+              ? "is empty"
+              : `starts with "${string.slice(0, 25)}"`
           }`,
         );
       }
-      parts.push({ type, value });
+      parts.push({ type: part.type, value });
 
-      string = string.slice(length);
+      string = string.slice(parsedLength ?? value.length);
     }
 
-    if (string.length) {
+    if (string.length > 0) {
       throw new Error(
-        `datetime string was not fully parsed! ${string.slice(0, 25)}`,
+        `ParserError: Input exceeds format, remaining input starts with "${
+          string.slice(0, 25)
+        }"`,
       );
     }
 
@@ -557,83 +553,98 @@ export class DateTimeFormatter {
   }
 
   partsToDate(parts: DateTimeFormatPart[]): Date {
-    parts = sortDateTimeFormatParts(parts);
+    let year;
+    let month;
+    let day;
+    let hour = 0;
+    let minute = 0;
+    let second = 0;
+    let fractionalSecond = 0;
+    let dayPeriod: "am" | "pm" | undefined = undefined;
+    let utc = false;
 
-    const date = new Date();
-    const utc = parts.find(
-      (part) => part.type === "timeZoneName" && part.value === "UTC",
-    );
-
-    const dayPart = parts.find((part) => part.type === "day");
-
-    utc ? date.setUTCHours(0, 0, 0, 0) : date.setHours(0, 0, 0, 0);
     for (const part of parts) {
       switch (part.type) {
-        case "year": {
-          const value = Number(part.value.padStart(4, "20"));
-          utc ? date.setUTCFullYear(value) : date.setFullYear(value);
+        case "year":
+          year = Number(part.value);
           break;
-        }
-        case "month": {
-          const value = Number(part.value) - 1;
-          if (dayPart) {
-            utc
-              ? date.setUTCMonth(value, Number(dayPart.value))
-              : date.setMonth(value, Number(dayPart.value));
-          } else {
-            utc ? date.setUTCMonth(value) : date.setMonth(value);
+        case "month":
+          month = Number(part.value);
+          break;
+        case "day":
+          day = Number(part.value);
+          break;
+        case "hour":
+          hour = Number(part.value);
+          break;
+        case "minute":
+          minute = Number(part.value);
+          break;
+        case "second":
+          second = Number(part.value);
+          break;
+        case "fractionalSecond":
+          fractionalSecond = Number(part.value);
+          break;
+        case "dayPeriod": {
+          switch (part.value.toUpperCase()) {
+            case "AM":
+            case "AM.":
+            case "A.M.":
+              dayPeriod = "am";
+              break;
+            case "PM":
+            case "PM.":
+            case "P.M.":
+              dayPeriod = "pm";
+              break;
+            default:
+              throw new Error(
+                `ParserError: Could not parse dayPeriod from "${part.value}"`,
+              );
           }
           break;
         }
-        case "day": {
-          const value = Number(part.value);
-          utc ? date.setUTCDate(value) : date.setDate(value);
+        case "timeZoneName":
+          utc = part.value === "UTC";
           break;
-        }
-        case "hour": {
-          let value = Number(part.value);
-          const dayPeriod = parts.find(
-            (part: DateTimeFormatPart) => part.type === "dayPeriod",
-          );
-          if (dayPeriod) {
-            switch (dayPeriod.value.toUpperCase()) {
-              case "AM":
-              case "AM.":
-              case "A.M.":
-                // ignore
-                break;
-              case "PM":
-              case "PM.":
-              case "P.M.":
-                value += 12;
-                break;
-              default:
-                throw new Error(
-                  `dayPeriod '${dayPeriod.value}' is not supported.`,
-                );
-            }
-          }
-          utc ? date.setUTCHours(value) : date.setHours(value);
-          break;
-        }
-        case "minute": {
-          const value = Number(part.value);
-          utc ? date.setUTCMinutes(value) : date.setMinutes(value);
-          break;
-        }
-        case "second": {
-          const value = Number(part.value);
-          utc ? date.setUTCSeconds(value) : date.setSeconds(value);
-          break;
-        }
-        case "fractionalSecond": {
-          const value = Number(part.value);
-          utc ? date.setUTCMilliseconds(value) : date.setMilliseconds(value);
-          break;
-        }
       }
     }
-    return date;
+
+    if (dayPeriod !== undefined) {
+      if (hour === undefined) {
+        throw new Error(
+          `ParserError: Cannot use dayPeriod without hour`,
+        );
+      }
+      if (hour > 12) {
+        throw new Error(
+          `ParserError: Cannot use dayPeriod with hour greater than 12, hour is "${hour}"`,
+        );
+      }
+
+      if (dayPeriod === "pm") {
+        hour += 12;
+      }
+    }
+
+    const date = new Date();
+    if (year === undefined) {
+      year = utc ? date.getUTCFullYear() : date.getFullYear();
+    }
+    if (month === undefined) {
+      month = (utc ? date.getUTCMonth() : date.getMonth()) + 1;
+    }
+    if (day === undefined) {
+      day = utc ? date.getUTCDate() : date.getDate();
+    }
+
+    // TODO(WWRS): add time zone
+    return new Date(
+      `${year}-${digits(month, 2)}-${digits(day, 2)}T${digits(hour, 2)}:${
+        digits(minute, 2)
+      }:${digits(second, 2)}.${digits(fractionalSecond, 3)}${utc ? "Z" : ""}`,
+    );
   }
 
   parse(string: string): Date {

--- a/datetime/parse_test.ts
+++ b/datetime/parse_test.ts
@@ -70,6 +70,14 @@ Deno.test({
       parse("2019-01-03", "yyyy-MM-dd"),
       new Date(2019, 0, 3),
     );
+    assertEquals(
+      parse("19-01-03", "yy-MM-dd"),
+      new Date(2019, 0, 3),
+    );
+    assertEquals(
+      parse("3-1-19", "d-M-yy"),
+      new Date(2019, 0, 3),
+    );
   },
 });
 
@@ -136,6 +144,12 @@ Deno.test("parse(): The date is 2021-12-31", () => {
   assertEquals(
     parse("31", "dd"),
     new Date(2021, 11, 31),
+  );
+
+  // Ensure 2021-02-29 (which does not exist) is not an intermediate result
+  assertEquals(
+    parse("29-02-2020", "dd-MM-yyyy"),
+    new Date(2020, 1, 29),
   );
 });
 


### PR DESCRIPTION
- Fix an issue where fractional seconds are not properly formatted
- Pull static functions out to allow for testing
- Add support for `aa`-`aaaaa` and `MMM`-`MMMMM` to get closer to parity with `Intl` (though the months aren't fully functional)
- Add value validation to `"fractionalSecond"`
- In `formatToParts` > `"year"`
  - Make it stricter: Reject years that are not exactly 2 or 4 digits
  - For 2-digit years, produce the `20XX` value here instead of in `partsToDate`
- Rewrite `partsToDate` to collect all the parts and generate the final date in one step
  - Avoid doing any sorting or searching the array, which were used to handle short months: When generating a full date, short months are handled automatically
  - I think `new Date(...)` will be better for handling time zones
- Remove almost all `as string`s and handle errors caused by the cases where they're not strings
- Rewrite errors to match style guide
- Pull `symbolToFormatPart` out to make control flow in `formatToFormatParts` easier to understand
- Add a ton of tests, bringing coverage up to 100%
- Other minor refactors

TODO:
- Later: Add support for time zones
- Later: Add support for eras and months