### PR TITLE
fix(crypto): make `timingSafeEqual()` truly timing-safe

### DIFF
--- a/crypto/timing_safe_equal.ts
+++ b/crypto/timing_safe_equal.ts
@@ -48,14 +48,20 @@ export function timingSafeEqual(
   a: ArrayBufferView | ArrayBufferLike | DataView,
   b: ArrayBufferView | ArrayBufferLike | DataView,
 ): boolean {
-  if (a.byteLength !== b.byteLength) return false;
   const dataViewA = toDataView(a);
   const dataViewB = toDataView(b);
-  const length = a.byteLength;
+  const lengthA = a.byteLength;
+  const lengthB = b.byteLength;
+
+  const lengthDiff = lengthA ^ lengthB;
+  const lengthMax = Math.max(lengthA, lengthB);
+
   let out = 0;
   let i = -1;
-  while (++i < length) {
-    out |= dataViewA.getUint8(i) ^ dataViewB.getUint8(i);
+  while (++i < lengthMax) {
+    const dataA = i < lengthA ? dataViewA.getUint8(i) : 0;
+    const dataB = i < lengthB ? dataViewB.getUint8(i) : 0;
+    out |= dataA ^ dataB;
   }
-  return out === 0;
+  return (out | lengthDiff) === 0;
 }


### PR DESCRIPTION
The current `timingSafeEqual()` is not timing-safe and vulnerable to timing based attacks due to its early return on mismatched lengths:
```js
if (a.byteLength !== b.byteLength) return false;
```
This PR refactors the function to use constant-time comparison.

(Im not sure if there is a way to test this)