### PR TITLE
refactor(streams): throw `RangeError` within `Buffer` methods

### DIFF
--- a/streams/buffer.ts
+++ b/streams/buffer.ts
@@ -322,7 +322,7 @@ export class Buffer {
       return;
     }
     if (n < 0 || n > this.length) {
-      throw new Error(
+      throw new RangeError(
         `Buffer truncation value "${n}" is not between 0 and ${this.length}`,
       );
     }
@@ -383,7 +383,7 @@ export class Buffer {
       // don't spend all our time copying.
       copy(this.#buf.subarray(this.#off), this.#buf);
     } else if (c + n > MAX_SIZE) {
-      throw new Error(
+      throw new RangeError(
         `The buffer cannot grow beyond the maximum size of ${MAX_SIZE}`,
       );
     } else {
@@ -424,7 +424,7 @@ export class Buffer {
    */
   grow(n: number) {
     if (n < 0) {
-      throw new Error(
+      throw new RangeError(
         `Cannot grow buffer as growth must be positive: received ${n}`,
       );
     }

--- a/streams/buffer_test.ts
+++ b/streams/buffer_test.ts
@@ -58,7 +58,7 @@ Deno.test("Buffer.truncate(n) throws if n is negative", () => {
     () => {
       buf.truncate(-1);
     },
-    Error,
+    RangeError,
     'Buffer truncation value "-1" is not between 0 and 0',
   );
 });
@@ -69,7 +69,7 @@ Deno.test("Buffer.truncate(n) throws if n is greater than the length of the buff
     () => {
       buf.truncate(1);
     },
-    Error,
+    RangeError,
     'Buffer truncation value "1" is not between 0 and 0',
   );
 });
@@ -115,7 +115,7 @@ Deno.test("Buffer.grow(n) throws an error if n is a negative value", () => {
     () => {
       buf.grow(-1);
     },
-    Error,
+    RangeError,
     "Cannot grow buffer as growth must be positive: received -1",
   );
 });
@@ -126,7 +126,7 @@ Deno.test("Buffer.grow(n) throws if the total of byte size exceeds 2 ** 32 - 2",
     () => {
       buf.grow(2 ** 32);
     },
-    Error,
+    RangeError,
     "The buffer cannot grow beyond the maximum size of",
   );
 });


### PR DESCRIPTION
This error type is more fitting for the given error messages. This change is non-breaking as `RangeError` extends `Error`.