### PR TITLE
fix(cli/unstable): clamp `ratio`

### DIFF
--- a/cli/unstable_progress_bar.ts
+++ b/cli/unstable_progress_bar.ts
@@ -121,6 +121,10 @@ function defaultFormatter(x: ProgressBarFormatter) {
   return `[${x.styledTime}] [${x.progressBar}] [${x.styledData()}]`;
 }
 
+function clamp(value: number, min: number, max: number) {
+  return Math.min(Math.max(value, min), max);
+}
+
 /**
  * `ProgressBar` is a customisable class that reports updates to a
  * {@link WritableStream} on a 1s interval. Progress is communicated by using
@@ -265,7 +269,8 @@ export class ProgressBar {
   #createFormatterObject() {
     const time = performance.now() - this.#startTime;
 
-    const size = this.value / this.max * this.#barLength | 0;
+    const ratio = clamp(this.value / this.max, 0, 1);
+    const size = Math.trunc(ratio * this.#barLength);
     const fillChars = this.#fillChar.repeat(size);
     const emptyChars = this.#emptyChar.repeat(this.#barLength - size);
 

--- a/cli/unstable_progress_bar_test.ts
+++ b/cli/unstable_progress_bar_test.ts
@@ -141,6 +141,7 @@ Deno.test("ProgressBar() does not leak resources when immediately stopped", asyn
 });
 
 Deno.test("ProgressBar() handles value < 0", async () => {
+  using _fakeTime = new FakeTime();
   const { readable, writable } = new TransformStream();
   const bar = new ProgressBar({ writable, max: 2 ** 10, value: -1 });
   bar.stop().then(() => writable.close());
@@ -159,6 +160,7 @@ Deno.test("ProgressBar() handles value < 0", async () => {
 });
 
 Deno.test("ProgressBar() handles max < 0", async () => {
+  using _fakeTime = new FakeTime();
   const { readable, writable } = new TransformStream();
   const bar = new ProgressBar({ writable, max: -1 });
   bar.stop().then(() => writable.close());
@@ -177,6 +179,7 @@ Deno.test("ProgressBar() handles max < 0", async () => {
 });
 
 Deno.test("ProgressBar() handles value > max", async () => {
+  using _fakeTime = new FakeTime();
   const { readable, writable } = new TransformStream();
   const bar = new ProgressBar({ writable, max: 2 ** 10, value: 2 ** 10 + 1 });
   bar.stop().then(() => writable.close());


### PR DESCRIPTION
This handles some edge cases (`value > max`, `value < 0`, `max < 0`) which threw `.repeat(negativeNumber)` errors.