### PR TITLE
chore: enable dependency caching between GA workflow runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: ${{ matrix.deno }}
+          cache: true
 
       - name: Run tests
         run: |
@@ -93,6 +94,8 @@ jobs:
 
       - name: Set up Deno
         uses: denoland/setup-deno@v2
+        with:
+          cache: true
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -119,6 +122,8 @@ jobs:
 
       - name: Set up Deno
         uses: denoland/setup-deno@v2
+        with:
+          cache: true
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -147,6 +152,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: canary
+          cache: true
 
       - name: Format
         run: deno fmt --check
@@ -188,6 +194,8 @@ jobs:
       - name: Set up Deno
         uses: denoland/setup-deno@v2
         if: success() && steps.source.outputs.modified == 'true'
+        with:
+          cache: true
 
       - name: Set up Rust
         uses: hecrj/setup-rust-action@v2

--- a/.github/workflows/version_bump.yml
+++ b/.github/workflows/version_bump.yml
@@ -14,6 +14,8 @@ jobs:
 
       - name: Set up Deno
         uses: denoland/setup-deno@v2
+        with:
+          cache: true
 
       - name: Run version bump
         run: |

--- a/.github/workflows/workspace_publish.yml
+++ b/.github/workflows/workspace_publish.yml
@@ -22,6 +22,7 @@ jobs:
         uses: denoland/setup-deno@v2
         with:
           deno-version: canary
+          cache: true
 
       - name: Format
         run: deno fmt --check


### PR DESCRIPTION
It's possible that caching may not be the best idea for some of these cases, but I think it's worth just trying and seeing.