### PR TITLE
refactor(tar): TarStream

### DIFF
--- a/tar/tar_stream.ts
+++ b/tar/tar_stream.ts
@@ -1,5 +1,55 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
+import { toByteStream } from "@std/streams/unstable-to-byte-stream";
+
+/**
+ * The options that can go along with a file or directory.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ */
+export interface TarStreamOptions {
+  /**
+   * An octal literal.
+   * Defaults to 0o755 for directories and 0o644 for files.
+   */
+  mode?: number;
+  /**
+   * An octal literal.
+   * @default {0o0}
+   */
+  uid?: number;
+  /**
+   * An octal literal.
+   * @default {0o0}
+   */
+  gid?: number;
+  /**
+   * A number of seconds since the start of epoch. Avoid negative values.
+   * Defaults to the current time in seconds.
+   */
+  mtime?: number;
+  /**
+   * An ASCII string. Should be used in preference of uid.
+   * @default {''}
+   */
+  uname?: string;
+  /**
+   * An ASCII string. Should be used in preference of gid.
+   * @default {''}
+   */
+  gname?: string;
+  /**
+   * The major number for character device.
+   * @default {''}
+   */
+  devmajor?: string;
+  /**
+   * The minor number for block device entry.
+   * @default {''}
+   */
+  devminor?: string;
+}
+
 /**
  * The interface required to provide a file.
  *
@@ -55,58 +105,6 @@ export interface TarStreamDir {
  * @experimental **UNSTABLE**: New API, yet to be vetted.
  */
 export type TarStreamInput = TarStreamFile | TarStreamDir;
-
-type TarStreamInputInternal =
-  & (Omit<TarStreamFile, "path"> | Omit<TarStreamDir, "path">)
-  & { path: [Uint8Array, Uint8Array] };
-
-/**
- * The options that can go along with a file or directory.
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- */
-export interface TarStreamOptions {
-  /**
-   * An octal literal.
-   * Defaults to 0o755 for directories and 0o644 for files.
-   */
-  mode?: number;
-  /**
-   * An octal literal.
-   * @default {0o0}
-   */
-  uid?: number;
-  /**
-   * An octal literal.
-   * @default {0o0}
-   */
-  gid?: number;
-  /**
-   * A number of seconds since the start of epoch. Avoid negative values.
-   * Defaults to the current time in seconds.
-   */
-  mtime?: number;
-  /**
-   * An ASCII string. Should be used in preference of uid.
-   * @default {''}
-   */
-  uname?: string;
-  /**
-   * An ASCII string. Should be used in preference of gid.
-   * @default {''}
-   */
-  gname?: string;
-  /**
-   * The major number for character device.
-   * @default {''}
-   */
-  devmajor?: string;
-  /**
-   * The minor number for block device entry.
-   * @default {''}
-   */
-  devminor?: string;
-}
 
 const SLASH_CODE_POINT = "/".charCodeAt(0);
 
@@ -164,137 +162,201 @@ const SLASH_CODE_POINT = "/".charCodeAt(0);
  *   .pipeTo((await Deno.create('./out.tar.gz')).writable)
  * ```
  */
-
-export class TarStream implements TransformStream<TarStreamInput, Uint8Array> {
-  #readable: ReadableStream<Uint8Array>;
+export class TarStream
+  implements TransformStream<TarStreamInput, Uint8Array<ArrayBuffer>> {
+  #encoder = new TextEncoder();
+  #readable: ReadableStream<Uint8Array<ArrayBuffer>>;
   #writable: WritableStream<TarStreamInput>;
+  /**
+   * Constructs a new instance.
+   */
   constructor() {
     const { readable, writable } = new TransformStream<
       TarStreamInput,
-      TarStreamInputInternal
-    >({
-      transform(chunk, controller) {
-        if (chunk.options) {
-          try {
-            assertValidTarStreamOptions(chunk.options);
-          } catch (e) {
-            return controller.error(e);
-          }
+      TarStreamInput
+    >();
+    this.#writable = writable;
+    const gen = this.#tar(readable);
+    this.#readable = new ReadableStream({
+      type: "bytes",
+      autoAllocateChunkSize: 512,
+      async start(_controller) {
+        await gen.next(); // Prime the generator
+      },
+      async pull(controller) {
+        const offset = controller.byobRequest!.view!.byteOffset;
+        const length = controller.byobRequest!.view!.byteLength;
+
+        const { done, value } = await gen.next(
+          new Uint8Array(
+            controller.byobRequest!.view!.buffer as ArrayBuffer,
+            offset,
+            length,
+          ),
+        );
+        if (done) {
+          controller.close();
+          return controller.byobRequest!.respond(0);
         }
 
-        if (
-          "size" in chunk &&
-          (chunk.size < 0 || 8 ** 12 < chunk.size ||
-            chunk.size.toString() === "NaN")
-        ) {
-          return controller.error(
-            new RangeError(
-              "Cannot add to the tar archive: The size cannot exceed 64 Gibs",
+        // Buffer size is same
+        if (value.buffer.byteLength === length) {
+          return controller.byobRequest!.respondWithNewView(value);
+        }
+        // Buffer shrank
+        if (value.buffer.byteLength < length) {
+          const size = value.byteLength;
+          return controller.byobRequest!.respondWithNewView(
+            new Uint8Array(
+              value.buffer.transfer(offset + length),
+              offset,
+              size,
             ),
           );
         }
-
-        const path = parsePath(chunk.path);
-
-        controller.enqueue({ ...chunk, path });
+        // Buffer grew
+        const slice = value.slice(length);
+        controller.byobRequest!.respondWithNewView(
+          new Uint8Array(
+            value.buffer.transfer(offset + length),
+            offset,
+          ),
+        );
+        controller.enqueue(slice);
       },
-    });
-    this.#writable = writable;
-    const gen = async function* () {
-      const encoder = new TextEncoder();
-      for await (const chunk of readable) {
-        const [prefix, name] = chunk.path;
-        const typeflag = "size" in chunk ? "0" : "5";
-        const header = new Uint8Array(512);
-        const size = "size" in chunk ? chunk.size : 0;
-        const options: Required<TarStreamOptions> = {
-          mode: typeflag === "5" ? 0o755 : 0o644,
-          uid: 0o0,
-          gid: 0o0,
-          mtime: Math.floor(Date.now() / 1000),
-          uname: "",
-          gname: "",
-          devmajor: "",
-          devminor: "",
-          ...chunk.options,
-        };
+    }) as unknown as ReadableStream<Uint8Array<ArrayBuffer>>;
+  }
 
-        header.set(name); // name
-        header.set(
-          encoder.encode(
-            options.mode.toString(8).padStart(6, "0") + " \0" + // mode
-              options.uid.toString(8).padStart(6, "0") + " \0" + //uid
-              options.gid.toString(8).padStart(6, "0") + " \0" + // gid
-              size.toString(8).padStart(size < 8 ** 11 ? 11 : 12, "0") +
-              (size < 8 ** 11 ? " " : "") + // size
-              options.mtime.toString(8).padStart(11, "0") + " " + // mtime
-              " ".repeat(8) + // checksum | To be updated later
-              typeflag + // typeflag
-              "\0".repeat(100) + // linkname
-              "ustar\0" + // magic
-              "00" + // version
-              options.uname.padEnd(32, "\0") + // uname
-              options.gname.padEnd(32, "\0") + // gname
-              options.devmajor.padStart(8, "\0") + // devmajor
-              options.devminor.padStart(8, "\0"), // devminor
-          ),
-          100,
-        );
-        header.set(prefix, 345); // prefix
-        // Update Checksum
-        header.set(
-          encoder.encode(
-            header.reduce((x, y) => x + y).toString(8).padStart(6, "0") + "\0",
-          ),
-          148,
-        );
-        yield header;
+  #parsePathInto(path: string, buffer: Uint8Array<ArrayBuffer>): void {
+    parsePath(this.#encoder.encodeInto(path, buffer).written, buffer);
+  }
 
-        if ("size" in chunk) {
-          let size = 0;
-          for await (const value of chunk.readable) {
-            if (value.length) {
-              size += value.length;
-              yield value;
-            }
-          }
-          if (chunk.size !== size) {
-            throw new RangeError(
-              `Cannot add to the tar archive: The provided size (${chunk.size}) did not match bytes read from provided readable (${size})`,
-            );
-          }
-          if (chunk.size % 512) {
-            yield new Uint8Array(512 - size % 512);
-          }
+  #parseHeaderInto(
+    input: TarStreamInput,
+    buffer: Uint8Array<ArrayBuffer>,
+  ): void {
+    input.options ??= {};
+    input.options.mode ??= input.type === "file" ? 0o644 : 0o755;
+    input.options.uid ??= 0o0;
+    input.options.gid ??= 0o0;
+    input.options.mtime ??= Math.floor(Date.now() / 1000);
+    input.options.uname ??= "";
+    input.options.gname ??= "";
+    input.options.devmajor ??= "";
+    input.options.devminor ??= "";
+    assertValidTarStreamOptions(input.options);
+    if (
+      input.type === "file" &&
+      (input.size < 0 || 8 ** 12 < input.size || Number.isNaN(input.size))
+    ) {
+      throw new RangeError(
+        "Cannot add to the tar archive: The size cannot exceed 64 Gibs",
+      );
+    }
+
+    // name (100) & prefix (155)
+    this.#parsePathInto(input.path, buffer);
+    // mode (8)
+    parseOctalInto(input.options.mode, buffer.subarray(100, 106));
+    buffer[106] = 32;
+    buffer[107] = 0;
+    // uid (8)
+    parseOctalInto(input.options.uid, buffer.subarray(108, 114));
+    buffer[114] = 32;
+    buffer[115] = 0;
+    // gid (8)
+    parseOctalInto(input.options.gid, buffer.subarray(116, 122));
+    buffer[122] = 32;
+    buffer[123] = 0;
+    // size (12)
+    const size = input.type === "file" ? input.size : 0;
+    buffer[135] = 32;
+    parseOctalInto(size, buffer.subarray(124, 135 + +(8 ** 11 < size)));
+    // mtime (12)
+    parseOctalInto(input.options.mtime, buffer.subarray(136, 147));
+    buffer[147] = 32;
+    // checksum (8)
+    buffer.fill(32, 148, 156);
+    // typeflag (1)
+    buffer[156] = input.type === "file" ? 48 : 53;
+    // linkname (100)
+    buffer.fill(0, 157, 257);
+    // magic (6)
+    buffer[257] = 117;
+    buffer[258] = 115;
+    buffer[259] = 116;
+    buffer[260] = 97;
+    buffer[261] = 114;
+    buffer[262] = 0;
+    // version (2)
+    buffer.fill(48, 263, 265);
+    // uname (32)
+    this.#encoder
+      .encodeInto(input.options.uname, buffer.subarray(265, 297).fill(0));
+    // gname (32)
+    this.#encoder
+      .encodeInto(input.options.gname, buffer.subarray(297, 329).fill(0));
+    // devmajor (8)
+    this.#encoder
+      .encodeInto(input.options.devmajor, buffer.subarray(329, 337).fill(0));
+    // devminor (8)
+    this.#encoder
+      .encodeInto(input.options.devminor, buffer.subarray(337, 345).fill(0));
+    // pad (12)
+    buffer.fill(0, 500, 512);
+    // Update checksum
+    parseOctalInto(
+      buffer.subarray(0, 512).reduce((x, y) => x + y),
+      buffer.subarray(148, 154),
+    );
+    buffer[154] = 0;
+  }
+
+  async *#tar(
+    readable: ReadableStream<TarStreamInput>,
+  ): AsyncGenerator<
+    Uint8Array<ArrayBuffer>,
+    undefined,
+    Uint8Array<ArrayBuffer>
+  > {
+    let buffer = yield new Uint8Array(0); // Prime the generator
+    let offset = buffer.byteOffset;
+    for await (const input of readable) {
+      if (buffer.length < 512) {
+        buffer = new Uint8Array(offset + 512).subarray(offset);
+      }
+
+      this.#parseHeaderInto(input, buffer);
+      buffer = yield buffer.subarray(0, 512);
+      offset = buffer.byteOffset;
+      if (input.type === "directory") continue;
+
+      let size = 0;
+      const reader = toByteStream(input.readable).getReader({ mode: "byob" });
+
+      while (true) {
+        const { done, value } = await reader.read(buffer);
+        if (done) break;
+        size += value.length;
+        if (value.length) {
+          buffer = yield value;
+          offset = buffer.byteOffset;
         }
       }
-      yield new Uint8Array(1024);
-    }();
-    this.#readable = new ReadableStream({
-      type: "bytes",
-      async pull(controller) {
-        const { done, value } = await gen.next();
-        if (done) {
-          controller.close();
-          return controller.byobRequest?.respond(0);
-        }
-        if (controller.byobRequest?.view) {
-          const buffer = new Uint8Array(controller.byobRequest.view.buffer);
+      reader.releaseLock();
 
-          const size = buffer.length;
-          if (size < value.length) {
-            buffer.set(value.slice(0, size));
-            controller.byobRequest.respond(size);
-            controller.enqueue(value.slice(size));
-          } else {
-            buffer.set(value);
-            controller.byobRequest.respond(value.length);
-          }
-        } else {
-          controller.enqueue(value);
-        }
-      },
-    });
+      if (input.size !== size) {
+        throw new RangeError(
+          `Cannot add to the tar archive: The provided size (${input.size}) did not match bytes read from provided readable (${size})`,
+        );
+      }
+      if (size % 512) {
+        buffer = yield new Uint8Array(offset + 512 - size % 512)
+          .subarray(offset);
+      }
+    }
+    if (buffer.length < 1024) yield new Uint8Array(1024);
+    else yield buffer.subarray(0, 1024).fill(0);
   }
 
   /**
@@ -329,7 +391,7 @@ export class TarStream implements TransformStream<TarStreamInput, Uint8Array> {
    *   .pipeTo((await Deno.create('./out.tar.gz')).writable)
    * ```
    */
-  get readable(): ReadableStream<Uint8Array> {
+  get readable(): ReadableStream<Uint8Array<ArrayBuffer>> {
     return this.#readable;
   }
 
@@ -368,104 +430,6 @@ export class TarStream implements TransformStream<TarStreamInput, Uint8Array> {
   get writable(): WritableStream<TarStreamInput> {
     return this.#writable;
   }
-}
-
-function parsePath(
-  path: string,
-): [Uint8Array, Uint8Array] {
-  const name = new TextEncoder().encode(path);
-  if (name.length <= 100) {
-    return [new Uint8Array(0), name];
-  }
-
-  if (name.length > 256) {
-    throw new RangeError(
-      `Cannot parse the path as the path length cannot exceed 256 bytes: The path length is ${name.length}`,
-    );
-  }
-
-  // If length of last part is > 100, then there's no possible answer to split the path
-  let suitableSlashPos = Math.max(0, name.lastIndexOf(SLASH_CODE_POINT)); // always holds position of '/'
-  if (name.length - suitableSlashPos > 100) {
-    throw new RangeError(
-      `Cannot parse the path as the filename cannot exceed 100 bytes: The filename length is ${
-        name.length - suitableSlashPos
-      }`,
-    );
-  }
-
-  for (
-    let nextPos = suitableSlashPos;
-    nextPos > 0;
-    suitableSlashPos = nextPos
-  ) {
-    // disclaimer: '/' won't appear at pos 0, so nextPos always be > 0 or = -1
-    nextPos = name.lastIndexOf(SLASH_CODE_POINT, suitableSlashPos - 1);
-    // disclaimer: since name.length > 100 in this case, if nextPos = -1, name.length - nextPos will also > 100
-    if (name.length - nextPos > 100) {
-      break;
-    }
-  }
-
-  const prefix = name.slice(0, suitableSlashPos);
-  if (prefix.length > 155) {
-    throw new TypeError(
-      "Cannot parse the path as the path needs to be split-able on a forward slash separator into [155, 100] bytes respectively",
-    );
-  }
-  return [prefix, name.slice(suitableSlashPos + 1)];
-}
-
-/**
- * Asserts that the path provided is valid for a {@linkcode TarStream}.
- *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
- * It provides a means to check that a path is valid before pipping it through
- * the `TarStream`, where if invalid will throw an error. Ruining any progress
- * made when archiving.
- *
- * @param path The path as a string
- *
- * @example Usage
- * ```ts no-assert ignore
- * import { assertValidPath, TarStream, type TarStreamInput } from "@std/tar";
- *
- * const paths = (await Array.fromAsync(Deno.readDir("./")))
- *   .filter(entry => entry.isFile)
- *   .map((entry) => entry.name)
- *   // Filter out any paths that are invalid as they are to be placed inside a Tar.
- *   .filter(path => {
- *     try {
- *       assertValidPath(path);
- *       return true;
- *     } catch (error) {
- *       console.error(error);
- *       return false;
- *     }
- *   });
- *
- * await Deno.mkdir('./out/', { recursive: true })
- * await ReadableStream.from(paths)
- *   .pipeThrough(
- *     new TransformStream<string, TarStreamInput>({
- *       async transform(path, controller) {
- *         controller.enqueue({
- *           type: "file",
- *           path,
- *           size: (await Deno.stat(path)).size,
- *           readable: (await Deno.open(path)).readable,
- *         });
- *       },
- *     }),
- *   )
- *   .pipeThrough(new TarStream())
- *   .pipeThrough(new CompressionStream('gzip'))
- *   .pipeTo((await Deno.create('./out/archive.tar.gz')).writable);
- * ```
- */
-export function assertValidPath(path: string) {
-  parsePath(path);
 }
 
 /**
@@ -509,7 +473,7 @@ export function assertValidPath(path: string) {
  *   .pipeTo((await Deno.create('./out/archive.tar.gz')).writable);
  * ```
  */
-export function assertValidTarStreamOptions(options: TarStreamOptions) {
+export function assertValidTarStreamOptions(options: TarStreamOptions): void {
   if (options.mode && (options.mode.toString(8).length > 6)) {
     throw new TypeError("Cannot add to the tar archive: Invalid Mode provided");
   }
@@ -561,5 +525,101 @@ export function assertValidTarStreamOptions(options: TarStreamOptions) {
     throw new TypeError(
       "Cannot add to the tar archive: Invalid DevMinor provided",
     );
+  }
+}
+
+function parsePath(size: number, buffer: Uint8Array<ArrayBuffer>): void {
+  if (size <= 100) return;
+  if (size > 256) {
+    throw new RangeError(
+      `Cannot parse the path as the path length cannot exceed 256 bytes: The path length is ${size}`,
+    );
+  }
+
+  const sub = buffer.subarray(0, size);
+  let slashPos = Math.max(0, sub.lastIndexOf(SLASH_CODE_POINT));
+  if (size - slashPos > 100) {
+    throw new RangeError(
+      `Cannot parse the path as the file cannot exceed 100 bytes: The filename length is ${
+        size - slashPos
+      }`,
+    );
+  }
+
+  for (let pos = slashPos; pos > 0; slashPos = pos) {
+    pos = sub.lastIndexOf(SLASH_CODE_POINT, slashPos - 1);
+    if (size - pos > 100) break;
+  }
+
+  const prefix = sub.subarray(0, slashPos);
+  if (prefix.length > 155) {
+    throw new TypeError(
+      "Cannot parse the path as the path needs to be split-able on a forward slash separator into [155, 100] bytes respectively",
+    );
+  }
+  buffer.set(prefix, 345);
+  buffer.subarray(345 + prefix.length, 500).fill(0);
+  const name = sub.subarray(slashPos + 1);
+  buffer.set(name);
+  buffer.subarray(name.length, 100).fill(0);
+}
+
+/**
+ * Asserts that the path provided is valid for a {@linkcode TarStream}.
+ *
+ * @experimental **UNSTABLE**: New API, yet to be vetted.
+ *
+ * It provides a means to check that a path is valid before pipping it through
+ * the `TarStream`, where if invalid will throw an error. Ruining any progress
+ * made when archiving.
+ *
+ * @param path The path as a string
+ *
+ * @example Usage
+ * ```ts no-assert ignore
+ * import { assertValidPath, TarStream, type TarStreamInput } from "@std/tar";
+ *
+ * const paths = (await Array.fromAsync(Deno.readDir("./")))
+ *   .filter(entry => entry.isFile)
+ *   .map((entry) => entry.name)
+ *   // Filter out any paths that are invalid as they are to be placed inside a Tar.
+ *   .filter(path => {
+ *     try {
+ *       assertValidPath(path);
+ *       return true;
+ *     } catch (error) {
+ *       console.error(error);
+ *       return false;
+ *     }
+ *   });
+ *
+ * await Deno.mkdir('./out/', { recursive: true })
+ * await ReadableStream.from(paths)
+ *   .pipeThrough(
+ *     new TransformStream<string, TarStreamInput>({
+ *       async transform(path, controller) {
+ *         controller.enqueue({
+ *           type: "file",
+ *           path,
+ *           size: (await Deno.stat(path)).size,
+ *           readable: (await Deno.open(path)).readable,
+ *         });
+ *       },
+ *     }),
+ *   )
+ *   .pipeThrough(new TarStream())
+ *   .pipeThrough(new CompressionStream('gzip'))
+ *   .pipeTo((await Deno.create('./out/archive.tar.gz')).writable);
+ * ```
+ */
+export function assertValidPath(path: string): void {
+  const buffer = new Uint8Array(512);
+  parsePath(new TextEncoder().encodeInto(path, buffer).written, buffer);
+}
+
+function parseOctalInto(x: number, buffer: Uint8Array<ArrayBuffer>): void {
+  for (let i = buffer.length - 1; i >= 0; --i) {
+    buffer[i] = x % 8 + 48;
+    x = x / 8 | 0;
   }
 }


### PR DESCRIPTION
This pull request refactors the underlying code of `TarStream` to be easier to read, more memory efficient by skipping using strings as a medium, and offers a real BYOB stream instead of a superficial one, where buffers are taken from the start and passed up.

This pull request passes all existing tests and changes no API usage.