### PR TITLE
chore: simplify and move `isTestFile()`

### DIFF
--- a/_tools/check_mod_exports.ts
+++ b/_tools/check_mod_exports.ts
@@ -6,7 +6,6 @@ import { relative } from "../path/relative.ts";
 import { dirname } from "../path/dirname.ts";
 import * as colors from "../fmt/colors.ts";
 import ts from "npm:typescript";
-import { isTestFile } from "./utils.ts";
 
 const ROOT = new URL("../", import.meta.url);
 const FAIL_FAST = Deno.args.includes("--fail-fast");
@@ -68,7 +67,10 @@ for await (
       .replaceAll("\\", "/");
 
     if (!modExportSpecifiers.has(relativeSpecifier)) {
-      if (isTestFile(filePath)) continue;
+      if (
+        filePath.endsWith("test.ts") &&
+        Deno.readTextFileSync(filePath).includes("Deno.test(")
+      ) continue;
 
       console.warn(
         `${

--- a/_tools/utils.ts
+++ b/_tools/utils.ts
@@ -1,7 +1,5 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import ts from "npm:typescript";
-
 export function resolve(
   specifier: string,
   referrer: string,
@@ -9,38 +7,4 @@ export function resolve(
   return (specifier.startsWith("./") || specifier.startsWith("../"))
     ? new URL(specifier, referrer).href
     : import.meta.resolve(specifier);
-}
-
-/**
- * Checks whether a file is named `test.ts` and has no exports.
- * @param filePath
- * @returns true if file is named `test.ts` and has no exports, false otherwise
- */
-export function isTestFile(filePath: string): boolean {
-  if (!filePath.endsWith("test.ts")) return false;
-  const source = Deno.readTextFileSync(filePath);
-  const sourceFile = ts.createSourceFile(
-    filePath,
-    source,
-    ts.ScriptTarget.Latest,
-  );
-
-  let result = true;
-
-  function visitNode(node: ts.Node) {
-    if (!result) return;
-    if (
-      ts.isExportSpecifier(node) ||
-      ts.isExportAssignment(node) ||
-      ts.isExportDeclaration(node) ||
-      node.kind === ts.SyntaxKind.ExportKeyword
-    ) {
-      result = false;
-    } else {
-      ts.forEachChild(node, visitNode);
-    }
-  }
-
-  visitNode(sourceFile);
-  return result;
 }


### PR DESCRIPTION
There are very few edge cases where this will return a false positive. So I think this is more than sufficient.