### PR TITLE
chore(semver): remove `MIN` constant

### DIFF
--- a/semver/_constants.ts
+++ b/semver/_constants.ts
@@ -3,17 +3,6 @@
 import type { Comparator, SemVer } from "./types.ts";
 
 /**
- * The minimum valid SemVer object. Equivalent to `0.0.0`.
- */
-export const MIN: SemVer = {
-  major: 0,
-  minor: 0,
-  patch: 0,
-  prerelease: [],
-  build: [],
-};
-
-/**
  * ANY is a sentinel value used by some range calculations. It is not a valid
  * SemVer object and should not be used directly.
  */

--- a/semver/is_range_test.ts
+++ b/semver/is_range_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 import { assertEquals } from "@std/assert";
-import { ALL, MIN } from "./_constants.ts";
+import { ALL } from "./_constants.ts";
 import { isRange } from "./is_range.ts";
 import type { Range } from "./types.ts";
 
@@ -15,9 +15,6 @@ Deno.test({
         patch: 0,
         prerelease: [],
         build: [],
-      }, {
-        operator: "<",
-        ...MIN,
       }],
     ];
     const actual = isRange(range);

--- a/semver/is_range_test.ts
+++ b/semver/is_range_test.ts
@@ -15,6 +15,13 @@ Deno.test({
         patch: 0,
         prerelease: [],
         build: [],
+      }, {
+        operator: "<",
+        major: 0,
+        minor: 0,
+        patch: 0,
+        prerelease: [],
+        build: [],
       }],
     ];
     const actual = isRange(range);

--- a/semver/is_semver_test.ts
+++ b/semver/is_semver_test.ts
@@ -1,6 +1,6 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 import { assert } from "@std/assert";
-import { ANY, MIN } from "./_constants.ts";
+import { ANY } from "./_constants.ts";
 import { isSemVer } from "./is_semver.ts";
 
 Deno.test({
@@ -60,7 +60,7 @@ Deno.test({
       [{ major: 0, minor: 0, patch: 0, build: ["abc"], prerelease: [] }],
       [{ major: 0, minor: 0, patch: 0, build: [], prerelease: ["abc"] }],
       [{ major: 0, minor: 0, patch: 0, build: [], prerelease: ["abc", 0] }],
-      [MIN],
+
       [ANY],
     ];
     for (const [v] of versions) {


### PR DESCRIPTION
Seems like this constant is only used in tests.