### PR TITLE
chore: change badge color

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,19 +32,19 @@ package versions <1.0.0 follow
 > Previously, this repo hosted the badge SVG file. Now, the badge is retrieved
 > directly from [Shields.io](https://shields.io/).
 
-[![Built with the Deno Standard Library](https://img.shields.io/badge/Built_with_std-blue?logo=deno)](https://jsr.io/@std)
+[![Built with the Deno Standard Library](https://img.shields.io/badge/Built_with_std-black?logo=deno)](https://jsr.io/@std)
 
 ```html
 <a href="https://jsr.io/@std">
   <img
     width="135"
     height="20"
-    src="https://img.shields.io/badge/Built_with_std-blue?logo=deno"
+    src="https://img.shields.io/badge/Built_with_std-black?logo=deno"
     alt="Built with the Deno Standard Library"
   />
 </a>
 ```
 
 ```md
-[![Built with the Deno Standard Library](https://img.shields.io/badge/Built_with_std-blue?logo=deno)](https://jsr.io/@std)
+[![Built with the Deno Standard Library](https://img.shields.io/badge/Built_with_std-black?logo=deno)](https://jsr.io/@std)
 ```


### PR DESCRIPTION
Looks cooler and suits better, given the Deno logo is now green.