### PR TITLE
chore(text/unstable): use locale-agnostic Intl.Segmenter

### DIFF
--- a/text/unstable_slugify.ts
+++ b/text/unstable_slugify.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 // This module is browser compatible.
 
-const wordSegmenter = new Intl.Segmenter("en-US", { granularity: "word" });
+const wordSegmenter = new Intl.Segmenter("und", { granularity: "word" });
 
 /** Options for {@linkcode slugify}. */
 export type SlugifyOptions = {


### PR DESCRIPTION
In practice I don't think this can ever make a difference as there are no specific word segmentation rules for `en-US`, but it's more semantically correct.

https://unicode.org/reports/tr35/tr35.html#unknown-or-invalid-identifiers