### PR TITLE
refactor(datetime): simplify month difference

### DIFF
--- a/datetime/difference.ts
+++ b/datetime/difference.ts
@@ -133,15 +133,15 @@ export function difference(
         differences.weeks = Math.floor(differenceInMs / WEEK);
         break;
       case "months":
-        if (months == null) months = calculateMonthsDifference(from, to);
+        if (months === null) months = calculateMonthsDifference(from, to);
         differences.months = months;
         break;
       case "quarters":
-        if (months == null) months = calculateMonthsDifference(from, to);
+        if (months === null) months = calculateMonthsDifference(from, to);
         differences.quarters = Math.floor(months / 3);
         break;
       case "years":
-        if (months == null) months = calculateMonthsDifference(from, to);
+        if (months === null) months = calculateMonthsDifference(from, to);
         differences.years = Math.floor(months / 12);
         break;
     }

--- a/datetime/difference.ts
+++ b/datetime/difference.ts
@@ -110,6 +110,8 @@ export function difference(
 
   const differences: DifferenceFormat = {};
 
+  let months = null;
+
   for (const uniqueUnit of uniqueUnits) {
     switch (uniqueUnit) {
       case "milliseconds":
@@ -131,19 +133,16 @@ export function difference(
         differences.weeks = Math.floor(differenceInMs / WEEK);
         break;
       case "months":
-        differences.months = calculateMonthsDifference(from, to);
+        if (months == null) months = calculateMonthsDifference(from, to);
+        differences.months = months;
         break;
       case "quarters":
-        differences.quarters = Math.floor(
-          (differences.months !== undefined && differences.months / 3) ||
-            calculateMonthsDifference(from, to) / 3,
-        );
+        if (months == null) months = calculateMonthsDifference(from, to);
+        differences.quarters = Math.floor(months / 3);
         break;
       case "years":
-        differences.years = Math.floor(
-          (differences.months !== undefined && differences.months / 12) ||
-            calculateMonthsDifference(from, to) / 12,
-        );
+        if (months == null) months = calculateMonthsDifference(from, to);
+        differences.years = Math.floor(months / 12);
         break;
     }
   }


### PR DESCRIPTION
This makes the code easier to read and also caches the result of `calculateMonthsDifference()` when either `quarters` or `years` is calculated first.