### PR TITLE
refactor(cli/unstable): print initial `ProgressBar`

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -295,9 +295,17 @@ export class ProgressBar {
    */
   async stop(): Promise<void> {
     clearInterval(this.#id);
-    await this.#writer.write(this.#clear ? "\r\u001b[K" : "\n")
-      .then(() => this.#writer.close())
-      .then(() => this.#pipePromise)
-      .catch(() => {});
+    try {
+      if (this.#clear) {
+        await this.#writer.write("\r\u001b[K");
+      } else {
+        await this.#print();
+        await this.#writer.write("\n");
+      }
+      await this.#writer.close();
+      await this.#pipePromise;
+    } catch {
+      // ignore
+    }
   }
 }

--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -243,10 +243,12 @@ export class ProgressBar {
       .pipeTo(writable, { preventClose: this.#keepOpen })
       .catch(() => clearInterval(this.#id));
     this.#writer = stream.writable.getWriter();
-    this.#id = setInterval(() => this.#print(), 1000);
     this.#startTime = performance.now();
     this.#lastTime = this.#startTime;
     this.#lastValue = this.value;
+
+    this.#id = setInterval(() => this.#print(), 1000);
+    this.#print();
   }
 
   async #print(): Promise<void> {
@@ -293,8 +295,7 @@ export class ProgressBar {
    */
   async stop(): Promise<void> {
     clearInterval(this.#id);
-    await this.#print()
-      .then(() => this.#writer.write(this.#clear ? "\r\u001b[K" : "\n"))
+    await this.#writer.write(this.#clear ? "\r\u001b[K" : "\n")
       .then(() => this.#writer.close())
       .then(() => this.#pipePromise)
       .catch(() => {});


### PR DESCRIPTION
This PR adds a `print()` call when the progress bar is initialized (`setInterval()` only starts printing after the delay) and removes the `print()` call when it is stopped.