### PR TITLE
feat(fs/unstable): add chown and chownSync

### DIFF
--- a/_tools/node_test_runner/run_test.mjs
+++ b/_tools/node_test_runner/run_test.mjs
@@ -48,6 +48,7 @@ import "../../collections/union_test.ts";
 import "../../collections/unzip_test.ts";
 import "../../collections/without_all_test.ts";
 import "../../collections/zip_test.ts";
+import "../../fs/unstable_chown_test.ts";
 import "../../fs/unstable_copy_file_test.ts";
 import "../../fs/unstable_link_test.ts";
 import "../../fs/unstable_make_temp_dir_test.ts";

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -14,6 +14,7 @@
     "./expand-glob": "./expand_glob.ts",
     "./move": "./move.ts",
     "./unstable-chmod": "./unstable_chmod.ts",
+    "./unstable-chown": "./unstable_chown.ts",
     "./unstable-copy-file": "./unstable_copy_file.ts",
     "./unstable-link": "./unstable_link.ts",
     "./unstable-lstat": "./unstable_lstat.ts",

--- a/fs/unstable_chown.ts
+++ b/fs/unstable_chown.ts
@@ -1,0 +1,78 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { getNodeFs, isDeno } from "./_utils.ts";
+import { mapError } from "./_map_error.ts";
+
+/**
+ * Change owner of a regular file or directory.
+ *
+ * This functionality is not available on Windows.
+ *
+ * Requires `allow-write` permission.
+ *
+ * Throws Error (not implemented) if executed on Windows.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { chown } from "@std/fs/unstable-chown";
+ * await chown("README.md", 1000, 1002);
+ * ```
+ *
+ * @tags allow-write
+ *
+ * @param path The path to the file/directory.
+ * @param uid The user id (UID) of the new owner, or `null` for no change.
+ * @param gid The group id (GID) of the new owner, or `null` for no change.
+ */
+export async function chown(
+  path: string | URL,
+  uid: number | null,
+  gid: number | null,
+): Promise<void> {
+  if (isDeno) {
+    await Deno.chown(path, uid, gid);
+  } else {
+    try {
+      await getNodeFs().promises.chown(path, uid ?? -1, gid ?? -1);
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}
+
+/**
+ * Synchronously change owner of a regular file or directory.
+ *
+ * This functionality is not available on Windows.
+ *
+ * Requires `allow-write` permission.
+ *
+ * Throws Error (not implemented) if executed on Windows.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { chownSync } from "@std/fs/unstable-chown";
+ * chownSync("README.md", 1000, 1002);
+ * ```
+ *
+ * @tags allow-write
+ *
+ * @param path The path to the file/directory.
+ * @param uid The user id (UID) of the new owner, or `null` for no change.
+ * @param gid The group id (GID) of the new owner, or `null` for no change.
+ */
+export function chownSync(
+  path: string | URL,
+  uid: number | null,
+  gid: number | null,
+): void {
+  if (isDeno) {
+    Deno.chownSync(path, uid, gid);
+  } else {
+    try {
+      getNodeFs().chownSync(path, uid ?? -1, gid ?? -1);
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}

--- a/fs/unstable_chown_test.ts
+++ b/fs/unstable_chown_test.ts
@@ -1,0 +1,166 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { chown, chownSync } from "./unstable_chown.ts";
+import { NotFound } from "./unstable_errors.js";
+import { makeTempFile, makeTempFileSync } from "./unstable_make_temp_file.ts";
+import { remove, removeSync } from "./unstable_remove.ts";
+import { platform } from "node:os";
+import { spawn } from "node:child_process";
+
+type IdResult = {
+  id: string;
+  code: number;
+};
+
+function runId(
+  option?: "group" | "user",
+): Promise<IdResult> {
+  return new Promise((resolve, reject) => {
+    let id;
+    if (option === "user") {
+      id = spawn("id", ["-u"]);
+    } else if (option === "group") {
+      id = spawn("id", ["-g"]);
+    } else {
+      return reject(new Error("Invalid option."));
+    }
+
+    id.stderr.on("error", (err: Error) => {
+      return reject(err);
+    });
+
+    let data = "";
+    const result: Partial<IdResult> = {};
+    id.stdout.on("data", (chunk) => {
+      data += chunk;
+    });
+
+    id.stdout.on("end", () => {
+      result.id = data;
+    });
+
+    id.on("close", (code: number) => {
+      result.code = code;
+      resolve(result as IdResult);
+    });
+  });
+}
+
+async function getUidAndGid(): Promise<{ uid: number; gid: number }> {
+  try {
+    const uidProc = await runId("user");
+    const gidProc = await runId("group");
+    assertEquals(uidProc.code, 0);
+    assertEquals(gidProc.code, 0);
+    return {
+      uid: parseInt(uidProc.id),
+      gid: parseInt(gidProc.id),
+    };
+  } catch (error) {
+    throw error;
+  }
+}
+
+Deno.test({
+  name: "chown() changes user and group ids",
+  ignore: platform() === "win32",
+  fn: async () => {
+    const { uid, gid } = await getUidAndGid();
+    const tempFile = await makeTempFile({ prefix: "chown_" });
+
+    // `chown` needs elevated privileges to change to different UIDs and GIDs.
+    // Instead, pass the same IDs back to invoke `chown` and avoid erroring.
+    await chown(tempFile, uid, gid);
+    await remove(tempFile);
+  },
+});
+
+Deno.test({
+  name: "chown() handles `null` id arguments",
+  ignore: platform() === "win32",
+  fn: async () => {
+    const { uid, gid } = await getUidAndGid();
+    const tempFile = await makeTempFile({ prefix: "chown_" });
+
+    await chown(tempFile, uid, null);
+    await chown(tempFile, null, gid);
+    await remove(tempFile);
+  },
+});
+
+Deno.test({
+  name: "chown() rejects with NotFound for a non-existent file",
+  ignore: platform() === "win32",
+  fn: async () => {
+    await assertRejects(async () => {
+      await chown("non-existent-file.txt", null, null);
+    }, NotFound);
+  },
+});
+
+Deno.test({
+  name: "chown() rejects with Error when called without elevated privileges",
+  ignore: platform() === "win32",
+  fn: async () => {
+    const tempFile = await makeTempFile({ prefix: "chown_" });
+
+    await assertRejects(async () => {
+      await chown(tempFile, 0, 0);
+    }, Error);
+
+    await remove(tempFile);
+  },
+});
+
+Deno.test({
+  name: "chownSync() changes user and group ids",
+  ignore: platform() === "win32",
+  fn: async () => {
+    const { uid, gid } = await getUidAndGid();
+    const tempFile = makeTempFileSync({ prefix: "chownSync_ " });
+
+    // `chownSync` needs elevated privileges to change to different UIDs and
+    // GIDs. Instead, pass the same IDs back to invoke `chownSync` and avoid
+    // erroring.
+    chownSync(tempFile, uid, gid);
+    removeSync(tempFile);
+  },
+});
+
+Deno.test({
+  name: "chownSync() handles `null` id arguments",
+  ignore: platform() === "win32",
+  fn: async () => {
+    const { uid, gid } = await getUidAndGid();
+    const tempFile = makeTempFileSync({ prefix: "chownSync_" });
+
+    chownSync(tempFile, uid, null);
+    chownSync(tempFile, null, gid);
+    removeSync(tempFile);
+  },
+});
+
+Deno.test({
+  name: "chownSync() throws with NotFound for a non-existent file",
+  ignore: platform() === "win32",
+  fn: () => {
+    assertThrows(() => {
+      chownSync("non-existent-file.txt", null, null);
+    }, NotFound);
+  },
+});
+
+Deno.test({
+  name: "chownSync() throws with Error when called without elevated privileges",
+  ignore: platform() === "win32",
+  fn: () => {
+    const tempFile = makeTempFileSync({ prefix: "chownSync_" });
+
+    assertThrows(() => {
+      chownSync(tempFile, 0, 0);
+    }, Error);
+
+    removeSync(tempFile);
+  },
+});


### PR DESCRIPTION
This PR adds `chown` and `chownSync` APIs to `@std/fs` package which are intended to mirror the `Deno.chown` and `Deno.chownSync` functions.

Towards #6255.