### PR TITLE
feat(fs/unstable): add create and createSync

### DIFF
--- a/_tools/node_test_runner/run_test.mjs
+++ b/_tools/node_test_runner/run_test.mjs
@@ -51,6 +51,7 @@ import "../../collections/zip_test.ts";
 import "../../fs/_node_fs_file_test.ts";
 import "../../fs/unstable_chown_test.ts";
 import "../../fs/unstable_copy_file_test.ts";
+import "../../fs/unstable_create.ts";
 import "../../fs/unstable_link_test.ts";
 import "../../fs/unstable_make_temp_dir_test.ts";
 import "../../fs/unstable_make_temp_file_test.ts";

--- a/fs/deno.json
+++ b/fs/deno.json
@@ -16,6 +16,7 @@
     "./unstable-chmod": "./unstable_chmod.ts",
     "./unstable-chown": "./unstable_chown.ts",
     "./unstable-copy-file": "./unstable_copy_file.ts",
+    "./unstable-create": "./unstable_create.ts",
     "./unstable-link": "./unstable_link.ts",
     "./unstable-lstat": "./unstable_lstat.ts",
     "./unstable-make-temp-dir": "./unstable_make_temp_dir.ts",

--- a/fs/unstable_create.ts
+++ b/fs/unstable_create.ts
@@ -1,0 +1,64 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { isDeno } from "./_utils.ts";
+import { mapError } from "./_map_error.ts";
+import { open, openSync } from "./unstable_open.ts";
+import type { FsFile } from "./unstable_types.ts";
+
+/**
+ * Creates a file if none exists or truncates an existing file and resolves to
+ * an instance of {@linkcode FsFile}.
+ *
+ * Requires `allow-read` and `allow-write` permissions.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { create } from "@std/fs/unstable-create";
+ * const file = await create("/foo/bar.txt");
+ * ```
+ *
+ * @tags allow-read, allow-write
+ *
+ * @param path The path to the newly created file.
+ * @returns A promise that resolves to a {@linkcode FsFile} instance.
+ */
+export async function create(path: string | URL): Promise<FsFile> {
+  if (isDeno) {
+    return Deno.create(path);
+  } else {
+    try {
+      return await open(path, { create: true, write: true, truncate: true });
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}
+
+/**
+ * Creates a file if none exists or truncates an existing file and returns
+ * an instance of {@linkcode FsFile}.
+ *
+ * Requires `allow-read` and `allow-write` permissions.
+ *
+ * @example Usage
+ * ```ts ignore
+ * import { createSync } from "@std/fs/unstable-create";
+ * const file = createSync("/foo/bar.txt");
+ * ```
+ *
+ * @tags allow-read, allow-write
+ *
+ * @param path The path to the newly created file.
+ * @returns A {@linkcode FsFile} instance.
+ */
+export function createSync(path: string | URL): FsFile {
+  if (isDeno) {
+    return Deno.createSync(path);
+  } else {
+    try {
+      return openSync(path, { create: true, write: true, truncate: true });
+    } catch (error) {
+      throw mapError(error);
+    }
+  }
+}

--- a/fs/unstable_create_test.ts
+++ b/fs/unstable_create_test.ts
@@ -1,0 +1,101 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { assert, assertEquals, assertRejects, assertThrows } from "@std/assert";
+import { create, createSync } from "./unstable_create.ts";
+import { makeTempDir, makeTempDirSync } from "./unstable_make_temp_dir.ts";
+import { makeTempFile, makeTempFileSync } from "./unstable_make_temp_file.ts";
+import { stat, statSync } from "./unstable_stat.ts";
+import {
+  writeTextFile,
+  writeTextFileSync,
+} from "./unstable_write_text_file.ts";
+import { remove, removeSync } from "./unstable_remove.ts";
+import { join } from "node:path";
+
+Deno.test("create() creates a file", async () => {
+  const tempDirPath = await makeTempDir({ prefix: "create_" });
+  const testFile = join(tempDirPath, "createFile.txt");
+
+  const fh = await create(testFile);
+
+  let fileStat = await fh.stat();
+  assert(fileStat.isFile);
+  assertEquals(fileStat.size, 0);
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode("Hello, Standard Library");
+  await fh.write(data);
+
+  fileStat = await fh.stat();
+  assertEquals(fileStat.size, 23);
+
+  fh.close();
+  await remove(tempDirPath, { recursive: true });
+});
+
+Deno.test("create() truncates an existing file path", async () => {
+  const tempFile = await makeTempFile({ prefix: "create_" });
+  await writeTextFile(tempFile, "Hello, Standard Library");
+
+  const fh = await create(tempFile);
+
+  const fileStat = await stat(tempFile);
+  assertEquals(fileStat.size, 0);
+
+  fh.close();
+  await remove(tempFile);
+});
+
+Deno.test("create() rejects with Error when using a file path that is not a regular file", async () => {
+  const tempDir = await makeTempDir({ prefix: "create_" });
+
+  await assertRejects(async () => {
+    await create(tempDir);
+  }, Error);
+
+  await remove(tempDir);
+});
+
+Deno.test("createSync() creates a new file", () => {
+  const tempDirPath = makeTempDirSync({ prefix: "createSync_" });
+  const testFile = join(tempDirPath, "createFile.txt");
+
+  const fh = createSync(testFile);
+
+  let fileStat = fh.statSync();
+  assert(fileStat.isFile);
+  assertEquals(fileStat.size, 0);
+
+  const encoder = new TextEncoder();
+  const data = encoder.encode("Hello, Standard Library");
+  fh.writeSync(data);
+
+  fileStat = fh.statSync();
+  assertEquals(fileStat.size, 23);
+
+  fh.close();
+  removeSync(tempDirPath, { recursive: true });
+});
+
+Deno.test("createSync() truncates an existing file path", () => {
+  const tempFile = makeTempFileSync({ prefix: "createSync_ " });
+  writeTextFileSync(tempFile, "Hello, Standard Library");
+
+  const fh = createSync(tempFile);
+
+  const fileStat = statSync(tempFile);
+  assertEquals(fileStat.size, 0);
+
+  fh.close();
+  removeSync(tempFile);
+});
+
+Deno.test("createSync() throws with Error when using a file path that is not a regular file", () => {
+  const tempDir = makeTempDirSync({ prefix: "createSync_" });
+
+  assertThrows(() => {
+    createSync(tempDir);
+  }, Error);
+
+  removeSync(tempDir);
+});


### PR DESCRIPTION
This PR adds the `create` and `createSync` APIs to the `@std/fs` package which are intended to mimic the `Deno.create` and `Deno.createSync` functions.

Towards #6255.