### PR TITLE
chore: run some test cases in bun in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,32 @@ jobs:
       - name: Run tests
         run: deno task test:node
 
+  test-bun:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        bun:
+          - latest
+        os:
+          - ubuntu-latest
+
+    steps:
+      - name: Clone repository
+        uses: actions/checkout@v4
+
+      - name: Set up Deno
+        uses: denoland/setup-deno@v2
+
+      - name: Set up Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: ${{ matrix.node }}
+
+      - name: Run tests
+        run: deno task test:bun
+
   lint:
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ coverage/
 .vim
 _tmp/
 !_tmp/.keep
+
+# tsconfig for bun
+/tsconfig.json

--- a/_tools/node_test_runner/.gitignore
+++ b/_tools/node_test_runner/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 package-lock.json
+bun.lock

--- a/_tools/node_test_runner/run_test.mjs
+++ b/_tools/node_test_runner/run_test.mjs
@@ -75,5 +75,9 @@ import "../../fs/unstable_umask_test.ts";
 import "../../fs/unstable_utime_test.ts";
 
 for (const testDef of testDefinitions) {
-  test(testDef.name, testDef.fn);
+  if (testDef.ignore) {
+    test.skip(testDef.name, testDef.fn);
+  } else {
+    test(testDef.name, testDef.fn);
+  }
 }

--- a/_tools/node_test_runner/tsconfig_for_bun.json
+++ b/_tools/node_test_runner/tsconfig_for_bun.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "paths": {
+      "@std/assert": ["./assert/mod.ts"],
+      "@std/assert/greater-or-equal": ["./assert/greater_or_equal.ts"],
+      "@std/path": ["./path/mod.ts"],
+      "@std/internal/format": ["./internal/format.ts"],
+      "@std/internal/styles": ["./internal/styles.ts"],
+      "@std/internal/build-message": ["./internal/build_message.ts"],
+      "@std/internal/diff": ["./internal/diff.ts"],
+      "@std/internal/diff-str": ["./internal/diff_str.ts"],
+      "@std/semver": ["./semver/mod.ts"],
+    }
+  }
+}

--- a/collections/invert_test.ts
+++ b/collections/invert_test.ts
@@ -29,7 +29,7 @@ Deno.test("invert() handles nested input", () => {
   // @ts-expect-error - testing invalid input
   invertTest({ a: "x", b: Object }, {
     "x": "a",
-    "function Object() { [native code] }": "b",
+    [Object.toString()]: "b",
   });
   // @ts-expect-error - testing invalid input
   invertTest({ a: "x", b: ["y", "z"] }, { "x": "a", "y,z": "b" });

--- a/deno.json
+++ b/deno.json
@@ -12,6 +12,7 @@
     "test:with-unsafe-proto": "deno test --unstable-http --unstable-webgpu --unstable-fs --unstable-unsafe-proto --doc --allow-all --parallel --coverage --trace-leaks --clean",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | grep -v media_types/vendor/update.ts | xargs deno check --config browser-compat.tsconfig.json",
     "test:node": "(cd _tools/node_test_runner && npm install) && node --import ./_tools/node_test_runner/register_deno_shim.mjs ./_tools/node_test_runner/run_test.mjs",
+    "test:bun": "(cd _tools/node_test_runner && bun install) && cp _tools/node_test_runner/tsconfig_for_bun.json ./tsconfig.json && bun test --require ./_tools/node_test_runner/register_deno_shim.mjs _tools/node_test_runner/run_test.mjs && rm tsconfig.json",
     "fmt:licence-headers": "deno run --allow-read --allow-write ./_tools/check_licence.ts",
     "lint:circular": "deno run --allow-env --allow-read --allow-write --allow-net=deno.land,jsr.io ./_tools/check_circular_package_dependencies.ts",
     "lint:mod-exports": "deno run --allow-env --allow-read ./_tools/check_mod_exports.ts",

--- a/fs/unstable_chown_test.ts
+++ b/fs/unstable_chown_test.ts
@@ -8,6 +8,8 @@ import { remove, removeSync } from "./unstable_remove.ts";
 import { platform } from "node:os";
 import { spawn } from "node:child_process";
 
+const isBun = navigator.userAgent.includes("Bun/");
+
 type IdResult = {
   id: string;
   code: number;
@@ -64,7 +66,7 @@ async function getUidAndGid(): Promise<{ uid: number; gid: number }> {
 
 Deno.test({
   name: "chown() changes user and group ids",
-  ignore: platform() === "win32",
+  ignore: platform() === "win32" || isBun,
   fn: async () => {
     const { uid, gid } = await getUidAndGid();
     const tempFile = await makeTempFile({ prefix: "chown_" });
@@ -78,7 +80,7 @@ Deno.test({
 
 Deno.test({
   name: "chown() handles `null` id arguments",
-  ignore: platform() === "win32",
+  ignore: platform() === "win32" || isBun,
   fn: async () => {
     const { uid, gid } = await getUidAndGid();
     const tempFile = await makeTempFile({ prefix: "chown_" });
@@ -115,7 +117,7 @@ Deno.test({
 
 Deno.test({
   name: "chownSync() changes user and group ids",
-  ignore: platform() === "win32",
+  ignore: platform() === "win32" || isBun,
   fn: async () => {
     const { uid, gid } = await getUidAndGid();
     const tempFile = makeTempFileSync({ prefix: "chownSync_ " });
@@ -130,7 +132,7 @@ Deno.test({
 
 Deno.test({
   name: "chownSync() handles `null` id arguments",
-  ignore: platform() === "win32",
+  ignore: platform() === "win32" || isBun,
   fn: async () => {
     const { uid, gid } = await getUidAndGid();
     const tempFile = makeTempFileSync({ prefix: "chownSync_" });

--- a/fs/unstable_remove_test.ts
+++ b/fs/unstable_remove_test.ts
@@ -9,6 +9,8 @@ import { makeTempDir, makeTempDirSync } from "./unstable_make_temp_dir.ts";
 import { remove, removeSync } from "./unstable_remove.ts";
 import { stat, statSync } from "./unstable_stat.ts";
 
+const isBun = navigator.userAgent.includes("Bun/");
+
 async function checkExists(path: string | URL) {
   try {
     const stated = await stat(path);
@@ -33,19 +35,23 @@ function checkExistsSync(path: string | URL) {
   }
 }
 
-Deno.test("remove() removes an existing and empty directory", async () => {
-  const tempDir = await makeTempDir({ prefix: "remove_async_" });
-  const existedCheck = await stat(tempDir);
-  assert(existedCheck.isDirectory === true);
+Deno.test(
+  "remove() removes an existing and empty directory",
+  { ignore: isBun },
+  async () => {
+    const tempDir = await makeTempDir({ prefix: "remove_async_" });
+    const existedCheck = await stat(tempDir);
+    assert(existedCheck.isDirectory === true);
 
-  try {
-    await remove(tempDir);
-    const existed = await checkExists(tempDir);
-    assert(existed === false);
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-});
+    try {
+      await remove(tempDir);
+      const existed = await checkExists(tempDir);
+      assert(existed === false);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  },
+);
 
 Deno.test("remove() remove a non empty directory", async () => {
   const tempDir1 = await makeTempDir({ prefix: "remove_async_" });
@@ -74,49 +80,61 @@ Deno.test("remove() remove a non empty directory", async () => {
   }
 });
 
-Deno.test("remove() remove a non existed directory", async () => {
-  const tempDir = await makeTempDir({ prefix: "remove_async_" });
-  const nonExistedDir = join(tempDir, "non", "existed", "dir");
+Deno.test(
+  "remove() remove a non existed directory",
+  { ignore: isBun },
+  async () => {
+    const tempDir = await makeTempDir({ prefix: "remove_async_" });
+    const nonExistedDir = join(tempDir, "non", "existed", "dir");
 
-  try {
-    await assertRejects(async () => {
-      await remove(nonExistedDir);
-    }, NotFound);
-    await remove(tempDir);
-    const existed = await checkExists(tempDir);
-    assert(existed === false);
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-});
+    try {
+      await assertRejects(async () => {
+        await remove(nonExistedDir);
+      }, NotFound);
+      await remove(tempDir);
+      const existed = await checkExists(tempDir);
+      assert(existed === false);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  },
+);
 
-Deno.test("remove() remove a non existed directory with option", async () => {
-  const tempDir = await makeTempDir({ prefix: "remove_async_" });
-  const nonExistedDir = join(tempDir, "non", "existed", "dir");
+Deno.test(
+  "remove() remove a non existed directory with option",
+  { ignore: isBun },
+  async () => {
+    const tempDir = await makeTempDir({ prefix: "remove_async_" });
+    const nonExistedDir = join(tempDir, "non", "existed", "dir");
 
-  try {
-    await assertRejects(async () => {
-      await remove(nonExistedDir, { recursive: true });
-    }, NotFound);
-    await remove(tempDir);
-    const existed = await checkExists(tempDir);
-    assert(existed === false);
-  } finally {
-    await rm(tempDir, { recursive: true, force: true });
-  }
-});
+    try {
+      await assertRejects(async () => {
+        await remove(nonExistedDir, { recursive: true });
+      }, NotFound);
+      await remove(tempDir);
+      const existed = await checkExists(tempDir);
+      assert(existed === false);
+    } finally {
+      await rm(tempDir, { recursive: true, force: true });
+    }
+  },
+);
 
-Deno.test("removeSync() remove an existed and empty directory", () => {
-  const tempDir = makeTempDirSync({ prefix: "remove_sync_" });
-  assert(statSync(tempDir).isDirectory === true);
+Deno.test(
+  "removeSync() remove an existed and empty directory",
+  { ignore: isBun },
+  () => {
+    const tempDir = makeTempDirSync({ prefix: "remove_sync_" });
+    assert(statSync(tempDir).isDirectory === true);
 
-  try {
-    removeSync(tempDir);
-    assert(checkExistsSync(tempDir) === false);
-  } finally {
-    rmSync(tempDir, { recursive: true, force: true });
-  }
-});
+    try {
+      removeSync(tempDir);
+      assert(checkExistsSync(tempDir) === false);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  },
+);
 
 Deno.test("removeSync() remove a non empty directory", () => {
   const tempDir1 = makeTempDirSync({ prefix: "remove_sync_" });

--- a/fs/unstable_truncate_test.ts
+++ b/fs/unstable_truncate_test.ts
@@ -8,6 +8,8 @@ import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { join, resolve } from "node:path";
 import { tmpdir } from "node:os";
 
+const isBun = navigator.userAgent.includes("Bun/");
+
 Deno.test("truncate() succeeds in truncating file sizes", async () => {
   const tempDataDir = await mkdtemp(resolve(tmpdir(), "truncate_"));
   const testFile = join(tempDataDir, "truncFile.txt");
@@ -23,16 +25,20 @@ Deno.test("truncate() succeeds in truncating file sizes", async () => {
   await rm(tempDataDir, { recursive: true, force: true });
 });
 
-Deno.test("truncate() truncates the file to zero when 'len' is not provided", async () => {
-  const tempDataDir = await mkdtemp(resolve(tmpdir(), "truncate_"));
-  const testFile = join(tempDataDir, "truncFile.txt");
-  await writeFile(testFile, "Hello, Standard Library");
+Deno.test(
+  "truncate() truncates the file to zero when 'len' is not provided",
+  { ignore: isBun },
+  async () => {
+    const tempDataDir = await mkdtemp(resolve(tmpdir(), "truncate_"));
+    const testFile = join(tempDataDir, "truncFile.txt");
+    await writeFile(testFile, "Hello, Standard Library");
 
-  await truncate(testFile);
-  assertEquals((await readFile(testFile)).length, 0);
+    await truncate(testFile);
+    assertEquals((await readFile(testFile)).length, 0);
 
-  await rm(tempDataDir, { recursive: true, force: true });
-});
+    await rm(tempDataDir, { recursive: true, force: true });
+  },
+);
 
 Deno.test("truncate() rejects with Error when passing a non-regular file", async () => {
   const tempDataDir = await mkdtemp(resolve(tmpdir(), "truncate_"));
@@ -44,11 +50,15 @@ Deno.test("truncate() rejects with Error when passing a non-regular file", async
   await rm(tempDataDir, { recursive: true, force: true });
 });
 
-Deno.test("truncate() rejects with NotFound with a non-existent file", async () => {
-  await assertRejects(async () => {
-    await truncate("non-existent-file.txt");
-  }, NotFound);
-});
+Deno.test(
+  "truncate() rejects with NotFound with a non-existent file",
+  { ignore: isBun },
+  async () => {
+    await assertRejects(async () => {
+      await truncate("non-existent-file.txt");
+    }, NotFound);
+  },
+);
 
 Deno.test("truncateSync() succeeds in truncating file sizes", () => {
   const tempDataDir = mkdtempSync(resolve(tmpdir(), "truncateSync_"));
@@ -65,16 +75,20 @@ Deno.test("truncateSync() succeeds in truncating file sizes", () => {
   rmSync(tempDataDir, { recursive: true, force: true });
 });
 
-Deno.test("truncateSync() truncates the file to zero when 'len' is not provided", () => {
-  const tempDataDir = mkdtempSync(resolve(tmpdir(), "truncateSync_"));
-  const testFile = join(tempDataDir, "truncFile.txt");
-  writeFileSync(testFile, "Hello, Standard Library");
+Deno.test(
+  "truncateSync() truncates the file to zero when 'len' is not provided",
+  { ignore: isBun },
+  () => {
+    const tempDataDir = mkdtempSync(resolve(tmpdir(), "truncateSync_"));
+    const testFile = join(tempDataDir, "truncFile.txt");
+    writeFileSync(testFile, "Hello, Standard Library");
 
-  truncateSync(testFile);
-  assertEquals((readFileSync(testFile)).length, 0);
+    truncateSync(testFile);
+    assertEquals((readFileSync(testFile)).length, 0);
 
-  rmSync(tempDataDir, { recursive: true, force: true });
-});
+    rmSync(tempDataDir, { recursive: true, force: true });
+  },
+);
 
 Deno.test("truncateSync() throws with Error with a non-regular file", () => {
   const tempDataDir = mkdtempSync(resolve(tmpdir(), "truncateSync_"));
@@ -86,8 +100,12 @@ Deno.test("truncateSync() throws with Error with a non-regular file", () => {
   rmSync(tempDataDir, { recursive: true, force: true });
 });
 
-Deno.test("truncateSync() throws with NotFound with a non-existent file", () => {
-  assertThrows(() => {
-    truncateSync("non-existent-file.txt");
-  }, NotFound);
-});
+Deno.test(
+  "truncateSync() throws with NotFound with a non-existent file",
+  { ignore: isBun },
+  () => {
+    assertThrows(() => {
+      truncateSync("non-existent-file.txt");
+    }, NotFound);
+  },
+);


### PR DESCRIPTION
This PR starts running node compatible test cases in Bun in CI. This makes it easier to accept PRs like https://github.com/denoland/std/pull/6630 which says the change improves the bun compatibility.

In JSR pages, we already mark some of std packages compatible with Bun. So I believe this addition is reasonable