### PR TITLE
docs(encoding): fixed for calcSize functions

### DIFF
--- a/encoding/_common16.ts
+++ b/encoding/_common16.ts
@@ -12,7 +12,7 @@ new TextEncoder()
 
 /**
  * Calculate the output size needed to encode a given input size for
- * {@linkcode encodeRawHex}.
+ * {@linkcode encodeIntoHex}.
  *
  * @param originalSize The size of the input buffer.
  * @returns The size of the output buffer.

--- a/encoding/_common32.ts
+++ b/encoding/_common32.ts
@@ -28,7 +28,7 @@ export type Base32Format = "Base32" | "Base32Hex" | "Base32Crockford";
 
 /**
  * Calculate the output size needed to encode a given input size for
- * {@linkcode encodeRawBase32}.
+ * {@linkcode encodeIntoBase32}.
  *
  * @param rawSize The size of the input buffer.
  * @returns The size of the output buffer.

--- a/encoding/_common64.ts
+++ b/encoding/_common64.ts
@@ -26,7 +26,7 @@ export type Base64Format = "Base64" | "Base64Url";
 
 /**
  * Calculate the output size needed to encode a given input size for
- * {@linkcode encodeRawBase64}.
+ * {@linkcode encodeIntoBase64}.
  *
  * @param originalSize The size of the input buffer.
  * @returns The size of the output buffer.


### PR DESCRIPTION
This pull request fixed the docs for calcSizeBase64, 32 and hex as they are incorrectly still mentioning the Raw instead of Into name. 