### PR TITLE
feat(dotenv): add URL as envPath type

### DIFF
--- a/dotenv/mod.ts
+++ b/dotenv/mod.ts
@@ -35,7 +35,7 @@ export interface LoadOptions {
    *
    * @default {"./.env"}
    */
-  envPath?: string | null;
+  envPath?: string | URL | null;
 
   /**
    * Set to `true` to export all `.env` variables to the current processes
@@ -227,7 +227,7 @@ export async function load(
 }
 
 function parseFileSync(
-  filepath: string,
+  filepath: string | URL,
 ): Record<string, string> {
   try {
     return parse(Deno.readTextFileSync(filepath));
@@ -238,7 +238,7 @@ function parseFileSync(
 }
 
 async function parseFile(
-  filepath: string,
+  filepath: string | URL,
 ): Promise<Record<string, string>> {
   try {
     return parse(await Deno.readTextFile(filepath));

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -29,6 +29,24 @@ Deno.test("load() handles non-existent .env files", async () => {
   assertEquals({}, loadSync(loadOptions));
 });
 
+Deno.test("load() handles URL as path for .env files", async () => {
+  const conf = loadSync({
+    envPath: new URL(
+      path.toFileUrl(path.join(testdataDir, ".env")),
+      import.meta.url,
+    ),
+  });
+  assertEquals(conf.GREETING, "hello world", "loaded from .env");
+
+  const asyncConf = await load({
+    envPath: new URL(
+      path.toFileUrl(path.join(testdataDir, ".env")),
+      import.meta.url,
+    ),
+  });
+  assertEquals(asyncConf.GREETING, "hello world", "loaded from .env");
+});
+
 Deno.test("load() handles comprised .env and .env.defaults", async () => {
   const conf = loadSync(testOptions);
   assertEquals(conf.GREETING, "hello world", "loaded from .env");


### PR DESCRIPTION
This PR fixes https://github.com/denoland/std/issues/6620, by adding `URL` as a valid type to the `envPath` parameter in the `LoadOptions` interface.