### PR TITLE
fix(async): pass numeric value of `delay` timer to `unrefTimer` when `persistent=false`

### DIFF
--- a/async/delay.ts
+++ b/async/delay.ts
@@ -65,6 +65,7 @@ export function delay(ms: number, options: DelayOptions = {}): Promise<void> {
         Deno.unrefTimer(+i);
       } catch (error) {
         if (!(error instanceof ReferenceError)) {
+          clearTimeout(+i);
           throw error;
         }
         // deno-lint-ignore no-console

--- a/async/delay.ts
+++ b/async/delay.ts
@@ -12,6 +12,9 @@ export interface DelayOptions {
   persistent?: boolean;
 }
 
+// Make type available in browser environments; we catch the `ReferenceError` below
+declare const Deno: { unrefTimer(id: number): void };
+
 /**
  * Resolve a {@linkcode Promise} after a given amount of milliseconds.
  *
@@ -59,8 +62,7 @@ export function delay(ms: number, options: DelayOptions = {}): Promise<void> {
     signal?.addEventListener("abort", abort, { once: true });
     if (persistent === false) {
       try {
-        // @ts-ignore For browser compatibility
-        Deno.unrefTimer(i);
+        Deno.unrefTimer(+i);
       } catch (error) {
         if (!(error instanceof ReferenceError)) {
           throw error;

--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -108,8 +108,14 @@ Deno.test("delay() handles already aborted signal", async () => {
 });
 
 Deno.test("delay() handles persistent option", async () => {
-  using unrefTimer = stub(Deno, "unrefTimer");
-  await delay(100, { persistent: false });
+  // Stub with itself to ensure the actual function is still called, but we can track calls
+  using unrefTimer = stub(Deno, "unrefTimer", Deno.unrefTimer);
+
+  await Promise.all([
+    delay(0, { persistent: false }),
+    // Longer, persistent timer to ensure the process doesn't actually exit early (this would cause a test failure)
+    delay(1),
+  ]);
   assertSpyCalls(unrefTimer, 1);
 });
 

--- a/async/delay_test.ts
+++ b/async/delay_test.ts
@@ -131,15 +131,16 @@ Deno.test({
   name: "delay() handles persistent option with error",
   async fn() {
     using unrefTimer = stub(Deno, "unrefTimer", () => {
-      throw new Error("Error!");
+      throw new TypeError("Error!");
     });
-    try {
-      await delay(100, { persistent: false });
-    } catch (e) {
-      assert(e instanceof Error);
-      assertEquals(e.message, "Error!");
-      assertSpyCalls(unrefTimer, 1);
-    }
+
+    await assertRejects(
+      () => delay(100, { persistent: false }),
+      TypeError,
+      "Error!",
+    );
+
+    assertSpyCalls(unrefTimer, 1);
   },
   sanitizeResources: false,
   sanitizeOps: false,


### PR DESCRIPTION
Bug was introduced in https://github.com/denoland/std/pull/6775, as `setArbitraryLengthTimeout` returns `{ valueOf(): number }` rather than a primitive `number`, and `Deno.unrefTimer` throws if its argument isn't a `number`.

Previous type checking missed it due to already using a `// @ts-ignore` for the offending line, and the test also missed it due to stubbing `Deno.unrefTimer` with a no-op.