### PR TITLE
refactor(toml): add `Scanner` `skipWhitespaces()` method

### DIFF
--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -64,31 +64,9 @@ export class Scanner {
     this.#position += count;
   }
 
-  /**
-   * Move position until current char is not a whitespace, EOL, or comment.
-   * @param options.inline - skip only whitespaces
-   */
-  nextUntilChar(
-    options: { inline?: boolean; comment?: boolean } = { comment: true },
-  ) {
-    if (options.inline) {
-      while (this.#whitespace.test(this.char()) && !this.eof()) {
-        this.next();
-      }
-    } else {
-      while (!this.eof()) {
-        const char = this.char();
-        if (this.#whitespace.test(char) || this.isCurrentCharEOL()) {
-          this.next();
-        } else if (options.comment && this.char() === "#") {
-          // entering comment
-          while (!this.isCurrentCharEOL() && !this.eof()) {
-            this.next();
-          }
-        } else {
-          break;
-        }
-      }
+  skipWhitespaces() {
+    while (this.#whitespace.test(this.char()) && !this.eof()) {
+      this.next();
     }
     // Invalid if current char is other kinds of whitespace
     if (!this.isCurrentCharEOL() && /\s/.test(this.char())) {
@@ -97,6 +75,26 @@ export class Scanner {
       throw new SyntaxError(
         `Cannot parse the TOML: It contains invalid whitespace at position '${position}': \`${escaped}\``,
       );
+    }
+  }
+
+  /**
+   * Move position until current char is not a whitespace, EOL, or comment.
+   * @param options.inline - skip only whitespaces
+   */
+  nextUntilChar(options: { skipComments?: boolean } = { skipComments: true }) {
+    while (!this.eof()) {
+      const char = this.char();
+      if (this.#whitespace.test(char) || this.isCurrentCharEOL()) {
+        this.next();
+      } else if (options.skipComments && this.char() === "#") {
+        // entering comment
+        while (!this.isCurrentCharEOL() && !this.eof()) {
+          this.next();
+        }
+      } else {
+        break;
+      }
     }
   }
 
@@ -307,10 +305,10 @@ function surround<T>(
 
 function character(str: string) {
   return (scanner: Scanner): ParseResult<void> => {
-    scanner.nextUntilChar({ inline: true });
+    scanner.skipWhitespaces();
     if (!scanner.startsWith(str)) return failure();
     scanner.next(str.length);
-    scanner.nextUntilChar({ inline: true });
+    scanner.skipWhitespaces();
     return success(undefined);
   };
 }
@@ -324,7 +322,7 @@ const FLOAT_REGEXP = /[0-9_\.e+\-]/i;
 const END_OF_VALUE_REGEXP = /[ \t\r\n#,}\]]/;
 
 export function bareKey(scanner: Scanner): ParseResult<string> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
   if (!scanner.char() || !BARE_KEY_REGEXP.test(scanner.char())) {
     return failure();
   }
@@ -383,7 +381,7 @@ function escapeSequence(scanner: Scanner): ParseResult<string> {
 }
 
 export function basicString(scanner: Scanner): ParseResult<string> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
   if (scanner.char() !== '"') return failure();
   scanner.next();
   const acc = [];
@@ -409,7 +407,7 @@ export function basicString(scanner: Scanner): ParseResult<string> {
 }
 
 export function literalString(scanner: Scanner): ParseResult<string> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
   if (scanner.char() !== "'") return failure();
   scanner.next();
   const acc: string[] = [];
@@ -432,7 +430,7 @@ export function literalString(scanner: Scanner): ParseResult<string> {
 export function multilineBasicString(
   scanner: Scanner,
 ): ParseResult<string> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
   if (!scanner.startsWith('"""')) return failure();
   scanner.next(3);
   if (scanner.char() === "\n") {
@@ -447,11 +445,11 @@ export function multilineBasicString(
     // line ending backslash
     if (scanner.startsWith("\\\n")) {
       scanner.next();
-      scanner.nextUntilChar({ comment: false });
+      scanner.nextUntilChar({ skipComments: false });
       continue;
     } else if (scanner.startsWith("\\\r\n")) {
       scanner.next();
-      scanner.nextUntilChar({ comment: false });
+      scanner.nextUntilChar({ skipComments: false });
       continue;
     }
     const escapedChar = escapeSequence(scanner);
@@ -480,7 +478,7 @@ export function multilineBasicString(
 export function multilineLiteralString(
   scanner: Scanner,
 ): ParseResult<string> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
   if (!scanner.startsWith("'''")) return failure();
   scanner.next(3);
   if (scanner.char() === "\n") {
@@ -520,7 +518,7 @@ const symbolPairs: [string, unknown][] = [
   ["-nan", NaN],
 ];
 export function symbols(scanner: Scanner): ParseResult<unknown> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
   const found = symbolPairs.find(([str]) => scanner.startsWith(str));
   if (!found) return failure();
   const [str, value] = found;
@@ -531,7 +529,7 @@ export function symbols(scanner: Scanner): ParseResult<unknown> {
 export const dottedKey = join(or([bareKey, basicString, literalString]), ".");
 
 export function integer(scanner: Scanner): ParseResult<number | string> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
 
   // Handle binary, octal, or hex numbers
   const first2 = scanner.slice(0, 2);
@@ -601,7 +599,7 @@ export function integer(scanner: Scanner): ParseResult<number | string> {
 }
 
 export function float(scanner: Scanner): ParseResult<number> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
 
   // lookahead validation is needed for integer value is similar to float
   let position = 0;
@@ -631,7 +629,7 @@ export function float(scanner: Scanner): ParseResult<number> {
 }
 
 export function dateTime(scanner: Scanner): ParseResult<Date> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
 
   let dateStr = scanner.slice(0, 10);
   // example: 1979-05-27
@@ -655,7 +653,7 @@ export function dateTime(scanner: Scanner): ParseResult<Date> {
 }
 
 export function localTime(scanner: Scanner): ParseResult<string> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
 
   let timeStr = scanner.slice(0, 8);
   if (!/^(\d{2}):(\d{2}):(\d{2})/.test(timeStr)) return failure();
@@ -675,7 +673,7 @@ export function localTime(scanner: Scanner): ParseResult<string> {
 }
 
 export function arrayValue(scanner: Scanner): ParseResult<unknown[]> {
-  scanner.nextUntilChar({ inline: true });
+  scanner.skipWhitespaces();
 
   if (scanner.char() !== "[") return failure();
   scanner.next();
@@ -686,7 +684,7 @@ export function arrayValue(scanner: Scanner): ParseResult<unknown[]> {
     const result = value(scanner);
     if (!result.ok) break;
     array.push(result.body);
-    scanner.nextUntilChar({ inline: true });
+    scanner.skipWhitespaces();
     // may have a next item, but trailing comma is allowed at array
     if (scanner.char() !== ",") break;
     scanner.next();

--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -78,10 +78,6 @@ export class Scanner {
     }
   }
 
-  /**
-   * Move position until current char is not a whitespace, EOL, or comment.
-   * @param options.inline - skip only whitespaces
-   */
   nextUntilChar(options: { skipComments?: boolean } = { skipComments: true }) {
     while (!this.eof()) {
       const char = this.char();

--- a/toml/parse_test.ts
+++ b/toml/parse_test.ts
@@ -27,12 +27,12 @@ Deno.test({
   name: "Scanner",
   fn() {
     const scanner = new Scanner(" # comment\n\n\na \nb");
-    scanner.nextUntilChar({ inline: true });
+    scanner.skipWhitespaces();
     assertEquals(scanner.char(), "#");
     scanner.nextUntilChar();
     assertEquals(scanner.char(), "a");
     scanner.next();
-    scanner.nextUntilChar({ inline: true });
+    scanner.skipWhitespaces();
     assertEquals(scanner.char(), "\n");
     scanner.nextUntilChar();
     assertEquals(scanner.char(), "b");


### PR DESCRIPTION
This PR adds `skipWhitespaces()`  in order to declutter `nextUntilChar()`. 