### PR TITLE
fix(http): don't set the Date header in file_server.ts responses (use the default Date header value)

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -202,11 +202,6 @@ export async function serveFile(
 
   const headers = createBaseHeaders();
 
-  // Set date header if access timestamp is available
-  if (fileInfo.atime) {
-    headers.set(HEADER.Date, fileInfo.atime.toUTCString());
-  }
-
   const etag = fileInfo.mtime
     ? await eTag(fileInfo, { algorithm })
     : await HASHED_DENO_DEPLOYMENT_ID;

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -119,20 +119,6 @@ Deno.test("serveDir() sets last-modified header", async () => {
   assertAlmostEquals(lastModifiedTime, expectedTime, 5 * MINUTE);
 });
 
-Deno.test("serveDir() sets date header", async () => {
-  const req = new Request("http://localhost/test_file.txt");
-  const res = await serveDir(req, serveDirOptions);
-  await res.body?.cancel();
-  const dateHeader = res.headers.get("date") as string;
-  const date = Date.parse(dateHeader);
-  const expectedTime =
-    TEST_FILE_STAT.atime && TEST_FILE_STAT.atime instanceof Date
-      ? TEST_FILE_STAT.atime.getTime()
-      : Number.NaN;
-
-  assertAlmostEquals(date, expectedTime, 5 * MINUTE);
-});
-
 Deno.test("serveDir()", async () => {
   const req = new Request("http://localhost/hello.html");
   const res = await serveDir(req, serveDirOptions);


### PR DESCRIPTION
Fixes #6609

`Deno.serve()` already sets the `Date` header on responses. So simply removing these lines should fix this.