### PR TITLE
refactor(toml): fix object check in 'merge' util

### DIFF
--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -251,9 +251,8 @@ function merge(
     if (!result.ok) return failure();
     let body = {};
     for (const record of result.body) {
-      if (typeof body === "object" && body !== null) {
-        // deno-lint-ignore no-explicit-any
-        body = deepMerge(body, record as Record<any, any>);
+      if (typeof record === "object" && record !== null) {
+        body = deepMerge(body, record);
       }
     }
     return success(body);


### PR DESCRIPTION
Pretty sure this check is meant for `record`, not `body`.