### PR TITLE
YAML: Allow to add custom types for parse and stringify

### DIFF
--- a/yaml/_schema.ts
+++ b/yaml/_schema.ts
@@ -46,8 +46,8 @@ import { undefinedType } from "./_type/undefined.ts";
  */
 export type SchemaType = "failsafe" | "json" | "core" | "default" | "extended";
 
-type ImplicitType = Type<"scalar">;
-type ExplicitType = Type<KindType>;
+export type ImplicitType = Type<"scalar">;
+export type ExplicitType = Type<KindType>;
 
 export type TypeMap = Record<
   KindType | "fallback",
@@ -161,3 +161,19 @@ export const SCHEMA_MAP = new Map<SchemaType, Schema>([
   ["json", JSON_SCHEMA],
   ["extended", EXTENDED_SCHEMA],
 ]);
+
+export function getSchema(
+  schema: SchemaType = "default",
+  types?: ImplicitType[],
+): Schema {
+  const schemaObj = SCHEMA_MAP.get(schema)!;
+
+  if (!types) {
+    return schemaObj;
+  }
+
+  return createSchema({
+    implicitTypes: [...types, ...schemaObj.implicitTypes],
+    explicitTypes: [...schemaObj.explicitTypes],
+  });
+}

--- a/yaml/_type.ts
+++ b/yaml/_type.ts
@@ -21,13 +21,20 @@ export type RepresentFn<D> = (data: D, style?: StyleVariant) => string;
 
 // deno-lint-ignore no-explicit-any
 export interface Type<K extends KindType, D = any> {
+  /** Tag to identify the type */
   tag: string;
+  /** Kind of type */
   kind: K;
+  /** Cast the type. Used to stringify */
   predicate?: (data: unknown) => data is D;
+  /** Function to represent data. Used to stringify */
   represent?: RepresentFn<D> | Record<string, RepresentFn<D>>;
+  /** Default style for the type. Used to stringify */
   defaultStyle?: StyleVariant;
+  /** Function to test whether data can be resolved by this type. Used to parse */
   // deno-lint-ignore no-explicit-any
   resolve: (data: any) => boolean;
+  /** Function to construct data from string. Used to parse */
   // deno-lint-ignore no-explicit-any
   construct: (data: any) => D;
 }

--- a/yaml/parse.ts
+++ b/yaml/parse.ts
@@ -6,9 +6,9 @@
 
 import { isEOL } from "./_chars.ts";
 import { LoaderState } from "./_loader_state.ts";
-import { SCHEMA_MAP, type SchemaType } from "./_schema.ts";
+import { getSchema, type ImplicitType, type SchemaType } from "./_schema.ts";
 
-export type { SchemaType };
+export type { ImplicitType, SchemaType };
 
 /** Options for {@linkcode parse}. */
 export interface ParseOptions {
@@ -30,6 +30,11 @@ export interface ParseOptions {
    * {@linkcode Error} as its only argument.
    */
   onWarning?(error: Error): void;
+
+  /**
+   * Extra types to be added to the schema.
+   */
+  extraTypes?: ImplicitType[];
 }
 
 function sanitizeInput(input: string) {
@@ -79,7 +84,7 @@ export function parse(
   content = sanitizeInput(content);
   const state = new LoaderState(content, {
     ...options,
-    schema: SCHEMA_MAP.get(options.schema!)!,
+    schema: getSchema(options.schema, options.extraTypes),
   });
   const documentGenerator = state.readDocuments();
   const document = documentGenerator.next().value;
@@ -122,7 +127,7 @@ export function parseAll(content: string, options: ParseOptions = {}): unknown {
   content = sanitizeInput(content);
   const state = new LoaderState(content, {
     ...options,
-    schema: SCHEMA_MAP.get(options.schema!)!,
+    schema: getSchema(options.schema, options.extraTypes),
   });
   return [...state.readDocuments()];
 }

--- a/yaml/parse_test.ts
+++ b/yaml/parse_test.ts
@@ -3,7 +3,7 @@
 // Copyright 2011-2015 by Vitaly Puzrin. All rights reserved. MIT license.
 // Copyright 2018-2025 the Deno authors. MIT license.
 
-import { parse, parseAll } from "./parse.ts";
+import { type ImplicitType, parse, parseAll } from "./parse.ts";
 import {
   assert,
   assertEquals,
@@ -488,6 +488,36 @@ Deno.test({
       () => parse("--- !!omap\n- foo: 1\n- foo: 2"),
       SyntaxError,
       "Cannot resolve a node with !<tag:yaml.org,2002:omap> explicit tag",
+    );
+  },
+});
+
+Deno.test({
+  name: "parse() handles custom types",
+  fn() {
+    const foo: ImplicitType = {
+      tag: "tag:custom:smile",
+      resolve: (data: string): boolean => data === "=)",
+      construct: (): string => "🙂",
+      predicate: (data: unknown): data is string => data === "🙂",
+      kind: "scalar",
+      represent: (): string => "=)",
+    };
+
+    assertEquals(
+      parse(
+        `
+title: =)
+tags:
+  - =)
+  - bar
+`,
+        { extraTypes: [foo] },
+      ),
+      {
+        title: "🙂",
+        tags: ["🙂", "bar"],
+      },
     );
   },
 });

--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -5,10 +5,10 @@
 // This module is browser compatible.
 
 import { DumperState } from "./_dumper_state.ts";
-import { SCHEMA_MAP, type SchemaType } from "./_schema.ts";
+import { getSchema, type ImplicitType, type SchemaType } from "./_schema.ts";
 import type { StyleVariant } from "./_type.ts";
 
-export type { SchemaType, StyleVariant };
+export type { ImplicitType, SchemaType, StyleVariant };
 
 /** Options for {@linkcode stringify}. */
 export type StringifyOptions = {
@@ -85,6 +85,10 @@ export type StringifyOptions = {
    * @default {false}
    */
   condenseFlow?: boolean;
+  /**
+   * Extra types to be added to the schema.
+   */
+  extraTypes?: ImplicitType[];
 };
 
 /**
@@ -112,7 +116,7 @@ export function stringify(
 ): string {
   const state = new DumperState({
     ...options,
-    schema: SCHEMA_MAP.get(options.schema!)!,
+    schema: getSchema(options.schema, options.extraTypes),
   });
   return state.stringify(data);
 }

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -4,7 +4,7 @@
 // Copyright 2018-2025 the Deno authors. MIT license.
 
 import { assertEquals, assertThrows } from "@std/assert";
-import { stringify } from "./stringify.ts";
+import { type ImplicitType, stringify } from "./stringify.ts";
 import { stringify as unstableStringify } from "./unstable_stringify.ts";
 import { compare, parse } from "@std/semver";
 
@@ -864,6 +864,32 @@ Deno.test({
     assertEquals(
       unstableStringify(object, { quoteStyle: "'" }),
       `url: 'https://example.com'\n`,
+    );
+  },
+});
+
+Deno.test({
+  name: "stringify() handles custom types",
+  fn() {
+    const foo: ImplicitType = {
+      tag: "tag:custom:smile",
+      resolve: (data: string): boolean => data === "=)",
+      construct: (): string => "🙂",
+      predicate: (data: unknown): data is string => data === "🙂",
+      kind: "scalar",
+      represent: (): string => "=)",
+    };
+
+    assertEquals(
+      stringify({
+        title: "🙂",
+        tags: ["🙂", "bar"],
+      }, { extraTypes: [foo] }),
+      `title: =)
+tags:
+  - =)
+  - bar
+`,
     );
   },
 });


### PR DESCRIPTION
This change adds a new option to add custom types for `parse` and `stringify` functions of YAML, which can fix #5680.

For example: 

```js
import { parse, type ImplicitType } from "@std/yaml";

const smile: ImplicitType = {
  tag: "tag:custom:smile",
  resolve: (data): boolean => data === "=)",
  construct: (): string => "🙂",
  predicate: (data): data is string => data === "🙂",
  kind: "scalar",
  represent: (): string => "=)",
};

const yaml = `
title: =)
tags:
  - =)
  - bar
`

const result = parse(yaml, { extraTypes: [ smile ] }
console.assert(result.title === "🙂");
```
