### PR TITLE
fix(async/unstable): fix handling of async predicate in waitFor

### DIFF
--- a/async/unstable_wait_for.ts
+++ b/async/unstable_wait_for.ts
@@ -51,13 +51,20 @@ export function waitFor(
   const { step = 100 } = options;
 
   // Create a new promise that resolves when the predicate is true
-  let interval: number;
+  let timer: number;
   const p: Promise<void> = new Promise(function (resolve) {
-    interval = setInterval(() => {
-      if (predicate()) resolve();
-    }, step);
+    const setTimer = () => {
+      timer = setTimeout(async () => {
+        if (await predicate()) {
+          resolve();
+        } else {
+          setTimer();
+        }
+      }, step);
+    };
+    setTimer();
   });
 
   // Return a deadline promise
-  return deadline(p, ms, options).finally(() => clearInterval(interval));
+  return deadline(p, ms, options).finally(() => clearTimeout(timer));
 }

--- a/async/unstable_wait_for_test.ts
+++ b/async/unstable_wait_for_test.ts
@@ -1,6 +1,13 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
-import { assertEquals, assertLess, assertRejects } from "@std/assert";
+import {
+  assertEquals,
+  assertFalse,
+  assertGreater,
+  assertLess,
+  assertRejects,
+} from "@std/assert";
 import { waitFor } from "./unstable_wait_for.ts";
+import { delay } from "./delay.ts";
 import { FakeTime } from "@std/testing/time";
 
 // NOT detecting leaks means that the internal interval was correctly cleared
@@ -37,4 +44,26 @@ Deno.test("waitFor() throws DOMException on timeout", async () => {
   assertLess(Date.now() - start, 1000);
   assertEquals(error.name, "TimeoutError");
   clearTimeout(id);
+});
+
+Deno.test("waitFor() supports async predicate", async () => {
+  let i = 0;
+  const start = Date.now();
+  await waitFor(async () => {
+    await delay(200);
+    return ++i === 3;
+  }, 2000);
+  assertGreater(Date.now() - start, 600);
+});
+
+Deno.test("waitFor() does not call async predicate concurrently", async () => {
+  let i = 0;
+  let beingCalled = false;
+  await waitFor(async () => {
+    assertFalse(beingCalled);
+    beingCalled = true;
+    await delay(200);
+    beingCalled = false;
+    return ++i === 3;
+  }, 2000);
 });


### PR DESCRIPTION
`waitFor` accepts async predicate in type definition, however if `predicate` returns a Promise, it's considered true and always resolves at the first call. This PR fixes it by handling returned promise correctly.