### PR TITLE
fix(cli/unstable): `Spinner` print on `start()`

### DIFF
--- a/cli/unstable_spinner.ts
+++ b/cli/unstable_spinner.ts
@@ -239,6 +239,7 @@ export class Spinner {
     };
 
     this.#intervalId = setInterval(updateFrame, this.#interval);
+    updateFrame();
   }
 
   /**

--- a/cli/unstable_spinner_test.ts
+++ b/cli/unstable_spinner_test.ts
@@ -134,6 +134,7 @@ Deno.test("Spinner constructor accepts interval", async () => {
       "\r\x1b[K⠋\x1b[0m ",
       "\r\x1b[K⠙\x1b[0m ",
       "\r\x1b[K⠹\x1b[0m ",
+      "\r\x1b[K⠸\x1b[0m ",
       "\r\x1b[K",
     ];
 


### PR DESCRIPTION
This PR adds a `updateFrame()` call when `start()` is called. This fixes an initial empty console mostly notable when the interval option was set as a big number.