### PR TITLE
test(fmt): reduce unnecessary output during test run

### DIFF
--- a/fmt/printf_test.ts
+++ b/fmt/printf_test.ts
@@ -7,7 +7,7 @@
 
 import { printf, sprintf } from "./printf.ts";
 import { assertEquals, assertThrows } from "@std/assert";
-import { restore, stub } from "@std/testing/mock";
+import { assertSpyCall, spy, stub } from "@std/testing/mock";
 import * as c from "./colors.ts";
 
 Deno.test("sprintf() handles noVerb", function () {
@@ -786,13 +786,11 @@ Deno.test("sprintf() throws with d with sharp option", () => {
 });
 
 Deno.test("printf() prints the result synchronously", () => {
-  let called = false;
-  stub(Deno.stdout, "writeSync", (p) => {
-    assertEquals(new TextDecoder().decode(p), "Hello world");
-    called = true;
-    return p.length;
-  });
+  const writeSpy = spy(() => 1);
+  using _ = stub(Deno.stdout, "writeSync", writeSpy);
   printf("Hello %s", "world");
-  assertEquals(called, true);
-  restore();
+
+  assertSpyCall(writeSpy, 0, {
+    args: [new TextEncoder().encode("Hello world")],
+  });
 });

--- a/fmt/printf_test.ts
+++ b/fmt/printf_test.ts
@@ -7,7 +7,7 @@
 
 import { printf, sprintf } from "./printf.ts";
 import { assertEquals, assertThrows } from "@std/assert";
-import { assertSpyCall, spy } from "@std/testing/mock";
+import { restore, stub } from "@std/testing/mock";
 import * as c from "./colors.ts";
 
 Deno.test("sprintf() handles noVerb", function () {
@@ -786,10 +786,13 @@ Deno.test("sprintf() throws with d with sharp option", () => {
 });
 
 Deno.test("printf() prints the result synchronously", () => {
-  using writeSpy = spy(Deno.stdout, "writeSync");
-  printf("Hello %s", "world");
-
-  assertSpyCall(writeSpy, 0, {
-    args: [new TextEncoder().encode("Hello world")],
+  let called = false;
+  stub(Deno.stdout, "writeSync", (p) => {
+    assertEquals(new TextDecoder().decode(p), "Hello world");
+    called = true;
+    return p.length;
   });
+  printf("Hello %s", "world");
+  assertEquals(called, true);
+  restore();
 });


### PR DESCRIPTION
This PR replaces `spy()` call with `stub()` call in order to avoid test cli output pollution.