### PR TITLE
ci: use correct Bun version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: ${{ matrix.node }}
+          bun-version: ${{ matrix.bun }}
 
       - name: Run tests
         run: deno task test:bun


### PR DESCRIPTION
This is a minor change. This PR changes `matrix.node` to `matrix.bun` to prevent the use of unintended versions of Bun in the future.

https://github.com/denoland/std/blob/6a00d6cd34ca70b3a38932e313151a80531c5d2b/.github/workflows/ci.yml#L105-L126