### PR TITLE
fix(expect): include diff when `expect.toMatchObject` throws

### DIFF
--- a/expect/_build_message.ts
+++ b/expect/_build_message.ts
@@ -18,9 +18,9 @@ function isString(value: unknown): value is string {
 export function buildEqualErrorMessage<T>(
   actual: T,
   expected: T,
-  options: EqualErrorMessageOptions,
+  options: EqualErrorMessageOptions = {},
 ): string {
-  const { formatter = format, msg } = options ?? {};
+  const { formatter = format, msg } = options;
   const msgPrefix = msg ? `${msg}: ` : "";
   const actualString = formatter(actual);
   const expectedString = formatter(expected);
@@ -40,9 +40,9 @@ export function buildEqualErrorMessage<T>(
 export function buildNotEqualErrorMessage<T>(
   actual: T,
   expected: T,
-  options: EqualErrorMessageOptions,
+  options: EqualErrorMessageOptions = {},
 ): string {
-  const { msg } = options ?? {};
+  const { msg } = options;
   const actualString = String(actual);
   const expectedString = String(expected);
 

--- a/expect/_build_message.ts
+++ b/expect/_build_message.ts
@@ -42,9 +42,9 @@ export function buildNotEqualErrorMessage<T>(
   expected: T,
   options: EqualErrorMessageOptions = {},
 ): string {
-  const { msg } = options;
-  const actualString = String(actual);
-  const expectedString = String(expected);
+  const { formatter = format, msg } = options;
+  const actualString = formatter(actual);
+  const expectedString = formatter(expected);
 
   const msgPrefix = msg ? `${msg}: ` : "";
   return `${msgPrefix}Expected actual: ${actualString} not to be: ${expectedString}.`;

--- a/expect/_matchers.ts
+++ b/expect/_matchers.ts
@@ -21,6 +21,10 @@ import {
   iterableEquality,
   subsetEquality,
 } from "./_utils.ts";
+import {
+  buildEqualErrorMessage,
+  buildNotEqualErrorMessage,
+} from "./_build_message.ts";
 
 export function toBe(context: MatcherContext, expect: unknown): MatchResult {
   if (context.isNot) {
@@ -565,7 +569,7 @@ export function toMatchObject(
     );
   }
 
-  const pass = equal(context.value, expected, {
+  const pass = equal(received, expected, {
     strictCheck: false,
     customTesters: [
       ...context.customTesters,
@@ -575,20 +579,15 @@ export function toMatchObject(
   });
 
   const triggerError = () => {
-    const actualString = format(context.value);
-    const expectedString = format(expected);
-
     if (context.isNot) {
-      const defaultMessage =
-        `Expected ${actualString} to NOT match ${expectedString}`;
+      const defaultMessage = buildNotEqualErrorMessage(received, expected);
       throw new AssertionError(
         context.customMessage
           ? `${context.customMessage}: ${defaultMessage}`
           : defaultMessage,
       );
     } else {
-      const defaultMessage =
-        `Expected ${actualString} to match ${expectedString}`;
+      const defaultMessage = buildEqualErrorMessage(received, expected);
       throw new AssertionError(
         context.customMessage
           ? `${context.customMessage}: ${defaultMessage}`

--- a/expect/_to_match_object_test.ts
+++ b/expect/_to_match_object_test.ts
@@ -119,16 +119,16 @@ Deno.test("expect().toMatchObject() throws the correct error messages", () => {
   {
     const e = assertThrows(
       () => expect({ a: 1 }).toMatchObject({ a: 2 }),
-      Error,
+      AssertionError,
     );
-    assertNotMatch(e.message, /NOT/);
+    assertNotMatch(e.message, /not to be/);
   }
   {
     const e = assertThrows(
       () => expect({ a: 1 }).not.toMatchObject({ a: 1 }),
-      Error,
+      AssertionError,
     );
-    assertMatch(e.message, /NOT/);
+    assertMatch(e.message, /not to be/);
   }
 });
 

--- a/internal/format_test.ts
+++ b/internal/format_test.ts
@@ -27,7 +27,7 @@ Deno.test("format() overrides default behaviours of Deno.inspect", async (t) => 
   // Wraps objects into multiple lines even when they are small. Prints trailing
   // commas.
   await t.step(
-    "fromat() always wraps objects into multiple lines and prints trailing commas",
+    "format() always wraps objects into multiple lines and prints trailing commas",
     () =>
       assertEquals(
         stripAnsiCode(format({ a: 1, b: 2 })),
@@ -37,6 +37,12 @@ Deno.test("format() overrides default behaviours of Deno.inspect", async (t) => 
 }`,
       ),
   );
+
+  await t.step("format() sorts properties", () =>
+    assertEquals(
+      format({ b: 2, a: 1 }),
+      format({ a: 1, b: 2 }),
+    ));
 
   await t.step("format() wraps Object with getters", () =>
     assertEquals(


### PR DESCRIPTION
closes #6225

Does not change the behavior of `expect.toMatchObject`, only the error message.

The behaviors of `expect.toMatchObject` and `assertMatchObject` are slightly different, so one of the tests from the latter does not work. I duplicated the rest of the diff-based tests.

Also makes `buildNotEqualErrorMessage` accept the `formatter` option with a default of `format` which aligns it with `buildEqualErrorMessage`. For both, makes `options` optional.