### PR TITLE
fix(cli): avoid including Deno API when using `deno bundle`

### DIFF
--- a/cli/_prompt_select.ts
+++ b/cli/_prompt_select.ts
@@ -7,8 +7,6 @@ const SAFE_PADDING = 4;
 const MORE_CONTENT_BEFORE_INDICATOR = "...";
 const MORE_CONTENT_AFTER_INDICATOR = "...";
 
-const input = Deno.stdin;
-const output = Deno.stdout;
 const encoder = new TextEncoder();
 const decoder = new TextDecoder();
 
@@ -40,6 +38,8 @@ export function handlePromptSelect<V>(
     inputStr(): void;
   }) => boolean | "return",
 ) {
+  const input = Deno.stdin;
+  const output = Deno.stdout;
   const indexedValues = values.map((value, absoluteIndex) => ({
     value,
     absoluteIndex,

--- a/cli/unstable_prompt_multiple_select.ts
+++ b/cli/unstable_prompt_multiple_select.ts
@@ -45,8 +45,6 @@ const DELETE = "\u007F";
 const CHECKED = "◉";
 const UNCHECKED = "◯";
 
-const input = Deno.stdin;
-
 /**
  * Shows the given message and waits for the user's input. Returns the user's selected value as string.
  *
@@ -105,7 +103,7 @@ export function promptMultipleSelect<V = undefined>(
   values: PromptEntry<V>[],
   options: PromptMultipleSelectOptions = {},
 ): PromptEntry<V>[] | null {
-  if (!input.isTerminal()) return null;
+  if (!Deno.stdin.isTerminal()) return null;
 
   const selectedAbsoluteIndexes = new Set<number>();
 

--- a/cli/unstable_prompt_select.ts
+++ b/cli/unstable_prompt_select.ts
@@ -41,8 +41,6 @@ const ARROW_DOWN = "\u001B[B";
 const CR = "\r";
 const DELETE = "\u007F";
 
-const input = Deno.stdin;
-
 /**
  * Shows the given message and waits for the user's input. Returns the user's selected value as string.
  *
@@ -104,7 +102,7 @@ export function promptSelect<V = undefined>(
   values: PromptEntry<V>[],
   options: PromptSelectOptions = {},
 ): PromptEntry<V> | null {
-  if (!input.isTerminal()) return null;
+  if (!Deno.stdin.isTerminal()) return null;
 
   let selectedIndex = 0;
 


### PR DESCRIPTION
closes #6836 

With this change, `@std/cli` now depends on `@std/internal`.