### PR TITLE
chore: improve `_tools/check_browser_compat.ts` performance

### DIFF
--- a/_tools/check_browser_compat.ts
+++ b/_tools/check_browser_compat.ts
@@ -1,9 +1,8 @@
-// deno-lint-ignore-file no-console
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 /**
- * Running this script provides a list of suggested files that might be browser-compatible.
- * It skips test code, benchmark code, internal code and `version.ts` at the root.
+ * This script adds a browser-compatible declaration to files that are
+ * browser-compatible but do not have the declaration.
  *
  * Run using: deno run --allow-read --allow-run _tools/check_browser_compat.ts
  */
@@ -14,10 +13,9 @@ import { COPYRIGHT } from "./check_licence.ts";
 const ROOT = new URL("../", import.meta.url);
 const SKIP = [/(test|bench|\/_|\\_|testdata|version.ts)/];
 const DECLARATION = "// This module is browser compatible.";
-const CHECK = Deno.args.includes("--check");
 
-function isBrowserCompatible(filePath: string): boolean {
-  const command = new Deno.Command(Deno.execPath(), {
+async function isBrowserCompatible(filePath: string): Promise<boolean> {
+  return (await new Deno.Command(Deno.execPath(), {
     args: [
       "check",
       "--no-lock",
@@ -25,29 +23,16 @@ function isBrowserCompatible(filePath: string): boolean {
       "browser-compat.tsconfig.json",
       filePath,
     ],
-  });
-  const { success } = command.outputSync();
-  return success;
+  }).output()).success;
 }
-
-function hasBrowserCompatibleComment(source: string): boolean {
-  return source.includes(DECLARATION);
-}
-
 for await (const { path } of walk(ROOT, { exts: [".ts"], skip: SKIP })) {
   const source = await Deno.readTextFile(path);
-  if (isBrowserCompatible(path) && !hasBrowserCompatibleComment(source)) {
-    if (CHECK) {
-      console.log(
-        `${path} is likely browser-compatible and can have the "${DECLARATION}" comment added.`,
-      );
-    } else {
-      const index = source.indexOf(COPYRIGHT);
-      await Deno.writeTextFile(
-        path,
-        source.slice(0, index + COPYRIGHT.length) + "\n" + DECLARATION +
-          source.slice(index + COPYRIGHT.length),
-      );
-    }
+  if (!source.includes(DECLARATION) && await isBrowserCompatible(path)) {
+    const index = source.indexOf(COPYRIGHT);
+    await Deno.writeTextFile(
+      path,
+      source.slice(0, index + COPYRIGHT.length) + "\n" + DECLARATION +
+        source.slice(index + COPYRIGHT.length),
+    );
   }
 }


### PR DESCRIPTION
These changes reduces the execution time of this script by ~70% (60s) and removes the `--check` option, which feels redundant given we can just make the appropriate changes.