### PR TITLE
fix(toml): leading zeroes in float

### DIFF
--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -654,7 +654,7 @@ export function integer(scanner: Scanner): ParseResult<number | string> {
 }
 
 const FLOAT_REGEXP =
-  /[+-]?[0-9]+(?:_[0-9]+)*(?:\.[0-9]+(?:_[0-9]+)*)?(?:e[+-]?[0-9]+(?:_[0-9]+)*)?\b/yi;
+  /[+-]?(?:0|[1-9][0-9]*(?:_[0-9]+)*)(?:\.[0-9]+(?:_[0-9]+)*)?(?:e[+-]?[0-9]+(?:_[0-9]+)*)?\b/yi;
 export function float(scanner: Scanner): ParseResult<number> {
   scanner.skipWhitespaces();
   const match = scanner.match(FLOAT_REGEXP)?.[0];

--- a/toml/_parser_test.ts
+++ b/toml/_parser_test.ts
@@ -341,6 +341,9 @@ Deno.test({
     assertEquals(parse("-2E-2"), -2E-2);
     assertEquals(parse("6.626e-34"), 6.626e-34);
     assertEquals(parse("224_617.445_991_228"), 224_617.445_991_228);
+    assertEquals(parse("0.0"), 0.0);
+    assertEquals(parse("+0.0"), 0.0);
+    assertEquals(parse("-0.0"), 0.0);
     assertThrows(() => parse(""));
     assertThrows(() => parse("X"));
     assertThrows(() => parse("e_+-"));
@@ -353,6 +356,9 @@ Deno.test({
     assertThrows(() => parse("1_e06"));
     assertThrows(() => parse("1e_06"));
     assertThrows(() => parse("1e06_"));
+    assertThrows(() => parse("03.14"));
+    assertThrows(() => parse("+03.14"));
+    assertThrows(() => parse("-03.14"));
   },
 });
 


### PR DESCRIPTION
Refs #6663 

<details>
<summary>Should resolve these cases in toml-test:</summary>
<br>
<pre>
FAIL invalid/float/leading-zero
     Expected an error, but no error was reported.

     input sent to parser-cmd (PID 31292):
       leading-zero = 03.14

     output from parser-cmd (PID 31292) (stdout):
       {
         "leading-zero": {"type": "float", "value": "3.14"}
       }

     want:
       Exit code 1

FAIL invalid/float/leading-zero-neg
     Expected an error, but no error was reported.

     input sent to parser-cmd (PID 31284):
       leading-zero-neg = -03.14

     output from parser-cmd (PID 31284) (stdout):
       {
         "leading-zero-neg": {"type": "float", "value": "-3.14"}
       }

     want:
       Exit code 1

FAIL invalid/float/leading-zero-plus
     Expected an error, but no error was reported.

     input sent to parser-cmd (PID 31286):
       leading-zero-plus = +03.14

     output from parser-cmd (PID 31286) (stdout):
       {
         "leading-zero-plus": {"type": "float", "value": "3.14"}
       }

     want:
       Exit code 1
</pre>
</details>