### PR TITLE
test(collections): fix mapValues mutation test so it actually tests mutation

### DIFF
--- a/collections/map_values_test.ts
+++ b/collections/map_values_test.ts
@@ -13,10 +13,10 @@ function mapValuesTest<T, O>(
 }
 
 Deno.test({
-  name: "mapValues() handles no mutation",
+  name: "mapValues() does not mutate its input",
   fn() {
     const object = { a: 5, b: true };
-    mapValues(object, (it) => it ?? "nothing");
+    mapValues(object, () => 999);
 
     assertEquals(object, { a: 5, b: true });
   },


### PR DESCRIPTION
The current test doesn't test anything, as it would pass even if the input was subject to mutation, because `5 ?? "nothing"` and `true ?? "nothing"` evaluate to `5` and `true` respectively.

Technically (in common with built-ins like `Array#map`) the input can still be mutated if the callback itself causes mutation, but changing that behavior would require `structuredClone` or similar, which incurs a performance cost and isn't always lossless. It's almost certainly better to leave that responsibility to userland code.