### PR TITLE
chore: improve lint rules

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -45,11 +45,11 @@
   ],
   "lint": {
     "rules": {
+      "tags": ["recommended", "jsr"],
       "include": [
         "camelcase",
         "no-sync-fn-in-async-fn",
         "single-var-declarator",
-        "verbatim-module-syntax",
         "no-console"
       ]
     }


### PR DESCRIPTION
These changes improve lint rules by ensuring that future JSR lint rules, which should apply to this codebase, are enforced. It also removes the need to explicitly include the `verbatim-module-syntax` rule.