### PR TITLE
fix(ini): replace `isRecord()` with `isPlainObject()`

### DIFF
--- a/ini/_ini_map.ts
+++ b/ini/_ini_map.ts
@@ -51,6 +51,10 @@ export type ReviverFunction = (
 
 const ASSIGNMENT_MARK = "=";
 
+function isPlainObject(object: unknown): object is object {
+  return Object.prototype.toString.call(object) === "[object Object]";
+}
+
 function trimQuotes(value: string): string {
   if (value.startsWith('"') && value.endsWith('"')) {
     return value.slice(1, -1);
@@ -426,19 +430,17 @@ export class IniMap {
   ): IniMap {
     const ini = new IniMap(formatting);
     if (typeof input === "object" && input !== null) {
-      const isRecord = (val: unknown): val is IniSection =>
-        typeof val === "object" && val !== null;
       const sort = (
         [_a, valA]: [string, unknown],
         [_b, valB]: [string, unknown],
       ) => {
-        if (isRecord(valA)) return 1;
-        if (isRecord(valB)) return -1;
+        if (isPlainObject(valA)) return 1;
+        if (isPlainObject(valB)) return -1;
         return 0;
       };
 
       for (const [key, val] of Object.entries(input).sort(sort)) {
-        if (isRecord(val)) {
+        if (isPlainObject(val)) {
           for (const [sectionKey, sectionValue] of Object.entries(val)) {
             ini.set(key, sectionKey, sectionValue);
           }

--- a/ini/stringify_test.ts
+++ b/ini/stringify_test.ts
@@ -26,8 +26,8 @@ Deno.test({
       { replacer: (_, val) => val?.toJSON() },
     );
     assertValidStringify(
-      { dates: { a: new Date("1977-05-25") } },
-      "[dates]\na=1977-05-25T00:00:00.000Z",
+      { a: new Date("1977-05-25") },
+      "a=1977-05-25T00:00:00.000Z",
       { replacer: (_, val) => val?.toJSON() },
     );
     assertValidStringify({

--- a/ini/stringify_test.ts
+++ b/ini/stringify_test.ts
@@ -25,6 +25,11 @@ Deno.test({
       `[dates]\na=1977-05-25T00:00:00.000Z`,
       { replacer: (_, val) => val?.toJSON() },
     );
+    assertValidStringify(
+      { dates: { a: new Date("1977-05-25") } },
+      "[dates]\na=1977-05-25T00:00:00.000Z",
+      { replacer: (_, val) => val?.toJSON() },
+    );
     assertValidStringify({
       keyA: "1977-05-25",
       section1: { keyA: 100 },


### PR DESCRIPTION
This PR fixes the section check where a object values like `Date` would pass the check.