### PR TITLE
fix(fs): exists rethrows Deno.errors.PermissionDenied when existence is indeterminate

### DIFF
--- a/fs/exists.ts
+++ b/fs/exists.ts
@@ -156,8 +156,15 @@ export async function exists(
         (await Deno.permissions.query({ name: "read", path })).state ===
           "granted"
       ) {
-        // --allow-read not missing
-        return !options?.isReadable; // PermissionDenied was raised by file system, so the item exists, but can't be read
+        // --allow-read is not missing, so PermissionDenied came from the
+        // OS. If the caller specifically asked whether the path is
+        // readable, "no" is a defensible answer. Otherwise the usual
+        // cause is that the parent directory isn't traversable and we
+        // genuinely can't tell whether the path exists — guessing "true"
+        // silently misleads callers (see #6528). Re-throw so the caller
+        // can decide how to handle the indeterminate case.
+        if (options?.isReadable) return false;
+        throw error;
       }
     }
     throw error;
@@ -294,8 +301,15 @@ export function existsSync(
       if (
         Deno.permissions.querySync({ name: "read", path }).state === "granted"
       ) {
-        // --allow-read not missing
-        return !options?.isReadable; // PermissionDenied was raised by file system, so the item exists, but can't be read
+        // --allow-read is not missing, so PermissionDenied came from the
+        // OS. If the caller specifically asked whether the path is
+        // readable, "no" is a defensible answer. Otherwise the usual
+        // cause is that the parent directory isn't traversable and we
+        // genuinely can't tell whether the path exists — guessing "true"
+        // silently misleads callers (see #6528). Re-throw so the caller
+        // can decide how to handle the indeterminate case.
+        if (options?.isReadable) return false;
+        throw error;
       }
     }
     throw error;

--- a/fs/exists_test.ts
+++ b/fs/exists_test.ts
@@ -362,3 +362,64 @@ Deno.test("existsSync() returns false when both isDirectory and isFile sets true
     await Deno.remove(tempDirPath, { recursive: true });
   }
 });
+
+// https://github.com/denoland/std/issues/6528 — when --allow-read is granted
+// but the OS denies access (typically because the parent directory isn't
+// traversable), the previous behavior returned `true` and silently misled
+// callers. Now we rethrow Deno.errors.PermissionDenied so callers can decide
+// how to handle the indeterminate case. The `isReadable: true` branch is
+// unchanged: that question has a definitive answer (not readable → false).
+Deno.test(
+  {
+    name:
+      "exists() rethrows Deno.errors.PermissionDenied when the parent is inaccessible (#6528)",
+    ignore: Deno.build.os === "windows",
+  },
+  async function () {
+    const tempDirPath = await Deno.makeTempDir();
+    const innerPath = path.join(tempDirPath, "inner");
+    try {
+      await Deno.chmod(tempDirPath, 0o000);
+      let caught: unknown;
+      try {
+        await exists(innerPath);
+      } catch (e) {
+        caught = e;
+      }
+      assert(caught instanceof Deno.errors.PermissionDenied);
+
+      // isReadable:true still returns false — that question can be answered.
+      assertEquals(await exists(innerPath, { isReadable: true }), false);
+    } finally {
+      await Deno.chmod(tempDirPath, 0o755);
+      await Deno.remove(tempDirPath, { recursive: true });
+    }
+  },
+);
+
+Deno.test(
+  {
+    name:
+      "existsSync() rethrows Deno.errors.PermissionDenied when the parent is inaccessible (#6528)",
+    ignore: Deno.build.os === "windows",
+  },
+  function () {
+    const tempDirPath = Deno.makeTempDirSync();
+    const innerPath = path.join(tempDirPath, "inner");
+    try {
+      Deno.chmodSync(tempDirPath, 0o000);
+      let caught: unknown;
+      try {
+        existsSync(innerPath);
+      } catch (e) {
+        caught = e;
+      }
+      assert(caught instanceof Deno.errors.PermissionDenied);
+
+      assertEquals(existsSync(innerPath, { isReadable: true }), false);
+    } finally {
+      Deno.chmodSync(tempDirPath, 0o755);
+      Deno.removeSync(tempDirPath, { recursive: true });
+    }
+  },
+);


### PR DESCRIPTION
Fixes #6528.

`exists` and `existsSync` returned `true` for any path that produced a `PermissionDenied` at `stat()` time (with `--allow-read` granted), on the assumption that the OS error meant *the item is there, just not readable*. The far more common cause is that the parent directory isn't traversable, in which case we genuinely cannot determine existence and the `true` answer silently misleads the caller.

Repro from the issue:

```
$ ls /root
ls: cannot open directory '/root': Permission denied
$ cat test.ts
import { exists } from "jsr:@std/fs/exists";
console.log(await exists("/root/foo"));
$ deno run --allow-read test.ts
true
```

After the patch, `exists("/root/foo")` rethrows `Deno.errors.PermissionDenied` and the caller can pick the right policy for their context.

`exists(path, { isReadable: true })` is unchanged. That question has a defensible answer (the OS just told us "can't read" → `false`), and the existing `exists() returns true for an existing dir symlink` test in `fs/exists_test.ts` relies on it (it chmod-0o000s the parent and expects `false`).

Two new Unix-gated regression tests cover both `exists()` and `existsSync()`, asserting:
- `Deno.errors.PermissionDenied` is rethrown when the parent is unreadable
- `{ isReadable: true }` still returns `false` in the same scenario

This is a small but real behavior change for callers that today swallow a misleading `true`. Net diff is small and is documented inline at both call sites.