### PR TITLE
fix(bytes): allow to concat() readonly arrays of bytes arrays

### DIFF
--- a/bytes/concat.ts
+++ b/bytes/concat.ts
@@ -21,7 +21,7 @@ export type { Uint8Array_ };
  * assertEquals(concat([a, b]), new Uint8Array([0, 1, 2, 3, 4, 5]));
  * ```
  */
-export function concat(buffers: Uint8Array[]): Uint8Array_ {
+export function concat(buffers: readonly Uint8Array[]): Uint8Array_ {
   let length = 0;
   for (const buffer of buffers) {
     length += buffer.length;

--- a/bytes/concat_test.ts
+++ b/bytes/concat_test.ts
@@ -36,7 +36,7 @@ Deno.test("concat() handles multiple Uint8Array", () => {
 });
 
 Deno.test("concat() handles an array of Uint8Array", () => {
-  const a = [
+  const a: Uint8Array[] = [
     new Uint8Array([0, 1, 2, 3]),
     new Uint8Array([4, 5, 6]),
     new Uint8Array([7, 8, 9]),

--- a/bytes/concat_test.ts
+++ b/bytes/concat_test.ts
@@ -36,7 +36,7 @@ Deno.test("concat() handles multiple Uint8Array", () => {
 });
 
 Deno.test("concat() handles an array of Uint8Array", () => {
-  const a: Uint8Array[] = [
+  const a: readonly Uint8Array[] = [
     new Uint8Array([0, 1, 2, 3]),
     new Uint8Array([4, 5, 6]),
     new Uint8Array([7, 8, 9]),


### PR DESCRIPTION
`concat` currently only allows mutable arrays whereas it doesn't mutate its input.

This PR expands the signature to read-only arrays.

Doesn't refer to any open issue.