### PR TITLE
chore: cleanup `exclude` in root `deno.json`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,10 @@ jobs:
         run: deno task test:browser
         if: matrix.deno == 'v2.x' && matrix.os == 'ubuntu-latest'
 
+      - name: Publish dry run
+        run: deno publish --dry-run
+        if: matrix.deno == 'canary' && matrix.os == 'ubuntu-latest'
+
       - name: Generate lcov and html reports
         run: |
           deno task cov:lcov
@@ -71,10 +75,6 @@ jobs:
           root: coverage/html
           entrypoint: jsr:@std/http@1/file-server
         if: matrix.deno == 'canary' && matrix.os == 'ubuntu-latest' && github.event_name == 'push'
-
-      - name: Publish dry run
-        run: deno publish --dry-run
-        if: matrix.deno == 'canary' && matrix.os == 'ubuntu-latest'
 
   test-node:
     runs-on: ${{ matrix.os }}

--- a/.gitignore
+++ b/.gitignore
@@ -10,10 +10,6 @@ cli/testdata/unicode_width_crate/target
 
 # coverage
 coverage/
-cov.lcov
-codecov
-codecov.SHA256SUM
-codecov.SHA256SUM.sig
 
 # misc files
 .DS_Store

--- a/deno.json
+++ b/deno.json
@@ -34,13 +34,8 @@
   },
   "exclude": [
     ".git",
-    "crypto/_wasm/target",
-    "cov",
     "jsonc/testdata",
-    "front_matter/testdata",
-    "_tools/node_test_runner",
-    "coverage",
-    "docs"
+    "_tools/node_test_runner"
   ],
   "lint": {
     "rules": {


### PR DESCRIPTION
If it's listed in the `.gitignore` file, Deno automatically exlucdes it from linting, formatting, publishing, etc.