### PR TITLE
BREAKING(encoding/unstable): base64/32 functions to match proposal-arraybuffer-base64 API

### DIFF
--- a/encoding/_common32.ts
+++ b/encoding/_common32.ts
@@ -4,27 +4,35 @@ import type { Uint8Array_ } from "./_types.ts";
 export type { Uint8Array_ };
 
 export const padding = "=".charCodeAt(0);
-export const alphabet: Record<Base32Format, Uint8Array> = {
-  Base32: new TextEncoder().encode("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"),
-  Base32Hex: new TextEncoder().encode("0123456789ABCDEFGHIJKLMNOPQRSTUV"),
-  Base32Crockford: new TextEncoder().encode("0123456789ABCDEFGHJKMNPQRSTVWXYZ"),
+export const alphabet: Record<Base32Alphabet, Uint8Array> = {
+  base32: new TextEncoder().encode("ABCDEFGHIJKLMNOPQRSTUVWXYZ234567"),
+  base32hex: new TextEncoder().encode("0123456789ABCDEFGHIJKLMNOPQRSTUV"),
+  base32crockford: new TextEncoder().encode("0123456789ABCDEFGHJKMNPQRSTVWXYZ"),
 };
-export const rAlphabet: Record<Base32Format, Uint8Array> = {
-  Base32: new Uint8Array(128).fill(32), // alphabet.Base32.length
-  Base32Hex: new Uint8Array(128).fill(32),
-  Base32Crockford: new Uint8Array(128).fill(32),
+export const rAlphabet: Record<Base32Alphabet, Uint8Array> = {
+  base32: new Uint8Array(128).fill(32), // alphabet.base32.length
+  base32hex: new Uint8Array(128).fill(32),
+  base32crockford: new Uint8Array(128).fill(32),
 };
-alphabet.Base32
-  .forEach((byte, i) => rAlphabet.Base32[byte] = i);
-alphabet.Base32Hex
-  .forEach((byte, i) => rAlphabet.Base32Hex[byte] = i);
-alphabet.Base32Crockford
-  .forEach((byte, i) => rAlphabet.Base32Crockford[byte] = i);
+alphabet.base32
+  .forEach((byte, i) => rAlphabet.base32[byte] = i);
+alphabet.base32hex
+  .forEach((byte, i) => rAlphabet.base32hex[byte] = i);
+alphabet.base32crockford
+  .forEach((byte, i) => rAlphabet.base32crockford[byte] = i);
 
 /**
- * The base 32 encoding formats.
+ * Options for encoding and decoding base32 strings.
  */
-export type Base32Format = "Base32" | "Base32Hex" | "Base32Crockford";
+export interface Base32Options {
+  /** The base32 alphabet. Defaults to "base32" */
+  alphabet?: Base32Alphabet;
+}
+
+/**
+ * The base32 alphabets.
+ */
+export type Base32Alphabet = "base32" | "base32hex" | "base32crockford";
 
 /**
  * Calculate the output size needed to encode a given input size for

--- a/encoding/_common64.ts
+++ b/encoding/_common64.ts
@@ -23,12 +23,12 @@ alphabet.base64url
  * Options for encoding and decoding base64 strings.
  */
 export interface Base64Options {
-  /** The base 64 encoding alphabet. Defaults to "base64" */
+  /** The base64 alphabet. Defaults to "base64" */
   alphabet?: Base64Alphabet;
 }
 
 /**
- * The base 64 encoding alphabets.
+ * The base64 alphabets.
  */
 export type Base64Alphabet = "base64" | "base64url";
 

--- a/encoding/_common64.ts
+++ b/encoding/_common64.ts
@@ -4,25 +4,33 @@ import type { Uint8Array_ } from "./_types.ts";
 export type { Uint8Array_ };
 
 export const padding = "=".charCodeAt(0);
-export const alphabet: Record<Base64Format, Uint8Array> = {
-  Base64: new TextEncoder()
+export const alphabet: Record<Base64Alphabet, Uint8Array> = {
+  base64: new TextEncoder()
     .encode("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/"),
-  Base64Url: new TextEncoder()
+  base64url: new TextEncoder()
     .encode("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"),
 };
-export const rAlphabet: Record<Base64Format, Uint8Array> = {
-  Base64: new Uint8Array(128).fill(64), // alphabet.Base64.length
-  Base64Url: new Uint8Array(128).fill(64),
+export const rAlphabet: Record<Base64Alphabet, Uint8Array> = {
+  base64: new Uint8Array(128).fill(64), // alphabet.base64.length
+  base64url: new Uint8Array(128).fill(64),
 };
-alphabet.Base64
-  .forEach((byte, i) => rAlphabet.Base64[byte] = i);
-alphabet.Base64Url
-  .forEach((byte, i) => rAlphabet.Base64Url[byte] = i);
+alphabet.base64
+  .forEach((byte, i) => rAlphabet.base64[byte] = i);
+alphabet.base64url
+  .forEach((byte, i) => rAlphabet.base64url[byte] = i);
 
 /**
- * The base 64 encoding formats.
+ * Options for encoding and decoding base64 strings.
  */
-export type Base64Format = "Base64" | "Base64Url";
+export interface Base64Options {
+  /** The base 64 encoding alphabet. Defaults to "base64" */
+  alphabet?: Base64Alphabet;
+}
+
+/**
+ * The base 64 encoding alphabets.
+ */
+export type Base64Alphabet = "base64" | "base64url";
 
 /**
  * Calculate the output size needed to encode a given input size for

--- a/encoding/unstable_base32.ts
+++ b/encoding/unstable_base32.ts
@@ -6,11 +6,20 @@
  *
  * ```ts
  * import { assertEquals } from "@std/assert";
- * import { encodeBase32, type Uint8Array_ } from "@std/encoding/unstable-base32";
+ * import {
+ *   encodeBase32,
+ *   type Uint8Array_
+ * } from "@std/encoding/unstable-base32";
  *
- * assertEquals(encodeBase32("Hello World", "Base32"), "JBSWY3DPEBLW64TMMQ======");
  * assertEquals(
- *   encodeBase32(new TextEncoder().encode("Hello World") as Uint8Array_, "Base32"),
+ *   encodeBase32("Hello World", { alphabet: "base32" }),
+ *   "JBSWY3DPEBLW64TMMQ======",
+ * );
+ * assertEquals(
+ *   encodeBase32(
+ *     new TextEncoder().encode("Hello World") as Uint8Array_,
+ *     { alphabet: "base32" },
+ *   ),
  *   "JBSWY3DPEBLW64TMMQ======",
  * );
  * ```
@@ -25,14 +34,15 @@ import type { Uint8Array_ } from "./_types.ts";
 export type { Uint8Array_ };
 import {
   alphabet,
-  type Base32Format,
+  type Base32Alphabet,
+  type Base32Options,
   calcSizeBase32,
   decode,
   encode,
   padding,
   rAlphabet,
 } from "./_common32.ts";
-export { type Base32Format, calcSizeBase32 };
+export { type Base32Alphabet, type Base32Options, calcSizeBase32 };
 import { detach } from "./_common_detach.ts";
 
 /**
@@ -45,37 +55,59 @@ import { detach } from "./_common_detach.ts";
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @param input The input source to encode.
- * @param format The format to use for encoding.
+ * @param options The options to use for encoding.
  * @returns The base32 string representation of the input.
  *
  * @example Basic Usage
  * ```ts
  * import { assertEquals } from "@std/assert";
- * import { encodeBase32, type Uint8Array_ } from "@std/encoding/unstable-base32";
+ * import {
+ *   encodeBase32,
+ *   type Uint8Array_,
+ * } from "@std/encoding/unstable-base32";
  *
- * assertEquals(encodeBase32("Hello World", "Base32"), "JBSWY3DPEBLW64TMMQ======");
  * assertEquals(
- *   encodeBase32(new TextEncoder().encode("Hello World") as Uint8Array_, "Base32"),
+ *   encodeBase32("Hello World", { alphabet: "base32" }),
+ *   "JBSWY3DPEBLW64TMMQ======",
+ * );
+ * assertEquals(
+ *   encodeBase32(
+ *     new TextEncoder().encode("Hello World") as Uint8Array_,
+ *     { alphabet: "base32" },
+ *   ),
  *   "JBSWY3DPEBLW64TMMQ======",
  * );
  *
- * assertEquals(encodeBase32("Hello World", "Base32Hex"), "91IMOR3F41BMUSJCCG======");
  * assertEquals(
- *   encodeBase32(new TextEncoder().encode("Hello World") as Uint8Array_, "Base32Hex"),
+ *   encodeBase32("Hello World", { alphabet: "base32hex" }),
+ *   "91IMOR3F41BMUSJCCG======",
+ * );
+ * assertEquals(
+ *   encodeBase32(
+ *     new TextEncoder().encode("Hello World") as Uint8Array_,
+ *     { alphabet: "base32hex" },
+ *   ),
  *   "91IMOR3F41BMUSJCCG======",
  * );
  *
- * assertEquals(encodeBase32("Hello World", "Base32Crockford"), "91JPRV3F41BPYWKCCG======");
  * assertEquals(
- *   encodeBase32(new TextEncoder().encode("Hello World") as Uint8Array_, "Base32Crockford"),
+ *   encodeBase32("Hello World", { alphabet: "base32crockford" }),
+ *   "91JPRV3F41BPYWKCCG======",
+ * );
+ * assertEquals(
+ *   encodeBase32(
+ *     new TextEncoder().encode("Hello World") as Uint8Array_,
+ *     { alphabet: "base32crockford" },
+ *   ),
  *   "91JPRV3F41BPYWKCCG======",
  * );
  * ```
  */
 export function encodeBase32(
   input: string | Uint8Array_ | ArrayBuffer,
-  format: Base32Format = "Base32",
+  options: Base32Options = {},
 ): string {
+  options.alphabet ??= "base32";
   if (typeof input === "string") {
     input = new TextEncoder().encode(input) as Uint8Array_;
   } else if (input instanceof ArrayBuffer) {
@@ -85,7 +117,7 @@ export function encodeBase32(
     input as Uint8Array_,
     calcSizeBase32((input as Uint8Array_).length),
   );
-  encode(output, i, 0, alphabet[format], padding);
+  encode(output, i, 0, alphabet[options.alphabet], padding);
   return new TextDecoder().decode(output);
 }
 
@@ -97,7 +129,7 @@ export function encodeBase32(
  *
  * @param input the source to encode.
  * @param output the buffer to write the encoded source to.
- * @param format the format to use for encoding.
+ * @param options the options to use for encoding.
  * @returns the number of bytes written to the buffer.
  *
  * @example Basic Usage
@@ -114,19 +146,20 @@ export function encodeBase32(
  * const output = new Uint8Array(prefix.length + calcSizeBase32(input.length));
  *
  * const o = new TextEncoder().encodeInto(prefix, output).written;
- * encodeIntoBase32(input, output.subarray(o), "Base32");
+ * encodeIntoBase32(input, output.subarray(o), { alphabet: "base32" });
  * assertEquals(
  *   new TextDecoder().decode(output),
  *   "data:url/fake," +
- *     encodeBase32(await Deno.readFile("./deno.lock"), "Base32"),
+ *     encodeBase32(await Deno.readFile("./deno.lock"), { alphabet: "base32" }),
  * );
  * ```
  */
 export function encodeIntoBase32(
   input: string | Uint8Array_ | ArrayBuffer,
   output: Uint8Array_,
-  format: Base32Format = "Base32",
+  options: Base32Options = {},
 ): number {
+  options.alphabet ??= "base32";
   if (typeof input === "string") {
     input = new TextEncoder().encode(input) as Uint8Array_;
   } else if (input instanceof ArrayBuffer) {
@@ -139,7 +172,7 @@ export function encodeIntoBase32(
   output = output.subarray(0, min);
   const i = min - (input as Uint8Array_).length;
   output.set(input as Uint8Array_, i);
-  return encode(output, i, 0, alphabet[format], padding);
+  return encode(output, i, 0, alphabet[options.alphabet], padding);
 }
 
 /**
@@ -151,7 +184,7 @@ export function encodeIntoBase32(
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  *
  * @param input The input source to decode.
- * @param format The format to use for decoding.
+ * @param options The options to use for decoding.
  * @returns The decoded {@linkcode Uint8Array<ArrayBuffer>}.
  *
  * @example Basic Usage
@@ -160,27 +193,31 @@ export function encodeIntoBase32(
  * import { decodeBase32 } from "@std/encoding/unstable-base32";
  *
  * assertEquals(
- *   decodeBase32("JBSWY3DPEBLW64TMMQ======", "Base32"),
+ *   decodeBase32("JBSWY3DPEBLW64TMMQ======", { alphabet: "base32"}),
  *   new TextEncoder().encode("Hello World"),
  * );
  *
  * assertEquals(
- *   decodeBase32("91IMOR3F41BMUSJCCG======", "Base32Hex"),
+ *   decodeBase32("91IMOR3F41BMUSJCCG======", { alphabet: "base32hex"}),
  *   new TextEncoder().encode("Hello World"),
  * );
  *
  * assertEquals(
- *   decodeBase32("91JPRV3F41BPYWKCCG======", "Base32Crockford"),
+ *   decodeBase32("91JPRV3F41BPYWKCCG======", { alphabet: "base32crockford"}),
  *   new TextEncoder().encode("Hello World"),
  * );
  * ```
  */
 export function decodeBase32(
   input: string | Uint8Array_,
-  format: Base32Format = "Base32",
+  options: Base32Options = {},
 ): Uint8Array_ {
+  options.alphabet ??= "base32";
   if (typeof input === "string") {
     input = new TextEncoder().encode(input) as Uint8Array_;
   }
-  return input.subarray(0, decode(input, 0, 0, rAlphabet[format], padding));
+  return input.subarray(
+    0,
+    decode(input, 0, 0, rAlphabet[options.alphabet], padding),
+  );
 }

--- a/encoding/unstable_base32_stream.ts
+++ b/encoding/unstable_base32_stream.ts
@@ -16,7 +16,7 @@
  *
  * assertEquals(
  *   await toText(readable),
- *   encodeBase32(await Deno.readFile("./deno.lock"), "Base32"),
+ *   encodeBase32(await Deno.readFile("./deno.lock"), { alphabet: "base32" }),
  * );
  * ```
  *
@@ -29,7 +29,7 @@ import type { Uint8Array_ } from "./_types.ts";
 export type { Uint8Array_ };
 import {
   alphabet,
-  type Base32Format,
+  type Base32Alphabet,
   calcSizeBase32,
   decode,
   encode,
@@ -63,7 +63,7 @@ const decoder = new TextDecoder();
  *
  * assertEquals(
  *   await toText(readable),
- *   encodeBase32(await Deno.readFile("./deno.lock"), "Base32"),
+ *   encodeBase32(await Deno.readFile("./deno.lock"), { alphabet: "base32" }),
  * );
  * ```
  */
@@ -77,8 +77,8 @@ export class Base32EncoderStream<T extends "string" | "bytes">
    *
    * @param options The options of the base32 stream.
    */
-  constructor(options: { format?: Base32Format; output?: T } = {}) {
-    const abc = alphabet[options.format ?? "Base32"];
+  constructor(options: { alphabet?: Base32Alphabet; output?: T } = {}) {
+    const abc = alphabet[options.alphabet ?? "base32"];
     const decode = function (): (input: Uint8Array_) => Expect<T> {
       if (options.output === "bytes") return (x) => x as Expect<T>;
       return (x) => decoder.decode(x) as Expect<T>;
@@ -159,8 +159,8 @@ export class Base32DecoderStream<T extends "string" | "bytes">
    *
    * @param options The options of the base32 stream.
    */
-  constructor(options: { format?: Base32Format; input?: T } = {}) {
-    const abc = rAlphabet[options.format ?? "Base32"];
+  constructor(options: { alphabet?: Base32Alphabet; input?: T } = {}) {
+    const abc = rAlphabet[options.alphabet ?? "base32"];
     const encode = function (): (input: Expect<T>) => Uint8Array_ {
       if (options.input === "bytes") return (x) => x as Uint8Array_;
       return (x) => encoder.encode(x as string) as Uint8Array_;

--- a/encoding/unstable_base32_stream_test.ts
+++ b/encoding/unstable_base32_stream_test.ts
@@ -11,55 +11,55 @@ import {
 } from "./unstable_base32_stream.ts";
 
 Deno.test("Base32EncoderStream() with normal format", async () => {
-  for (const format of ["Base32", "Base32Hex", "Base32Crockford"] as const) {
+  for (const alphabet of ["base32", "base32hex", "base32crockford"] as const) {
     const readable = (await Deno.open("./deno.lock"))
       .readable
       .pipeThrough(new FixedChunkStream(1021))
-      .pipeThrough(new Base32EncoderStream({ format, output: "string" }));
+      .pipeThrough(new Base32EncoderStream({ alphabet, output: "string" }));
 
     assertEquals(
       await toText(readable),
-      encodeBase32(await Deno.readFile("./deno.lock"), format),
-      format,
+      encodeBase32(await Deno.readFile("./deno.lock"), { alphabet }),
+      alphabet,
     );
   }
 });
 
 Deno.test("Base32EncoderStream() with raw format", async () => {
   for (
-    const format of [
-      "Base32",
-      "Base32Hex",
-      "Base32Crockford",
+    const alphabet of [
+      "base32",
+      "base32hex",
+      "base32crockford",
     ] as const
   ) {
     const readable = (await Deno.open("./deno.lock"))
       .readable
       .pipeThrough(new FixedChunkStream(1021))
-      .pipeThrough(new Base32EncoderStream({ format, output: "bytes" }));
+      .pipeThrough(new Base32EncoderStream({ alphabet, output: "bytes" }));
 
     assertEquals(
       await toBytes(readable),
       new TextEncoder().encode(
         encodeBase32(
           await Deno.readFile("./deno.lock"),
-          format,
+          { alphabet },
         ),
       ),
-      format,
+      alphabet,
     );
   }
 });
 
 Deno.test("Base32DecoderStream() with normal format", async () => {
-  for (const format of ["Base32", "Base32Hex", "Base32Crockford"] as const) {
+  for (const alphabet of ["base32", "base32hex", "base32crockford"] as const) {
     const readable = (await Deno.open("./deno.lock"))
       .readable
-      .pipeThrough(new Base32EncoderStream({ format, output: "string" }))
+      .pipeThrough(new Base32EncoderStream({ alphabet, output: "string" }))
       .pipeThrough(new TextEncoderStream())
       .pipeThrough(new FixedChunkStream(1021))
       .pipeThrough(new TextDecoderStream())
-      .pipeThrough(new Base32DecoderStream({ format, input: "string" }));
+      .pipeThrough(new Base32DecoderStream({ alphabet, input: "string" }));
 
     assertEquals(
       await toBytes(readable),
@@ -70,17 +70,17 @@ Deno.test("Base32DecoderStream() with normal format", async () => {
 
 Deno.test("Base32DecoderStream() with raw format", async () => {
   for (
-    const format of [
-      "Base32",
-      "Base32Hex",
-      "Base32Crockford",
+    const alphabet of [
+      "base32",
+      "base32hex",
+      "base32crockford",
     ] as const
   ) {
     const readable = (await Deno.open("./deno.lock"))
       .readable
-      .pipeThrough(new Base32EncoderStream({ format, output: "bytes" }))
+      .pipeThrough(new Base32EncoderStream({ alphabet, output: "bytes" }))
       .pipeThrough(new FixedChunkStream(1021))
-      .pipeThrough(new Base32DecoderStream({ format, input: "bytes" }));
+      .pipeThrough(new Base32DecoderStream({ alphabet, input: "bytes" }));
 
     assertEquals(
       await toBytes(readable),

--- a/encoding/unstable_base32_test.ts
+++ b/encoding/unstable_base32_test.ts
@@ -58,14 +58,18 @@ const inputOutput: [string | ArrayBuffer, string, string, string][] = [
 
 Deno.test("encodeBase32()", () => {
   for (const [input, base32, base32hex, base32crockford] of inputOutput) {
-    assertEquals(encodeBase32(input.slice(0), "Base32"), base32, "Base32");
     assertEquals(
-      encodeBase32(input.slice(0), "Base32Hex"),
+      encodeBase32(input.slice(0), { alphabet: "base32" }),
+      base32,
+      "Base32",
+    );
+    assertEquals(
+      encodeBase32(input.slice(0), { alphabet: "base32hex" }),
       base32hex,
       "Base32Hex",
     );
     assertEquals(
-      encodeBase32(input.slice(0), "Base32Crockford"),
+      encodeBase32(input.slice(0), { alphabet: "base32crockford" }),
       base32crockford,
       "Base32Crockford",
     );
@@ -80,19 +84,23 @@ Deno.test("encodeBase32() subarray", () => {
     buffer.set(new Uint8Array(input), 10 - input.byteLength);
 
     assertEquals(
-      encodeBase32(buffer.slice().subarray(10 - input.byteLength), "Base32"),
+      encodeBase32(buffer.slice().subarray(10 - input.byteLength), {
+        alphabet: "base32",
+      }),
       base32,
       "Base32",
     );
     assertEquals(
-      encodeBase32(buffer.slice().subarray(10 - input.byteLength), "Base32Hex"),
+      encodeBase32(buffer.slice().subarray(10 - input.byteLength), {
+        alphabet: "base32hex",
+      }),
       base32hex,
       "Base32Hex",
     );
     assertEquals(
       encodeBase32(
         buffer.slice().subarray(10 - input.byteLength),
-        "Base32Crockford",
+        { alphabet: "base32crockford" },
       ),
       base32crockford,
       "Base32Crockford",
@@ -106,12 +114,12 @@ Deno.test("encodeBase32Into()", () => {
     if (typeof input === "string") continue;
 
     for (
-      const [output, format] of [
-        [concat([prefix, new TextEncoder().encode(base32)]), "Base32"],
-        [concat([prefix, new TextEncoder().encode(base32hex)]), "Base32Hex"],
+      const [output, alphabet] of [
+        [concat([prefix, new TextEncoder().encode(base32)]), "base32"],
+        [concat([prefix, new TextEncoder().encode(base32hex)]), "base32hex"],
         [
           concat([prefix, new TextEncoder().encode(base32crockford)]),
-          "Base32Crockford",
+          "base32crockford",
         ],
       ] as const
     ) {
@@ -123,9 +131,9 @@ Deno.test("encodeBase32Into()", () => {
       encodeIntoBase32(
         input,
         buffer.subarray(prefix.length),
-        format,
+        { alphabet },
       );
-      assertEquals(buffer, output, format);
+      assertEquals(buffer, output, alphabet);
     }
   }
 });
@@ -135,7 +143,9 @@ Deno.test("encodeBase32Into() with too small buffer", () => {
   for (const [input] of inputOutput) {
     if (typeof input === "string" || input.byteLength === 0) continue;
 
-    for (const format of ["Base32", "Base32Hex", "Base32Crockford"] as const) {
+    for (
+      const alphabet of ["base32", "base32hex", "base32crockford"] as const
+    ) {
       const buffer = new Uint8Array(
         prefix.length + calcSizeBase32(input.byteLength) - 2,
       );
@@ -146,11 +156,11 @@ Deno.test("encodeBase32Into() with too small buffer", () => {
           encodeIntoBase32(
             input,
             buffer.subarray(prefix.length),
-            format,
+            { alphabet },
           ),
         RangeError,
         "Cannot encode input as base32: Output too small",
-        format,
+        alphabet,
       );
     }
   }
@@ -161,10 +171,18 @@ Deno.test("decodeBase32()", () => {
     if (input instanceof ArrayBuffer) continue;
     const output = new TextEncoder().encode(input);
 
-    assertEquals(decodeBase32(base32, "Base32"), output, "Base32");
-    assertEquals(decodeBase32(base32hex, "Base32Hex"), output, "Base32Hex");
     assertEquals(
-      decodeBase32(base32crockford, "Base32Crockford"),
+      decodeBase32(base32, { alphabet: "base32" }),
+      output,
+      "Base32",
+    );
+    assertEquals(
+      decodeBase32(base32hex, { alphabet: "base32hex" }),
+      output,
+      "Base32Hex",
+    );
+    assertEquals(
+      decodeBase32(base32crockford, { alphabet: "base32crockford" }),
       output,
       "Base32Crockford",
     );
@@ -177,17 +195,17 @@ Deno.test("decodeBase32() invalid char after padding", () => {
     if (base32[base32.length - 2] !== "=") continue;
 
     for (
-      const [input, format] of [
-        [base32.substring(-1) + ".", "Base32"],
-        [base32hex.substring(-1) + ".", "Base32Hex"],
-        [base32crockford.substring(-1) + ".", "Base32Crockford"],
+      const [input, alphabet] of [
+        [base32.substring(-1) + ".", "base32"],
+        [base32hex.substring(-1) + ".", "base32hex"],
+        [base32crockford.substring(-1) + ".", "base32crockford"],
       ] as const
     ) {
       assertThrows(
-        () => decodeBase32(input, format),
+        () => decodeBase32(input, { alphabet }),
         TypeError,
         "Cannot decode input as base32: Invalid character (.)",
-        format,
+        alphabet,
       );
     }
   }
@@ -199,17 +217,17 @@ Deno.test("decodeBase32() invalid length", () => {
     if (input.length === 4 || input.length === 2) continue;
 
     for (
-      const [input, format] of [
-        [base32.replaceAll("=", "") + "A", "Base32"],
-        [base32hex.replaceAll("=", "") + "A", "Base32Hex"],
-        [base32crockford.replaceAll("=", "") + "A", "Base32Crockford"],
+      const [input, alphabet] of [
+        [base32.replaceAll("=", "") + "A", "base32"],
+        [base32hex.replaceAll("=", "") + "A", "base32hex"],
+        [base32crockford.replaceAll("=", "") + "A", "base32crockford"],
       ] as const
     ) {
       assertThrows(
-        () => decodeBase32(input, format),
+        () => decodeBase32(input, { alphabet }),
         RangeError,
         `Length (${input.length}), excluding padding, must not have a remainder of 1, 3, or 6 when divided by 8`,
-        format,
+        alphabet,
       );
     }
   }
@@ -220,17 +238,17 @@ Deno.test("decodeBase32() invalid char", () => {
     if (input instanceof ArrayBuffer) continue;
 
     for (
-      const [input, format] of [
-        [".".repeat(8) + base32, "Base32"],
-        [".".repeat(8) + base32hex, "Base32Hex"],
-        [".".repeat(8) + base32crockford, "Base32Crockford"],
+      const [input, alphabet] of [
+        [".".repeat(8) + base32, "base32"],
+        [".".repeat(8) + base32hex, "base32hex"],
+        [".".repeat(8) + base32crockford, "base32crockford"],
       ] as const
     ) {
       assertThrows(
-        () => decodeBase32(input, format),
+        () => decodeBase32(input, { alphabet }),
         TypeError,
         "Cannot decode input as base32: Invalid character (.)",
-        format,
+        alphabet,
       );
     }
   }

--- a/encoding/unstable_base64_stream.ts
+++ b/encoding/unstable_base64_stream.ts
@@ -16,7 +16,7 @@
  *
  * assertEquals(
  *   await toText(readable),
- *   encodeBase64(await Deno.readFile("./deno.lock"), "Base64"),
+ *   encodeBase64(await Deno.readFile("./deno.lock"), { alphabet: "base64" }),
  * );
  * ```
  *
@@ -29,7 +29,7 @@ import type { Uint8Array_ } from "./_types.ts";
 export type { Uint8Array_ };
 import {
   alphabet,
-  type Base64Format,
+  type Base64Alphabet,
   calcSizeBase64,
   decode,
   encode,
@@ -77,8 +77,8 @@ export class Base64EncoderStream<T extends "string" | "bytes">
    *
    * @param options The options for the base64 stream.
    */
-  constructor(options: { format?: Base64Format; output?: T } = {}) {
-    const abc = alphabet[options.format ?? "Base64"];
+  constructor(options: { alphabet?: Base64Alphabet; output?: T } = {}) {
+    const abc = alphabet[options.alphabet ?? "base64"];
     const decode = function (): (input: Uint8Array_) => Expect<T> {
       if (options.output === "bytes") return (x) => x as Expect<T>;
       return (x) => decoder.decode(x) as Expect<T>;
@@ -113,7 +113,7 @@ export class Base64EncoderStream<T extends "string" | "bytes">
             calcSizeBase64(remainder),
           );
           let o = encode(output, i, 0, abc, padding);
-          if (options.format === "Base64Url") {
+          if (options.alphabet === "base64url") {
             const i = output.indexOf(padding, o - 2);
             if (i > 0) o = i;
           }
@@ -161,8 +161,8 @@ export class Base64DecoderStream<T extends "string" | "bytes">
    *
    * @param options The options for the base64 stream.
    */
-  constructor(options: { format?: Base64Format; input?: T } = {}) {
-    const abc = rAlphabet[options.format ?? "Base64"];
+  constructor(options: { alphabet?: Base64Alphabet; input?: T } = {}) {
+    const abc = rAlphabet[options.alphabet ?? "base64"];
     const encode = function (): (input: Expect<T>) => Uint8Array_ {
       if (options.input === "bytes") return (x) => x as Uint8Array_;
       return (x) => encoder.encode(x as string) as Uint8Array_;

--- a/encoding/unstable_base64_stream_test.ts
+++ b/encoding/unstable_base64_stream_test.ts
@@ -11,49 +11,49 @@ import {
 } from "./unstable_base64_stream.ts";
 
 Deno.test("Base64EncoderStream() with normal format", async () => {
-  for (const format of ["Base64", "Base64Url"] as const) {
+  for (const alphabet of ["base64", "base64url"] as const) {
     const readable = (await Deno.open("./deno.lock"))
       .readable
       .pipeThrough(new FixedChunkStream(1021))
-      .pipeThrough(new Base64EncoderStream({ format, output: "string" }));
+      .pipeThrough(new Base64EncoderStream({ alphabet, output: "string" }));
 
     assertEquals(
       await toText(readable),
-      encodeBase64(await Deno.readFile("./deno.lock"), format),
-      format,
+      encodeBase64(await Deno.readFile("./deno.lock"), { alphabet }),
+      alphabet,
     );
   }
 });
 
 Deno.test("Base64EncoderStream() with raw format", async () => {
-  for (const format of ["Base64", "Base64Url"] as const) {
+  for (const alphabet of ["base64", "base64url"] as const) {
     const readable = (await Deno.open("./deno.lock"))
       .readable
       .pipeThrough(new FixedChunkStream(1021))
-      .pipeThrough(new Base64EncoderStream({ format, output: "bytes" }));
+      .pipeThrough(new Base64EncoderStream({ alphabet, output: "bytes" }));
 
     assertEquals(
       await toBytes(readable),
       new TextEncoder().encode(
         encodeBase64(
           await Deno.readFile("./deno.lock"),
-          format,
+          { alphabet },
         ),
       ),
-      format,
+      alphabet,
     );
   }
 });
 
 Deno.test("Base64DecoderStream() with normal format", async () => {
-  for (const format of ["Base64", "Base64Url"] as const) {
+  for (const alphabet of ["base64", "base64url"] as const) {
     const readable = (await Deno.open("./deno.lock"))
       .readable
-      .pipeThrough(new Base64EncoderStream({ format, output: "string" }))
+      .pipeThrough(new Base64EncoderStream({ alphabet, output: "string" }))
       .pipeThrough(new TextEncoderStream())
       .pipeThrough(new FixedChunkStream(1021))
       .pipeThrough(new TextDecoderStream())
-      .pipeThrough(new Base64DecoderStream({ format, input: "string" }));
+      .pipeThrough(new Base64DecoderStream({ alphabet, input: "string" }));
 
     assertEquals(
       await toBytes(readable),
@@ -63,12 +63,12 @@ Deno.test("Base64DecoderStream() with normal format", async () => {
 });
 
 Deno.test("Base64DecoderStream() with raw format", async () => {
-  for (const format of ["Base64", "Base64Url"] as const) {
+  for (const alphabet of ["base64", "base64url"] as const) {
     const readable = (await Deno.open("./deno.lock"))
       .readable
-      .pipeThrough(new Base64EncoderStream({ format, output: "bytes" }))
+      .pipeThrough(new Base64EncoderStream({ alphabet, output: "bytes" }))
       .pipeThrough(new FixedChunkStream(1021))
-      .pipeThrough(new Base64DecoderStream({ format, input: "bytes" }));
+      .pipeThrough(new Base64DecoderStream({ alphabet, input: "bytes" }));
 
     assertEquals(
       await toBytes(readable),


### PR DESCRIPTION
Closes: https://github.com/denoland/std/issues/6601

Looking at the documentation for the proposal on MDN, it has an `omitPadding` option. Testing it out on Firefox, it seems to always add padding, even for base64url. Would it be better to also implement this option here or stick with current behaviour of always adding padding for base64 and always omitting padding for base64url? 
 - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Uint8Array/toBase64