### PR TITLE
chore(lint): ensure versioned specifier

### DIFF
--- a/_tools/check_mod_exports.ts
+++ b/_tools/check_mod_exports.ts
@@ -5,7 +5,7 @@ import { walk } from "../fs/walk.ts";
 import { relative } from "../path/relative.ts";
 import { dirname } from "../path/dirname.ts";
 import * as colors from "../fmt/colors.ts";
-import ts from "npm:typescript";
+import ts from "npm:typescript@5.9";
 import { getEntrypoints } from "./utils.ts";
 import { fromFileUrl } from "@std/path/from-file-url";
 


### PR DESCRIPTION
Fixes a linting error in canary.