### PR TITLE
chore: remove `no-top-level-arrow-syntax` lint rule

### DIFF
--- a/_tools/lint_plugin.ts
+++ b/_tools/lint_plugin.ts
@@ -58,30 +58,6 @@ export default {
         };
       },
     },
-    // https://docs.deno.com/runtime/contributing/style_guide/#top-level-functions-should-not-use-arrow-syntax
-    "no-top-level-arrow-syntax": {
-      create(context) {
-        return {
-          ArrowFunctionExpression(node) {
-            if (
-              node.parent.type === "VariableDeclarator" &&
-              node.parent.parent.type === "VariableDeclaration" &&
-              (node.parent.parent.parent.type === "Program" ||
-                node.parent.parent.parent.type === "ExportNamedDeclaration")
-            ) {
-              // TODO(iuioiua): add fix
-              context.report({
-                node,
-                range: node.range,
-                message: "Top-level functions should not use arrow syntax",
-                hint:
-                  "Use function declaration instead of arrow function. E.g. Use `function foo() {}` instead of `const foo = () => {}`.",
-              });
-            }
-          },
-        };
-      },
-    },
     // https://docs.deno.com/runtime/contributing/style_guide/#do-not-depend-on-external-code.
     "no-external-code": {
       create(context) {

--- a/_tools/lint_plugin_test.ts
+++ b/_tools/lint_plugin_test.ts
@@ -56,47 +56,6 @@ class MyClass {
   );
 });
 
-Deno.test("deno-style-guide/no-top-level-arrow-syntax", {
-  ignore: !Deno.version.deno.startsWith("2"),
-}, () => {
-  // Bad
-  assertLintPluginDiagnostics(
-    `
-const foo = () => "bar";
-export const bar = () => "foo";
-    `,
-    [
-      {
-        id: "deno-style-guide/no-top-level-arrow-syntax",
-        range: [13, 24],
-        fix: [],
-        message: "Top-level functions should not use arrow syntax",
-        hint:
-          "Use function declaration instead of arrow function. E.g. Use `function foo() {}` instead of `const foo = () => {}`.",
-      },
-      {
-        id: "deno-style-guide/no-top-level-arrow-syntax",
-        range: [45, 56],
-        fix: [],
-        message: "Top-level functions should not use arrow syntax",
-        hint:
-          "Use function declaration instead of arrow function. E.g. Use `function foo() {}` instead of `const foo = () => {}`.",
-      },
-    ],
-  );
-
-  // Good
-  assertLintPluginDiagnostics(
-    `
-function foo() {
-  const bar = () => "baz";
-
-  return "bar";
-}`,
-    [],
-  );
-});
-
 Deno.test("deno-style-guide/no-external-code", {
   ignore: !Deno.version.deno.startsWith("2"),
 }, () => {


### PR DESCRIPTION
This rule no longer applies. See https://github.com/denoland/docs/pull/1685