### PR TITLE
docs(cli/unstable): fix Spinner example typo

### DIFF
--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -102,11 +102,11 @@ export interface SpinnerOptions {
  *
  * // You can also use the spinner with `Deno.stderr`
  * const spinner2 = new Spinner({ message: "Loading...", color: "yellow", output: Deno.stderr });
- * spinner.start();
+ * spinner2.start();
  *
  * setTimeout(() => {
- *  spinner.stop();
- *  console.error"Finished loading!");
+ *  spinner2.stop();
+ *  console.error("Finished loading!");
  * }, 3_000);
  * ```
  */


### PR DESCRIPTION
Fix `Spinner` example typo