### PR TITLE
refactor(ini): remove `IniMap.prototype.#cleanFormatting()`

### DIFF
--- a/ini/_ini_map.ts
+++ b/ini/_ini_map.ts
@@ -65,8 +65,8 @@ export class IniMap<T = any> {
    *
    * @param formatting Optional formatting options when printing an INI file.
    */
-  constructor(formatting?: FormattingOptions) {
-    this.#formatting = this.#cleanFormatting(formatting);
+  constructor(formatting: FormattingOptions = {}) {
+    this.#formatting = formatting;
   }
 
   /**
@@ -215,14 +215,6 @@ export class IniMap<T = any> {
     }
 
     yield line;
-  }
-
-  #cleanFormatting(options?: FormattingOptions): FormattingOptions {
-    return Object.fromEntries(
-      Object.entries(options ?? {}).filter(([key]) =>
-        FormattingKeys.includes(key as keyof FormattingOptions)
-      ),
-    );
   }
 
   /**
@@ -472,13 +464,6 @@ const LineOp = {
   Del: -1,
   Add: 1,
 } as const;
-const DummyFormatting: Required<FormattingOptions> = {
-  lineBreak: "\n",
-  pretty: false,
-};
-const FormattingKeys = Object.keys(
-  DummyFormatting,
-) as (keyof FormattingOptions)[];
 
 interface LineComment {
   type: "comment";


### PR DESCRIPTION
Seems like this is not needed as `IniMap.prototype.#formatting` properties are not dynamically used.