### PR TITLE
fix(assert): hint at reference-equality when assertEquals diff is empty (#6878)

### DIFF
--- a/assert/equals.ts
+++ b/assert/equals.ts
@@ -69,7 +69,10 @@ export function assertEquals<T>(
   // one nested property is a function (or Promise / Request / Blob / etc.)
   // that gets compared by reference. The empty diff is confusing, so append
   // a hint pointing at the likely cause.
-  if (!stringDiff && diffResult.every((r) => r.type !== "added" && r.type !== "removed")) {
+  if (
+    !stringDiff &&
+    diffResult.every((r) => r.type !== "added" && r.type !== "removed")
+  ) {
     message = `${message}\n` +
       "    Note: values stringify identically but are not structurally equal. " +
       "Functions, Promises, Requests, Blobs, and other built-ins are compared by " +

--- a/assert/equals.ts
+++ b/assert/equals.ts
@@ -64,5 +64,17 @@ export function assertEquals<T>(
   const diffMsg = buildMessage(diffResult, { stringDiff }, arguments[3])
     .join("\n");
   message = `${message}\n${diffMsg}`;
+  // #6878: if the diff shows no removed/added lines, the values stringify
+  // identically but were still deemed unequal — typically because at least
+  // one nested property is a function (or Promise / Request / Blob / etc.)
+  // that gets compared by reference. The empty diff is confusing, so append
+  // a hint pointing at the likely cause.
+  if (!stringDiff && diffResult.every((r) => r.type !== "added" && r.type !== "removed")) {
+    message = `${message}\n` +
+      "    Note: values stringify identically but are not structurally equal. " +
+      "Functions, Promises, Requests, Blobs, and other built-ins are compared by " +
+      "reference, so two distinct instances are never equal even when their " +
+      "representations match.";
+  }
   throw new AssertionError(message);
 }

--- a/assert/equals_test.ts
+++ b/assert/equals_test.ts
@@ -1,5 +1,10 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
-import { assertEquals, AssertionError, assertThrows } from "./mod.ts";
+import {
+  assertEquals,
+  AssertionError,
+  assertStringIncludes,
+  assertThrows,
+} from "./mod.ts";
 import {
   bold,
   gray,
@@ -203,6 +208,48 @@ Deno.test({
 -     ccccccccccccccccccccccc: 0,
 +     ccccccccccccccccccccccc: 1,
     }`,
+    );
+  },
+});
+
+Deno.test({
+  name:
+    "assertEquals() hints at reference-equality when objects with function props stringify identically (#6878)",
+  fn() {
+    let caught: AssertionError | undefined;
+    try {
+      assertEquals(
+        { x: 1, y: () => 2 },
+        { x: 1, y: () => 2 },
+      );
+    } catch (e) {
+      caught = e as AssertionError;
+    }
+    if (!caught) throw new Error("Expected assertEquals to throw");
+    assertStringIncludes(caught.message, "Values are not equal");
+    assertStringIncludes(
+      caught.message,
+      "stringify identically but are not structurally equal",
+    );
+    assertStringIncludes(caught.message, "compared by reference");
+  },
+});
+
+Deno.test({
+  name:
+    "assertEquals() does not append reference-equality hint when there is a real textual diff",
+  fn() {
+    let caught: AssertionError | undefined;
+    try {
+      assertEquals({ x: 1 }, { x: 2 });
+    } catch (e) {
+      caught = e as AssertionError;
+    }
+    if (!caught) throw new Error("Expected assertEquals to throw");
+    assertEquals(
+      caught.message.includes("stringify identically"),
+      false,
+      "Hint should only fire when the diff is empty",
     );
   },
 });


### PR DESCRIPTION
Fixes #6878.

When `assertEquals` decides two values are unequal but they stringify identically (typically because a property is a function compared by reference), the rendered diff is empty:

```
error: AssertionError: Values are not equal.


    [Diff] Actual / Expected


    {
      x: 1,
      y: [Function: y],
    }
```

That leaves users hunting for invisible differences. @lionel-rowe pointed at the underlying cause in the thread (functions, Promises, Requests, Blobs etc. fall back to reference equality) and suggested the diff should "explicitly state when there are invisible differences."

## Fix

After building the diff, check whether it contains any `added` / `removed` entries. If not, append:

```
    Note: values stringify identically but are not structurally equal.
    Functions, Promises, Requests, Blobs, and other built-ins are compared by
    reference, so two distinct instances are never equal even when their
    representations match.
```

The hint is skipped on string-vs-string comparisons (which always produce a visible diff when they differ) and on real textual diffs (so existing failures aren't noisier).

## Tests

Two cases in `assert/equals_test.ts`:
- `hints at reference-equality when objects with function props stringify identically (#6878)` — reproduces the exact issue body's call and asserts the new hint text is present.
- `does not append reference-equality hint when there is a real textual diff` — `assertEquals({ x: 1 }, { x: 2 })` must NOT include the hint.

```
$ deno test --allow-read --allow-write assert/
ok | 141 passed (25 steps) | 0 failed (1s)

$ deno lint assert/equals.ts assert/equals_test.ts
Checked 2 files

$ deno check assert/equals.ts assert/equals_test.ts
```