### PR TITLE
feat(collections/unstable): add zip truncate option to allow zipping until end of longest input

### DIFF
--- a/collections/deno.json
+++ b/collections/deno.json
@@ -48,6 +48,7 @@
     "./union": "./union.ts",
     "./unstable-binary-search": "./unstable_binary_search.ts",
     "./unstable-cycle": "./unstable_cycle.ts",
+    "./unstable-zip": "./unstable_zip.ts",
     "./unzip": "./unzip.ts",
     "./without-all": "./without_all.ts",
     "./zip": "./zip.ts"

--- a/collections/unstable_zip.ts
+++ b/collections/unstable_zip.ts
@@ -1,0 +1,107 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+// This module is browser compatible.
+
+/** Options for zipping arrays */
+export type ZipOptions = {
+  /**
+   * Determines how to handle arrays of different lengths.
+   * - `'shortest'`: stops zipping when the shortest array ends.
+   * - `'longest'`: continues zipping until the longest array ends, filling missing values with `undefined`.
+   * @default {'shortest'}
+   */
+  truncate?: "shortest" | "longest";
+};
+
+/**
+ * Builds N-tuples of elements from the given N arrays with matching indices,
+ * stopping when the smallest array's end is reached.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @typeParam T the type of the tuples produced by this function.
+ * @typeParam O the type of the options passed.
+ *
+ * @param options Options for zipping arrays.
+ * @param arrays The arrays to zip.
+ *
+ * @returns A new array containing N-tuples of elements from the given arrays.
+ *
+ * @example Usage with options
+ * ```ts
+ * import { zip } from "@std/collections/unstable-zip";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const numbers = [1, 2, 3];
+ * const letters = ["a", "b", "c", "d"];
+ *
+ * assertEquals(
+ *   zip({ truncate: "shortest" }, numbers, letters),
+ *   [[1, "a"], [2, "b"], [3, "c"]],
+ * );
+ * assertEquals(
+ *   zip({ truncate: "longest" }, numbers, letters),
+ *   [[1, "a"], [2, "b"], [3, "c"], [undefined, "d"]],
+ * );
+ * ```
+ */
+export function zip<T extends unknown[], O extends ZipOptions>(
+  options: O,
+  ...arrays: { [K in keyof T]: ReadonlyArray<T[K]> }
+): {
+  [K in keyof T]: O extends { truncate: "longest" } ? T[K] | undefined : T[K];
+}[];
+/**
+ * Builds N-tuples of elements from the given N arrays with matching indices,
+ * stopping when the smallest array's end is reached.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @typeParam T the type of the tuples produced by this function.
+ *
+ * @param arrays The arrays to zip.
+ *
+ * @returns A new array containing N-tuples of elements from the given arrays.
+ *
+ * @example Basic usage
+ * ```ts
+ * import { zip } from "@std/collections/unstable-zip";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const numbers = [1, 2, 3, 4];
+ * const letters = ["a", "b", "c", "d"];
+ * const pairs = zip(numbers, letters);
+ *
+ * assertEquals(
+ *   pairs,
+ *   [
+ *     [1, "a"],
+ *     [2, "b"],
+ *     [3, "c"],
+ *     [4, "d"],
+ *   ],
+ * );
+ * ```
+ */
+export function zip<T extends unknown[]>(
+  ...arrays: { [K in keyof T]: ReadonlyArray<T[K]> }
+): T[];
+export function zip(...args: unknown[]): unknown[] {
+  const [options, arrays] = args.length === 0 || Array.isArray(args[0])
+    ? [{}, args as unknown[][]]
+    : [args[0] as ZipOptions, args.slice(1) as unknown[][]];
+
+  if (arrays.length === 0) return [];
+
+  const minLength = Math[options.truncate === "longest" ? "max" : "min"](
+    ...arrays.map((x) => x.length),
+  );
+
+  const result = new Array(minLength);
+
+  for (let i = 0; i < minLength; i += 1) {
+    const arr = arrays.map((it) => it[i]);
+    result[i] = arr;
+  }
+
+  return result;
+}

--- a/collections/unstable_zip_test.ts
+++ b/collections/unstable_zip_test.ts
@@ -1,0 +1,207 @@
+// Copyright 2018-2025 the Deno authors. MIT license.
+
+import { assertEquals } from "@std/assert";
+import { zip, type ZipOptions } from "./unstable_zip.ts";
+import { assertType, type IsExact } from "@std/testing/types";
+
+const EMPTY_OPTIONS: ZipOptions = {};
+
+Deno.test({
+  name: "zip() handles zero arrays",
+  fn() {
+    assertEquals(zip([]), []);
+    assertEquals(zip(EMPTY_OPTIONS, []), []);
+  },
+});
+
+Deno.test({
+  name: "zip() handles one array",
+  fn() {
+    assertEquals(zip([1, 2, 3]), [[1], [2], [3]]);
+    assertEquals(zip(EMPTY_OPTIONS, [1, 2, 3]), [[1], [2], [3]]);
+  },
+});
+
+function zipTest<T, U>(
+  input: [ReadonlyArray<T>, ReadonlyArray<U>],
+  expected: Array<[T, U]>,
+  message?: string,
+) {
+  const actual = zip(...input);
+  assertEquals(actual, expected, message);
+}
+
+function zip3Test<T, U, V>(
+  input: [Array<T>, Array<U>, Array<V>],
+  expected: Array<[T, U, V]>,
+  message?: string,
+) {
+  const actual = zip(...input);
+  assertEquals(actual, expected, message);
+}
+
+Deno.test({
+  name: "zip() handles three arrays",
+  fn() {
+    zip3Test([
+      [1, 2, 3],
+      [4, 5, 6],
+      [7, 8, 9],
+    ], [[1, 4, 7], [2, 5, 8], [3, 6, 9]]);
+  },
+});
+
+Deno.test({
+  name: "zip() handles three arrays when the first is the shortest",
+  fn() {
+    zip3Test([
+      [1, 2],
+      [4, 5, 6],
+      [7, 8, 9],
+    ], [[1, 4, 7], [2, 5, 8]]);
+  },
+});
+
+Deno.test({
+  name: "zip() handles no mutation",
+  fn() {
+    const arrayA = [1, 4, 5];
+    const arrayB = ["foo", "bar"];
+    zip(arrayA, arrayB);
+
+    assertEquals(arrayA, [1, 4, 5]);
+    assertEquals(arrayB, ["foo", "bar"]);
+  },
+});
+
+Deno.test({
+  name: "zip() handles empty input",
+  fn() {
+    zipTest(
+      [[], []],
+      [],
+    );
+    zipTest(
+      [[1, 2, 3], []],
+      [],
+    );
+    zipTest(
+      [[], [{}, []]],
+      [],
+    );
+    assertEquals(zip(), []);
+  },
+});
+
+Deno.test({
+  name: "zip() handles same length",
+  fn() {
+    zipTest(
+      [
+        [1, 4, 5],
+        ["foo", "bar", "lorem"],
+      ],
+      [
+        [1, "foo"],
+        [4, "bar"],
+        [5, "lorem"],
+      ],
+    );
+    zipTest(
+      [
+        [2.2, false],
+        ["test", true],
+      ],
+      [
+        [2.2, "test"],
+        [false, true],
+      ],
+    );
+  },
+});
+
+Deno.test({
+  name: "zip() handles first shorter",
+  fn() {
+    zipTest(
+      [
+        [1],
+        ["foo", "bar", "lorem"],
+      ],
+      [[1, "foo"]],
+    );
+    zipTest(
+      [
+        [2.2, false],
+        ["test", true, {}],
+      ],
+      [
+        [2.2, "test"],
+        [false, true],
+      ],
+    );
+  },
+});
+
+Deno.test({
+  name: "zip() handles second shorter",
+  fn() {
+    zipTest(
+      [
+        [1, 4, 5],
+        ["foo"],
+      ],
+      [[1, "foo"]],
+    );
+    zipTest(
+      [
+        [2.2, false, "test"],
+        ["test", true],
+      ],
+      [
+        [2.2, "test"],
+        [false, true],
+      ],
+    );
+  },
+});
+
+Deno.test("zip() handles truncate option", async (t) => {
+  const arrays: [number[], string[], bigint[]] = [[1, 2, 3], [
+    "a",
+    "b",
+    "c",
+    "d",
+  ], [88n]];
+
+  await t.step('truncate: "shortest" (default)', () => {
+    const explicit = zip({ truncate: "shortest" }, ...arrays);
+    const implicit = zip(...arrays);
+
+    assertEquals(explicit, [[1, "a", 88n]]);
+    assertEquals(explicit, implicit);
+
+    assertType<IsExact<typeof explicit, [number, string, bigint][]>>(true);
+    assertType<IsExact<typeof implicit, [number, string, bigint][]>>(true);
+  });
+
+  await t.step('truncate: "longest"', () => {
+    const zipped = zip({ truncate: "longest" }, ...arrays);
+    assertEquals(
+      zipped,
+      [
+        [1, "a", 88n],
+        [2, "b", undefined],
+        [3, "c", undefined],
+        [undefined, "d", undefined],
+      ],
+    );
+
+    assertType<
+      IsExact<
+        typeof zipped,
+        [number | undefined, string | undefined, bigint | undefined][]
+      >
+    >(true);
+  });
+});


### PR DESCRIPTION
Closes https://github.com/denoland/std/issues/6732

<details>
<summary>Diffs stable vs. unstable</summary>

```diff
diff --git a/collections/zip.ts b/collections/unstable_zip.ts
index 61677b77..7bb6ea25 100644
--- a/collections/zip.ts
+++ b/collections/unstable_zip.ts
@@ -1,12 +1,61 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 // This module is browser compatible.
 
-import { minOf } from "./min_of.ts";
+/** Options for zipping arrays */
+export type ZipOptions = {
+  /**
+   * Determines how to handle arrays of different lengths.
+   * - `'shortest'`: stops zipping when the shortest array ends.
+   * - `'longest'`: continues zipping until the longest array ends, filling missing values with `undefined`.
+   * @default {'shortest'}
+   */
+  truncate?: "shortest" | "longest";
+};
 
 /**
  * Builds N-tuples of elements from the given N arrays with matching indices,
  * stopping when the smallest array's end is reached.
  *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * @typeParam T the type of the tuples produced by this function.
+ * @typeParam O the type of the options passed.
+ *
+ * @param options Options for zipping arrays.
+ * @param arrays The arrays to zip.
+ *
+ * @returns A new array containing N-tuples of elements from the given arrays.
+ *
+ * @example Usage with options
+ * ```ts
+ * import { zip } from "@std/collections/zip";
+ * import { assertEquals } from "@std/assert";
+ *
+ * const numbers = [1, 2, 3];
+ * const letters = ["a", "b", "c", "d"];
+ *
+ * assertEquals(
+ *   zip({ truncate: "shortest" }, numbers, letters),
+ *   [[1, "a"], [2, "b"], [3, "c"]],
+ * );
+ * assertEquals(
+ *   zip({ truncate: "longest" }, numbers, letters),
+ *   [[1, "a"], [2, "b"], [3, "c"], [undefined, "d"]],
+ * );
+ * ```
+ */
+export function zip<T extends unknown[], O extends ZipOptions>(
+  options: O,
+  ...arrays: { [K in keyof T]: ReadonlyArray<T[K]> }
+): {
+  [K in keyof T]: O extends { truncate: "longest" } ? T[K] | undefined : T[K];
+}[];
+/**
+ * Builds N-tuples of elements from the given N arrays with matching indices,
+ * stopping when the smallest array's end is reached.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
  * @typeParam T the type of the tuples produced by this function.
  *
  * @param arrays The arrays to zip.
@@ -35,14 +84,23 @@ import { minOf } from "./min_of.ts";
  */
 export function zip<T extends unknown[]>(
   ...arrays: { [K in keyof T]: ReadonlyArray<T[K]> }
-): T[] {
-  const minLength = minOf(arrays, (element) => element.length) ?? 0;
+): T[];
+export function zip(...args: unknown[]): unknown[] {
+  const [options, arrays] = args.length === 0 || Array.isArray(args[0])
+    ? [{}, args as unknown[][]]
+    : [args[0] as ZipOptions, args.slice(1) as unknown[][]];
+
+  if (arrays.length === 0) return [];
+
+  const minLength = Math[options.truncate === "longest" ? "max" : "min"](
+    ...arrays.map((x) => x.length),
+  );
 
-  const result: T[] = new Array(minLength);
+  const result = new Array(minLength);
 
   for (let i = 0; i < minLength; i += 1) {
     const arr = arrays.map((it) => it[i]);
-    result[i] = arr as T;
+    result[i] = arr;
   }
 
   return result;
```

```diff
diff --git a/collections/zip_test.ts b/collections/unstable_zip_test.ts
index 2bcd9994..48083180 100644
--- a/collections/zip_test.ts
+++ b/collections/unstable_zip_test.ts
@@ -1,25 +1,24 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 import { assertEquals } from "@std/assert";
-import { zip } from "./zip.ts";
+import { zip, type ZipOptions } from "./unstable_zip.ts";
+import { assertType, type IsExact } from "@std/testing/types";
 
-function zip1Test<T>(
-  input: [Array<T>],
-  expected: Array<[T]>,
-  message?: string,
-) {
-  const actual = zip(...input);
-  assertEquals(actual, expected, message);
-}
+const EMPTY_OPTIONS: ZipOptions = {};
 
-assertEquals(zip([]), []);
+Deno.test({
+  name: "zip() handles zero arrays",
+  fn() {
+    assertEquals(zip([]), []);
+    assertEquals(zip(EMPTY_OPTIONS, []), []);
+  },
+});
 
 Deno.test({
   name: "zip() handles one array",
   fn() {
-    zip1Test([
-      [1, 2, 3],
-    ], [[1], [2], [3]]);
+    assertEquals(zip([1, 2, 3]), [[1], [2], [3]]);
+    assertEquals(zip(EMPTY_OPTIONS, [1, 2, 3]), [[1], [2], [3]]);
   },
 });
 
@@ -166,3 +165,43 @@ Deno.test({
     );
   },
 });
+
+Deno.test("zip() handles truncate option", async (t) => {
+  const arrays: [number[], string[], bigint[]] = [[1, 2, 3], [
+    "a",
+    "b",
+    "c",
+    "d",
+  ], [88n]];
+
+  await t.step('truncate: "shortest" (default)', () => {
+    const explicit = zip({ truncate: "shortest" }, ...arrays);
+    const implicit = zip(...arrays);
+
+    assertEquals(explicit, [[1, "a", 88n]]);
+    assertEquals(explicit, implicit);
+
+    assertType<IsExact<typeof explicit, [number, string, bigint][]>>(true);
+    assertType<IsExact<typeof implicit, [number, string, bigint][]>>(true);
+  });
+
+  await t.step('truncate: "longest"', () => {
+    const zipped = zip({ truncate: "longest" }, ...arrays);
+    assertEquals(
+      zipped,
+      [
+        [1, "a", 88n],
+        [2, "b", undefined],
+        [3, "c", undefined],
+        [undefined, "d", undefined],
+      ],
+    );
+
+    assertType<
+      IsExact<
+        typeof zipped,
+        [number | undefined, string | undefined, bigint | undefined][]
+      >
+    >(true);
+  });
+});
```
</details>