### PR TITLE
fix(toml): fix empty string handling

### DIFF
--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -776,8 +776,8 @@ export function toml(
   scanner: Scanner,
 ): ParseResult<Record<string, unknown>> {
   const blocks = repeat(or([block, tableArray, table]))(scanner);
-  if (!blocks.ok) return failure();
   let body = {};
+  if (!blocks.ok) return success(body);
   for (const block of blocks.body) {
     switch (block.type) {
       case "Block": {

--- a/toml/parse_test.ts
+++ b/toml/parse_test.ts
@@ -540,11 +540,6 @@ Deno.test({
       "line 2, column 10",
     );
     assertThrows(
-      () => parse(""),
-      SyntaxError,
-      "line 1, column 0",
-    );
-    assertThrows(
       () =>
         parserFactory((_s) => {
           throw "Custom parser";
@@ -650,6 +645,17 @@ withUnicodeChar1 = "\\u3042"
 withUnicodeChar2 = "Deno\\U01F995"
 `);
     assertEquals(actual, expected);
+  },
+});
+
+Deno.test({
+  name: "handles empty string",
+  fn() {
+    assertEquals(parse(""), {});
+    assertEquals(parse(" "), {});
+    assertEquals(parse("\t"), {});
+    assertEquals(parse("\r\n"), {});
+    assertEquals(parse("\n"), {});
   },
 });
 


### PR DESCRIPTION
The current toml implementation throws when trying to parse an empty string.
(Probably) all toml npm implementations allow empty strings and return an empty object, so we should probably too.
```ts
import toml from "npm:toml";
assertEquals(toml.parse(""), {});

import tomljs from "npm:toml-js";
assertEquals(tomljs.parse(""), {});

import * as s from "npm:smol-toml";
assertEquals(s.parse(""), {});

import * as i from "npm:@iarna/toml";
assertEquals(i.parse(""), {});

import * as c from "npm:confbox";
assertEquals(c.parseTOML(""), {});
```