### PR TITLE
chore(http): do not request to example.com in doc testing

### DIFF
--- a/http/status.ts
+++ b/http/status.ts
@@ -18,7 +18,7 @@
  * ```
  *
  * @example Checking the status code type
- * ```ts
+ * ```ts ignore
  * import { isErrorStatus } from "@std/http/status";
  *
  * const res = await fetch("https://example.com/");


### PR DESCRIPTION
This example seems flaky in doc testing because of dependency to the actual example.com host. (See https://github.com/denoland/std/actions/runs/14436676442/job/40478863407?pr=6573 )

I think we should ignore this in doc testing