### PR TITLE
fix(async): convert setTimeout return values to Number (fixing type error when used with Node.js)

### DIFF
--- a/async/delay.ts
+++ b/async/delay.ts
@@ -89,8 +89,8 @@ function setArbitraryLengthTimeout(
   const queueTimeout = () => {
     currentDelay = delay - (Date.now() - start);
     timeoutId = currentDelay > I32_MAX
-      ? setTimeout(queueTimeout, I32_MAX)
-      : setTimeout(callback, currentDelay);
+      ? Number(setTimeout(queueTimeout, I32_MAX))
+      : Number(setTimeout(callback, currentDelay));
   };
 
   queueTimeout();


### PR DESCRIPTION
In Node.js, setTimeout returns a NodeJS.Timeout. When using tsc in a frontend project, this can cause type errors.

code: https://github.com/iugo/deno-std-in-node/tree/async-timeout-type-error