### PR TITLE
fix(semver): allow users to set prerelease number during increment

### DIFF
--- a/semver/_shared.ts
+++ b/semver/_shared.ts
@@ -173,7 +173,6 @@ const NUMERIC_IDENTIFIER_REGEXP = new RegExp(`^${NUMERIC_IDENTIFIER}$`);
 export function parsePrerelease(prerelease: string) {
   return prerelease
     .split(".")
-    .map((s) => s.trim())
     .filter(Boolean)
     .map((id: string) => {
       if (NUMERIC_IDENTIFIER_REGEXP.test(id)) {
@@ -185,10 +184,7 @@ export function parsePrerelease(prerelease: string) {
 }
 
 export function parseBuild(buildmetadata: string) {
-  return buildmetadata
-    .split(".")
-    .map((s) => s.trim())
-    .filter(Boolean);
+  return buildmetadata.split(".").filter(Boolean);
 }
 
 export function parseNumber(input: string, errorMessage: string) {

--- a/semver/_shared.ts
+++ b/semver/_shared.ts
@@ -173,6 +173,7 @@ const NUMERIC_IDENTIFIER_REGEXP = new RegExp(`^${NUMERIC_IDENTIFIER}$`);
 export function parsePrerelease(prerelease: string) {
   return prerelease
     .split(".")
+    .map((s) => s.trim())
     .filter(Boolean)
     .map((id: string) => {
       if (NUMERIC_IDENTIFIER_REGEXP.test(id)) {

--- a/semver/_shared.ts
+++ b/semver/_shared.ts
@@ -185,7 +185,10 @@ export function parsePrerelease(prerelease: string) {
 }
 
 export function parseBuild(buildmetadata: string) {
-  return buildmetadata.split(".").filter(Boolean);
+  return buildmetadata
+    .split(".")
+    .map((s) => s.trim())
+    .filter(Boolean);
 }
 
 export function parseNumber(input: string, errorMessage: string) {

--- a/semver/increment.ts
+++ b/semver/increment.ts
@@ -33,6 +33,8 @@ function bumpPrerelease(
   let newIdentifiers = parsePrerelease(newPrerelease);
 
   if (newIdentifiers.every((id) => typeof id === "string")) {
+    // When the give prerelease has no number and are all included in the existing prerelease
+    // it should just bump the number
     if (
       newIdentifiers.every((id, i) => id === bumpedPrerelease[i]) &&
       typeof bumpedPrerelease[newIdentifiers.length] === "number"

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -974,20 +974,6 @@ Deno.test("increment()", async (t) => {
       "1.2.3-0",
     ],
     [
-      { major: 1, minor: 2, patch: 3, prerelease: ["pr", 0], build: [] },
-      "pre",
-      "", // empty prerelease is the same as undefined
-      undefined,
-      "1.2.3-pr.1",
-    ],
-    [
-      { major: 1, minor: 2, patch: 3, prerelease: ["pr", 0], build: [] },
-      "pre",
-      " ", // prerelease with whitepsace is the same as undefined or empty
-      " ",
-      "1.2.3-pr.1",
-    ],
-    [
       { major: 1, minor: 2, patch: 3, prerelease: [], build: [] },
       "pre",
       "pr.123", // test specifying a specific prerelease number
@@ -1007,6 +993,34 @@ Deno.test("increment()", async (t) => {
       "pr.11", // when switching prereleases, if the number is specified, use it
       undefined,
       "1.2.3-pr.11",
+    ],
+    [
+      { major: 1, minor: 2, patch: 3, prerelease: ["alpha", 1], build: [] },
+      "pre",
+      "pr.xyz",
+      undefined,
+      "1.2.3-pr.xyz.0",
+    ],
+    [
+      { major: 1, minor: 2, patch: 3, prerelease: ["alpha", 1], build: [] },
+      "pre",
+      "pr.xyz.3",
+      undefined,
+      "1.2.3-pr.xyz.3",
+    ],
+    [
+      { major: 1, minor: 2, patch: 3, prerelease: ["alpha", 1], build: [] },
+      "pre",
+      "pr.xyz.5.foo",
+      undefined,
+      "1.2.3-pr.xyz.5.foo",
+    ],
+    [
+      { major: 1, minor: 2, patch: 3, prerelease: ["alpha", 1], build: [] },
+      "pre",
+      "alpha.1.foo",
+      undefined,
+      "1.2.3-alpha.1.foo",
     ],
   ];
 

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -981,6 +981,13 @@ Deno.test("increment()", async (t) => {
       "1.2.3-pr.1",
     ],
     [
+      { major: 1, minor: 2, patch: 3, prerelease: ["pr", 0], build: [] },
+      "pre",
+      " ", // prerelease with whitepsace is the same as undefined or empty
+      undefined,
+      "1.2.3-pr.1",
+    ],
+    [
       { major: 1, minor: 2, patch: 3, prerelease: [], build: [] },
       "pre",
       "pr.123", // test specifying a specific prerelease number

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -973,6 +973,27 @@ Deno.test("increment()", async (t) => {
       undefined,
       "1.2.3-0",
     ],
+    [
+      { major: 1, minor: 2, patch: 3, prerelease: [], build: [] },
+      "pre",
+      "pr.123", // test specifying a specific prerelease number
+      undefined,
+      "1.2.3-pr.123",
+    ],
+    [
+      { major: 1, minor: 2, patch: 3, prerelease: ["pr", 1], build: [] },
+      "pre",
+      "pr.7", // even when the prerelease labels match, if its specified, use it
+      undefined,
+      "1.2.3-pr.7",
+    ],
+    [
+      { major: 1, minor: 2, patch: 3, prerelease: ["alpha", 1], build: [] },
+      "pre",
+      "pr.11", // when switching prereleases, if the number is specified, use it
+      undefined,
+      "1.2.3-pr.11",
+    ],
   ];
 
   for (const [version, op, prerelease, build, expected] of versions) {

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -974,6 +974,13 @@ Deno.test("increment()", async (t) => {
       "1.2.3-0",
     ],
     [
+      { major: 1, minor: 2, patch: 3, prerelease: ["pr", 0], build: [] },
+      "pre",
+      "", // empty prerelease is the same as undefined
+      undefined,
+      "1.2.3-pr.1",
+    ],
+    [
       { major: 1, minor: 2, patch: 3, prerelease: [], build: [] },
       "pre",
       "pr.123", // test specifying a specific prerelease number

--- a/semver/increment_test.ts
+++ b/semver/increment_test.ts
@@ -984,7 +984,7 @@ Deno.test("increment()", async (t) => {
       { major: 1, minor: 2, patch: 3, prerelease: ["pr", 0], build: [] },
       "pre",
       " ", // prerelease with whitepsace is the same as undefined or empty
-      undefined,
+      " ",
       "1.2.3-pr.1",
     ],
     [


### PR DESCRIPTION
If a user specifies a prerelease value in the form of `{identifer}.{number}` then both the identifier and the number will be used to set the prerelease metadata.

---

- Fixes https://github.com/denoland/std/issues/6824