### PR TITLE
refactor(cli/unstable): remove brackets from strings

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -6,18 +6,18 @@
 export interface ProgressBarFormatter {
   /**
    * A function that returns a formatted version of the duration.
-   * `[mm:ss]`
+   * `mm:ss`
    */
   styledTime: () => string;
   /**
    * A function that returns a formatted version of the data received.
-   * `[0.40/97.66 KiB]`
+   * `0.40/97.66 KiB`
    * @param fractions The number of decimal places the values should have.
    */
   styledData: (fractions?: number) => string;
   /**
    * The progress bar string.
-   * Default Style: `[###-------]`
+   * Default Style: `###-------`
    */
   progressBar: string;
   /**
@@ -223,7 +223,7 @@ export class ProgressBar {
       fillChar = "#",
       emptyChar = "-",
       clear = false,
-      fmt = (x) => `${x.styledTime()} ${x.progressBar} ${x.styledData()} `,
+      fmt = (x) => `[${x.styledTime()}] [${x.progressBar}] [${x.styledData()}]`,
       keepOpen = true,
     } = options;
     this.value = value;
@@ -260,14 +260,14 @@ export class ProgressBar {
       styledTime() {
         const minutes = (this.time / 1000 / 60 | 0).toString().padStart(2, "0");
         const seconds = (this.time / 1000 % 60 | 0).toString().padStart(2, "0");
-        return `[${minutes}:${seconds}]`;
+        return `${minutes}:${seconds}`;
       },
       styledData: (fractions = 2): string => {
         const currentValue = (this.value / this.#rate).toFixed(fractions);
         const maxValue = (this.max / this.#rate).toFixed(fractions);
-        return `[${currentValue}/${maxValue} ${this.#unit}]`;
+        return `${currentValue}/${maxValue} ${this.#unit}`;
       },
-      progressBar: `[${fillChars}${emptyChars}]`,
+      progressBar: `${fillChars}${emptyChars}`,
       time: currentTime - this.#startTime,
       previousTime: this.#lastTime - this.#startTime,
       value: this.value,

--- a/cli/unstable_progress_bar_test.ts
+++ b/cli/unstable_progress_bar_test.ts
@@ -121,7 +121,7 @@ Deno.test("ProgressBar() uses correct unit type", async () => {
 
     const decoder = new TextDecoder();
     for await (const buffer of readable) {
-      assertEquals(decoder.decode(buffer.subarray(-5, -2)), unit);
+      assertEquals(decoder.decode(buffer.subarray(-4, -1)), unit);
       break;
     }
     bar.stop();


### PR DESCRIPTION
This PR removes the default addition of the `[]` brackets from formatter elements. This makes it easier to use a custom format without string slicing.