### PR TITLE
fix(datetime): fix formatting of `fractionalSecond`, fix parsing of `yy` and `yyyy`, test each part type in dateTimeFormatter.format

### DIFF
--- a/datetime/_date_time_formatter.ts
+++ b/datetime/_date_time_formatter.ts
@@ -295,7 +295,7 @@ export class DateTimeFormatter {
           const value = utc
             ? date.getUTCMilliseconds()
             : date.getMilliseconds();
-          string += digits(value, Number(part.value));
+          string += digits(value, 3).slice(0, Number(part.value));
           break;
         }
         // FIXME(bartlomieju)
@@ -331,12 +331,12 @@ export class DateTimeFormatter {
         case "year": {
           switch (part.value) {
             case "numeric": {
-              value = /^\d{1,4}/.exec(string)?.[0] as string;
+              value = /^\d{4}/.exec(string)?.[0] as string;
               length = value?.length;
               break;
             }
             case "2-digit": {
-              value = /^\d{1,2}/.exec(string)?.[0] as string;
+              value = /^\d{2}/.exec(string)?.[0] as string;
               length = value?.length;
               break;
             }

--- a/datetime/_date_time_formatter_test.ts
+++ b/datetime/_date_time_formatter_test.ts
@@ -3,29 +3,141 @@ import { assertEquals, assertThrows } from "@std/assert";
 import { FakeTime } from "@std/testing/time";
 import { DateTimeFormatter } from "./_date_time_formatter.ts";
 
-Deno.test("dateTimeFormatter.format()", () => {
-  const cases = [
-    ["yyyy-MM-dd HH:mm:ss a", new Date(2020, 0, 1), "2020-01-01 00:00:00 AM"],
-    [
-      "yyyy-MM-dd HH:mm:ss a",
-      new Date(2020, 0, 1, 23, 59, 59),
-      "2020-01-01 23:59:59 PM",
-    ],
-    [
-      "yyyy-MM-dd hh:mm:ss a",
-      new Date(2020, 0, 1, 23, 59, 59),
-      "2020-01-01 11:59:59 PM",
-    ],
-    ["yyyy-MM-dd a", new Date(2020, 0, 1), "2020-01-01 AM"],
-    ["yyyy-MM-dd HH:mm:ss a", new Date(2020, 0, 1), "2020-01-01 00:00:00 AM"],
-    ["yyyy-MM-dd hh:mm:ss a", new Date(2020, 0, 1), "2020-01-01 12:00:00 AM"],
-    ["yyyy", new Date(2020, 0, 1), "2020"],
-    ["MM", new Date(2020, 0, 1), "01"],
-  ] as const;
-  for (const [format, date, expected] of cases) {
-    const formatter = new DateTimeFormatter(format);
-    assertEquals(formatter.format(date), expected);
-  }
+Deno.test("dateTimeFormatter.format()", async (t) => {
+  await t.step("handles basic cases", () => {
+    const cases: [string, Date, string][] = [
+      ["yyyy-MM-dd HH:mm:ss a", new Date(2020, 0, 1), "2020-01-01 00:00:00 AM"],
+      [
+        "yyyy-MM-dd HH:mm:ss a",
+        new Date(2020, 0, 1, 23, 59, 59),
+        "2020-01-01 23:59:59 PM",
+      ],
+      [
+        "yyyy-MM-dd hh:mm:ss a",
+        new Date(2020, 0, 1, 23, 59, 59),
+        "2020-01-01 11:59:59 PM",
+      ],
+      ["yyyy-MM-dd a", new Date(2020, 0, 1), "2020-01-01 AM"],
+      ["yyyy-MM-dd HH:mm:ss a", new Date(2020, 0, 1), "2020-01-01 00:00:00 AM"],
+      ["yyyy-MM-dd hh:mm:ss a", new Date(2020, 0, 1), "2020-01-01 12:00:00 AM"],
+    ];
+    for (const [format, date, expected] of cases) {
+      const formatter = new DateTimeFormatter(format);
+      assertEquals(formatter.format(date), expected);
+    }
+  });
+
+  await t.step("handles yyyy", () => {
+    const formatter = new DateTimeFormatter("yyyy");
+    assertEquals(formatter.format(new Date(2020, 0, 1)), "2020");
+    assertEquals(formatter.format(new Date(20202, 0, 1)), "20202");
+  });
+  await t.step("handles yy", () => {
+    const formatter = new DateTimeFormatter("yy");
+    assertEquals(formatter.format(new Date(2020, 0, 1)), "20");
+    assertEquals(formatter.format(new Date(20202, 0, 1)), "02");
+  });
+
+  await t.step("handles MM", () => {
+    const formatter = new DateTimeFormatter("MM");
+    assertEquals(formatter.format(new Date(2020, 0, 1)), "01");
+    assertEquals(formatter.format(new Date(2020, 11, 1)), "12");
+  });
+  await t.step("handles M", () => {
+    const formatter = new DateTimeFormatter("M");
+    assertEquals(formatter.format(new Date(2020, 0, 1)), "1");
+    assertEquals(formatter.format(new Date(2020, 11, 1)), "12");
+  });
+
+  await t.step("handles dd", () => {
+    const formatter = new DateTimeFormatter("dd");
+    assertEquals(formatter.format(new Date(2020, 0, 1)), "01");
+    assertEquals(formatter.format(new Date(2020, 0, 22)), "22");
+  });
+  await t.step("handles d", () => {
+    const formatter = new DateTimeFormatter("d");
+    assertEquals(formatter.format(new Date(2020, 0, 1)), "1");
+    assertEquals(formatter.format(new Date(2020, 0, 22)), "22");
+  });
+
+  await t.step("handles HH", () => {
+    const formatter = new DateTimeFormatter("HH");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0)), "00");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 22, 0, 0)), "22");
+  });
+  await t.step("handles H", () => {
+    const formatter = new DateTimeFormatter("H");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0)), "0");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 22, 0, 0)), "22");
+  });
+  await t.step("handles hh", () => {
+    const formatter = new DateTimeFormatter("hh");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0)), "12");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 1, 0, 0)), "01");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 22, 0, 0)), "10");
+  });
+  await t.step("handles h", () => {
+    const formatter = new DateTimeFormatter("h");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0)), "12");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 1, 0, 0)), "1");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 22, 0, 0)), "10");
+  });
+
+  await t.step("handles mm", () => {
+    const formatter = new DateTimeFormatter("mm");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0)), "00");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 1, 0)), "01");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 22, 0)), "22");
+  });
+  await t.step("handles m", () => {
+    const formatter = new DateTimeFormatter("m");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0)), "0");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 1, 0)), "1");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 22, 0)), "22");
+  });
+
+  await t.step("handles ss", () => {
+    const formatter = new DateTimeFormatter("ss");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0)), "00");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 1)), "01");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 22)), "22");
+  });
+  await t.step("handles s", () => {
+    const formatter = new DateTimeFormatter("s");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0)), "0");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 1)), "1");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 22)), "22");
+  });
+
+  await t.step("handles SSS", () => {
+    const formatter = new DateTimeFormatter("SSS");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 105)), "105");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 10)), "010");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 0)), "000");
+  });
+  await t.step("handles SS", () => {
+    const formatter = new DateTimeFormatter("SS");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 105)), "10");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 10)), "01");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 0)), "00");
+  });
+  await t.step("handles S", () => {
+    const formatter = new DateTimeFormatter("S");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 105)), "1");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 10)), "0");
+    assertEquals(formatter.format(new Date(2020, 0, 1, 0, 0, 0, 0)), "0");
+  });
+
+  await t.step("handles utc", () => {
+    const formatter = new DateTimeFormatter("HH:mm");
+    assertEquals(
+      formatter.format(
+        new Date("2020-01-01T06:30:00.000-01:30"),
+        { timeZone: "UTC" },
+      ),
+      "08:00",
+    );
+  });
 });
 
 Deno.test("dateTimeFormatter.format() with empty format string returns empty string", () => {
@@ -55,6 +167,43 @@ Deno.test("dateTimeFormatter.formatToParts()", async (t) => {
       { type: "day", value: "01" },
     ]);
   });
+  await t.step("handles case without separators", () => {
+    const format = "yyyyMMdd";
+    const formatter = new DateTimeFormatter(format);
+    assertEquals(formatter.formatToParts("20200101"), [
+      { type: "year", value: "2020" },
+      { type: "month", value: "01" },
+      { type: "day", value: "01" },
+    ]);
+  });
+
+  await t.step("throws on an empty string", () => {
+    const format = "yyyy-MM-dd";
+    const formatter = new DateTimeFormatter(format);
+    assertThrows(
+      () => formatter.formatToParts(""),
+      Error,
+      "Cannot format value: The value is not valid for part { year undefined } ",
+    );
+  });
+  await t.step("throws on a string which exceeds the format", () => {
+    const format = "yyyy-MM-dd";
+    const formatter = new DateTimeFormatter(format);
+    assertThrows(
+      () => formatter.formatToParts("2020-01-01T00:00:00.000Z"),
+      Error,
+      "datetime string was not fully parsed!",
+    );
+  });
+  await t.step("throws on malformatted year", () => {
+    const format = "yyyy-MM-dd";
+    const formatter = new DateTimeFormatter(format);
+    assertThrows(
+      () => formatter.formatToParts("20-01-01"),
+      Error,
+      "Cannot format value: The value is not valid for part { year undefined } 20",
+    );
+  });
 
   await t.step("handles yy", () => {
     const format = "yy";
@@ -62,6 +211,12 @@ Deno.test("dateTimeFormatter.formatToParts()", async (t) => {
     assertEquals(formatter.formatToParts("20"), [
       { type: "year", value: "20" },
     ]);
+    assertEquals(formatter.formatToParts("00"), [
+      { type: "year", value: "00" },
+    ]);
+    assertThrows(() => formatter.formatToParts("2"));
+    assertThrows(() => formatter.formatToParts("202"));
+    assertThrows(() => formatter.formatToParts("2020"));
   });
   await t.step("handles yyyy", () => {
     const format = "yyyy";
@@ -69,6 +224,9 @@ Deno.test("dateTimeFormatter.formatToParts()", async (t) => {
     assertEquals(formatter.formatToParts("2020"), [
       { type: "year", value: "2020" },
     ]);
+    assertThrows(() => formatter.formatToParts("20"));
+    assertThrows(() => formatter.formatToParts("202"));
+    assertThrows(() => formatter.formatToParts("20202"));
   });
   await t.step("handles M", () => {
     const format = "M";
@@ -181,6 +339,10 @@ Deno.test("dateTimeFormatter.formatToParts()", async (t) => {
     assertEquals(formatter.formatToParts("1"), [
       { type: "fractionalSecond", value: "1" },
     ]);
+    assertEquals(formatter.formatToParts("0"), [
+      { type: "fractionalSecond", value: "0" },
+    ]);
+    assertThrows(() => formatter.formatToParts("00"));
   });
   await t.step("handles SS", () => {
     const format = "SS";
@@ -188,6 +350,14 @@ Deno.test("dateTimeFormatter.formatToParts()", async (t) => {
     assertEquals(formatter.formatToParts("10"), [
       { type: "fractionalSecond", value: "10" },
     ]);
+    assertEquals(formatter.formatToParts("01"), [
+      { type: "fractionalSecond", value: "01" },
+    ]);
+    assertEquals(formatter.formatToParts("00"), [
+      { type: "fractionalSecond", value: "00" },
+    ]);
+    assertThrows(() => formatter.formatToParts("0"));
+    assertThrows(() => formatter.formatToParts("000"));
   });
   await t.step("handles SSS", () => {
     const format = "SSS";
@@ -195,76 +365,57 @@ Deno.test("dateTimeFormatter.formatToParts()", async (t) => {
     assertEquals(formatter.formatToParts("100"), [
       { type: "fractionalSecond", value: "100" },
     ]);
+    assertEquals(formatter.formatToParts("010"), [
+      { type: "fractionalSecond", value: "010" },
+    ]);
+    assertEquals(formatter.formatToParts("000"), [
+      { type: "fractionalSecond", value: "000" },
+    ]);
+    assertThrows(() => formatter.formatToParts("0"));
+    assertThrows(() => formatter.formatToParts("0000"));
   });
-  await t.step("handles a", () => {
+  await t.step("handles a: AM", () => {
     const format = "a";
     const formatter = new DateTimeFormatter(format);
     assertEquals(formatter.formatToParts("AM"), [
       { type: "dayPeriod", value: "AM" },
     ]);
   });
-  await t.step("handles a AM", () => {
-    const format = "a";
-    const formatter = new DateTimeFormatter(format);
-    assertEquals(formatter.formatToParts("AM"), [
-      { type: "dayPeriod", value: "AM" },
-    ]);
-  });
-  await t.step("handles a AM.", () => {
+  await t.step("handles a: AM.", () => {
     const format = "a";
     const formatter = new DateTimeFormatter(format);
     assertEquals(formatter.formatToParts("AM."), [
       { type: "dayPeriod", value: "AM" },
     ]);
   });
-  await t.step("handles a A.M.", () => {
+  await t.step("handles a: A.M.", () => {
     const format = "a";
     const formatter = new DateTimeFormatter(format);
     assertEquals(formatter.formatToParts("A.M."), [
       { type: "dayPeriod", value: "AM" },
     ]);
   });
-  await t.step("handles a PM", () => {
+  await t.step("handles a: PM", () => {
     const format = "a";
     const formatter = new DateTimeFormatter(format);
     assertEquals(formatter.formatToParts("PM"), [
       { type: "dayPeriod", value: "PM" },
     ]);
   });
-  await t.step("handles a PM.", () => {
+  await t.step("handles a: PM.", () => {
     const format = "a";
     const formatter = new DateTimeFormatter(format);
     assertEquals(formatter.formatToParts("PM."), [
       { type: "dayPeriod", value: "PM" },
     ]);
   });
-  await t.step("handles a P.M.", () => {
+  await t.step("handles a: P.M.", () => {
     const format = "a";
     const formatter = new DateTimeFormatter(format);
     assertEquals(formatter.formatToParts("P.M."), [
       { type: "dayPeriod", value: "PM" },
     ]);
   });
-});
-
-Deno.test("dateTimeFormatter.formatToParts() throws on an empty string", () => {
-  const format = "yyyy-MM-dd";
-  const formatter = new DateTimeFormatter(format);
-  assertThrows(
-    () => formatter.formatToParts(""),
-    Error,
-    "Cannot format value: The value is not valid for part { year undefined } ",
-  );
-});
-
-Deno.test("dateTimeFormatter.formatToParts() throws on a string which exceeds the format", () => {
-  const format = "yyyy-MM-dd";
-  const formatter = new DateTimeFormatter(format);
-  assertThrows(
-    () => formatter.formatToParts("2020-01-01T00:00:00.000Z"),
-    Error,
-    "datetime string was not fully parsed!",
-  );
 });
 
 Deno.test("dateTimeFormatter.partsToDate()", () => {
@@ -282,6 +433,26 @@ Deno.test("dateTimeFormatter.partsToDate()", () => {
       { type: "second", value: "00" },
       { type: "fractionalSecond", value: "000" },
       { type: "dayPeriod", value: "AM" },
+      { type: "timeZoneName", value: "UTC" },
+    ]),
+    date,
+  );
+  assertEquals(
+    formatter.partsToDate([
+      { type: "year", value: "20" },
+      { type: "month", value: "1" },
+      { type: "day", value: "1" },
+      { type: "hour", value: "0" },
+      { type: "minute", value: "0" },
+      { type: "second", value: "0" },
+      { type: "fractionalSecond", value: "0" },
+      { type: "dayPeriod", value: "AM" },
+      { type: "timeZoneName", value: "UTC" },
+    ]),
+    date,
+  );
+  assertEquals(
+    formatter.partsToDate([
       { type: "timeZoneName", value: "UTC" },
     ]),
     date,

--- a/datetime/parse_test.ts
+++ b/datetime/parse_test.ts
@@ -70,6 +70,14 @@ Deno.test({
       parse("2019-01-03", "yyyy-MM-dd"),
       new Date(2019, 0, 3),
     );
+    assertEquals(
+      parse("19-01-03", "yy-MM-dd"),
+      new Date(2019, 0, 3),
+    );
+    assertEquals(
+      parse("3-1-19", "d-M-yy"),
+      new Date(2019, 0, 3),
+    );
   },
 });
 
@@ -136,6 +144,12 @@ Deno.test("parse(): The date is 2021-12-31", () => {
   assertEquals(
     parse("31", "dd"),
     new Date(2021, 11, 31),
+  );
+
+  // Ensure 2021-02-29 (which does not exist) is not an intermediate result
+  assertEquals(
+    parse("29-02-2020", "dd-MM-yyyy"),
+    new Date(2020, 1, 29),
   );
 });
 


### PR DESCRIPTION
Previously, larger tests meant these appeared to be covered, but there was no testing of the deep specifications for each part type. Covering the cases revealed a bug with `fractionalSecond`, and the fix is included in this PR.

I also made `formatToParts` require exactly 2 digits when parsing `yy` and exactly 4 digits when parsing `yyyy` instead of 1-2 or 1-4 respectively. The spec requires `yy` to represent exactly 2 digits, but `yyyy` technically represents 4+ digits. In neither case are fewer digits allowed. I think it's unlikely anyone will be trying to parse years with 5+ digits, and parsing `yyyyMMdd` would require a more sophisticated approach if we allowed 5+, so I think only allowing 4 is best.