### PR TITLE
feat(http): add support for extra headers in serveFile

### DIFF
--- a/http/file_server.ts
+++ b/http/file_server.ts
@@ -155,6 +155,12 @@ export interface ServeFileOptions {
    * `filePath`.
    */
   fileInfo?: Deno.FileInfo;
+
+  /** Headers to add to each response
+   *
+   * @default {[]}
+   */
+  headers?: string[];
 }
 
 /**
@@ -202,6 +208,15 @@ export async function serveFile(
   }
 
   const headers = createBaseHeaders();
+
+  if (options?.headers) {
+    for (const header of options.headers) {
+      const headerSplit = header.split(":");
+      const name = headerSplit[0]!;
+      const value = headerSplit.slice(1).join(":");
+      headers.append(name, value);
+    }
+  }
 
   const etag = fileInfo.mtime
     ? await eTag(fileInfo, { algorithm })


### PR DESCRIPTION
The headers customization is present in http serveDir but not in serveFile. This PR fixes this.