### PR TITLE
fix(dotenv): prevent prototype pollution during parsing

### DIFF
--- a/dotenv/parse.ts
+++ b/dotenv/parse.ts
@@ -74,7 +74,7 @@ function expand(str: string, variablesMap: { [key: string]: string }): string {
  * @returns The parsed object.
  */
 export function parse(text: string): Record<string, string> {
-  const env: Record<string, string> = {};
+  const env: Record<string, string> = Object.create(null);
 
   let match;
   const keysForExpandCheck = [];


### PR DESCRIPTION
If you did 

```
toString=FOO
```

that would overwrite `Object.prototype.toString`.
