### PR TITLE
chore: rename `assertSnippetsWorks` to `assertHasSnippets`

### DIFF
--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -16,7 +16,6 @@ import {
   type DocNodeClass,
   type DocNodeFunction,
   type DocNodeInterface,
-  type DocNodeModuleDoc,
   type JsDoc,
   type JsDocTagDocRequired,
   type JsDocTagParam,
@@ -411,14 +410,6 @@ function assertConstructorDocs(
 }
 
 /**
- * Checks a module document for:
- * - Code snippets that execute successfully.
- */
-function assertModuleDoc(document: DocNodeWithJsDoc<DocNodeModuleDoc>) {
-  assertSnippetsWork(document.jsDoc.doc!, document);
-}
-
-/**
  * Ensures an interface document:
  * - Has `@default` tags for all optional properties.
  */
@@ -466,12 +457,6 @@ async function checkDocs(specifier: string) {
 
     const document = d as DocNodeWithJsDoc<DocNode>;
     switch (document.kind) {
-      case "moduleDoc": {
-        if (document.location.filename.endsWith("/mod.ts")) {
-          assertModuleDoc(document);
-        }
-        break;
-      }
       case "function": {
         assertFunctionDocs(document);
         break;

--- a/_tools/check_docs.ts
+++ b/_tools/check_docs.ts
@@ -176,7 +176,7 @@ function assertHasParamTag(
   }
 }
 
-function assertHasSnippet(
+function assertHasSnippets(
   doc: string,
   document: { jsDoc: JsDoc; location: Location },
   required = true,
@@ -239,7 +239,7 @@ function assertHasExampleTag(
       "@example tag must have a title",
       document,
     );
-    assertHasSnippet(tag.doc, document);
+    assertHasSnippets(tag.doc, document);
   }
 }
 
@@ -279,7 +279,7 @@ function assertHasTypeParamTags(
 function assertFunctionDocs(
   document: DocNodeWithJsDoc<DocNodeFunction | ClassMethodDef>,
 ) {
-  assertHasSnippet(document.jsDoc.doc!, document, false);
+  assertHasSnippets(document.jsDoc.doc!, document, false);
   for (const param of document.functionDef.params) {
     if (param.kind === "identifier") {
       assertHasParamTag(document, param.name);
@@ -323,7 +323,7 @@ function assertFunctionDocs(
  * - Documentation on all properties, methods, and constructors.
  */
 function assertClassDocs(document: DocNodeWithJsDoc<DocNodeClass>) {
-  assertHasSnippet(document.jsDoc.doc!, document, false);
+  assertHasSnippets(document.jsDoc.doc!, document, false);
   for (const typeParam of document.classDef.typeParams) {
     assertHasTypeParamTags(document, typeParam.name);
   }
@@ -415,7 +415,7 @@ function assertConstructorDocs(
  * - Code snippets that execute successfully.
  */
 function assertModuleDoc(document: DocNodeWithJsDoc<DocNodeModuleDoc>) {
-  assertHasSnippet(document.jsDoc.doc!, document);
+  assertHasSnippets(document.jsDoc.doc!, document);
 }
 
 /**


### PR DESCRIPTION
This is no longer needed since `deno test --doc` now evaluates code snippets in JSDocs.