### PR TITLE
feat(data-structures/unstable): BidirectionalMap constructor accept iterables of key-value pairs

### DIFF
--- a/data_structures/unstable_bidirectional_map.ts
+++ b/data_structures/unstable_bidirectional_map.ts
@@ -45,7 +45,7 @@ export class BidirectionalMap<K, V> extends Map<K, V> {
    *
    * @param entries An iterable of key-value pairs for the initial entries.
    */
-  constructor(entries?: readonly (readonly [K, V])[] | null) {
+  constructor(entries?: Iterable<readonly [K, V]> | null) {
     super();
     this.#reverseMap = new Map<V, K>();
     if (entries) {

--- a/data_structures/unstable_bidirectional_map_test.ts
+++ b/data_structures/unstable_bidirectional_map_test.ts
@@ -312,3 +312,14 @@ Deno.test(
     assertEquals(entries, [[{ name: "Tūī" }, { favourite: true }]]);
   },
 );
+
+Deno.test(
+  "BidirectionalMap constructor accepts iterables of key-value pairs",
+  () => {
+    const bidiFromArr = new BidirectionalMap([
+      ...["zero", "one", "two"].entries(),
+    ]);
+    const bidiFromIter = new BidirectionalMap(["zero", "one", "two"].entries());
+    assertEquals(bidiFromArr, bidiFromIter);
+  },
+);


### PR DESCRIPTION
Fixes https://github.com/denoland/std/issues/6597