### PR TITLE
fix(toml): february edge cases in datetime

### DIFF
--- a/toml/_parser.ts
+++ b/toml/_parser.ts
@@ -673,6 +673,19 @@ export function dateTime(scanner: Scanner): ParseResult<Date> {
   const match = scanner.match(DATE_TIME_REGEXP)?.[0];
   if (!match) return failure();
   scanner.next(match.length);
+  //special case if month is February
+  if(match.substring(5,7) == "02") {
+    const days = parseInt(match.substring(8,10));
+    const year = parseInt(match.substring(0,4));
+    //more than 29 days
+    if(days > 29) {
+      throw new SyntaxError(`Invalid date string "${match}"`);
+    }
+    //more than 28 days and is not leap year
+    if(days > 28 && (year % 4 != 0 || year % 100 == 0 && year % 400 != 0)) {
+      throw new SyntaxError(`Invalid date string "${match}"`);
+    }
+  }
   const date = new Date(match.trim());
   // invalid date
   if (isNaN(date.getTime())) {

--- a/toml/_parser_test.ts
+++ b/toml/_parser_test.ts
@@ -395,6 +395,10 @@ Deno.test({
     assertThrows(() => parse(""));
     assertThrows(() => parse("X"));
     assertThrows(() => parse("0000-00-00"));
+    assertThrows(() => parse("2100-02-29"));
+    assertThrows(() => parse("1988-02-30"));
+    assertThrows(() => parse("1988-02-30T15:15:15Z"));
+    assertThrows(() => parse("2100-02-29T15:15:15Z"));
   },
 });
 


### PR DESCRIPTION
Refs #6663 

Add checks to ensure that February 30th is not accepted as a valid date, and that February 29th is only accepted as valid date if it is a leap year

<details>
<summary>Resolves these toml-test cases specifically</summary>
<br>
<pre>
FAIL invalid/datetime/feb-29
     Expected an error, but no error was reported.

     input sent to parser-cmd (PID 29560):
       "not a leap year" = 2100-02-29T15:15:15Z

     output from parser-cmd (PID 29560) (stdout):
       {
         "not a leap year": {"type": "datetime", "value": "2100-03-01T15:15:15.000Z"}
       }

     want:
       Exit code 1

FAIL invalid/local-date/feb-29
     Expected an error, but no error was reported.

     input sent to parser-cmd (PID 2372):
       "not a leap year" = 2100-02-29

     output from parser-cmd (PID 2372) (stdout):
       {
         "not a leap year": {"type": "datetime", "value": "2100-03-01T00:00:00.000Z"}
       }

     want:
       Exit code 1

FAIL invalid/local-date/feb-30
     Expected an error, but no error was reported.

     input sent to parser-cmd (PID 2373):
       "only 28 or 29 days in february" = 1988-02-30

     output from parser-cmd (PID 2373) (stdout):
       {
         "only 28 or 29 days in february": {"type": "datetime", "value": "1988-03-01T00:00:00.000Z"}
       }

     want:
       Exit code 1

FAIL invalid/local-datetime/feb-29
     Expected an error, but no error was reported.

     input sent to parser-cmd (PID 2614):
       "not a leap year" = 2100-02-29T15:15:15

     output from parser-cmd (PID 2614) (stdout):
       {
         "not a leap year": {"type": "datetime", "value": "2100-03-01T15:15:15.000Z"}
       }

     want:
       Exit code 1

FAIL invalid/local-datetime/feb-30
     Expected an error, but no error was reported.

     input sent to parser-cmd (PID 2618):
       "only 28 or 29 days in february" = 1988-02-30T15:15:15

     output from parser-cmd (PID 2618) (stdout):
       {
         "only 28 or 29 days in february": {"type": "datetime", "value": "1988-03-01T15:15:15.000Z"}
       }

     want:
       Exit code 1
</pre>
</details>