### PR TITLE
fix(http): respect colors and other `Deno.inspect` options when logging `UserAgent`s

### DIFF
--- a/http/user_agent.ts
+++ b/http/user_agent.ts
@@ -1200,15 +1200,17 @@ export class UserAgent {
    * ```
    *
    * @param inspect internal inspect function.
+   * @param options inspect options.
    *
    * @returns The custom value to inspect.
    */
   [Symbol.for("Deno.customInspect")](
-    inspect: (value: unknown) => string,
+    inspect: typeof Deno.inspect,
+    options: Deno.InspectOptions,
   ): string {
     const { browser, cpu, device, engine, os, ua } = this;
     return `${this.constructor.name} ${
-      inspect({ browser, cpu, device, engine, os, ua })
+      inspect({ browser, cpu, device, engine, os, ua }, options)
     }`;
   }
 

--- a/http/user_agent.ts
+++ b/http/user_agent.ts
@@ -1205,8 +1205,8 @@ export class UserAgent {
    * @returns The custom value to inspect.
    */
   [Symbol.for("Deno.customInspect")](
-    inspect: typeof Deno.inspect,
-    options: Deno.InspectOptions,
+    inspect: (value: unknown, options: unknown) => string,
+    options: unknown,
   ): string {
     const { browser, cpu, device, engine, os, ua } = this;
     return `${this.constructor.name} ${


### PR DESCRIPTION
Current:

<img width="1111" height="210" alt="image" src="https://github.com/user-attachments/assets/7cb5ec01-199d-4f1b-b2fc-27b5670f6b1f" />

After fix:

<img width="1109" height="208" alt="image" src="https://github.com/user-attachments/assets/a9ef8e53-5b13-4574-9a41-2f9577580701" />
