### PR TITLE
docs: remove dead deno.land/std link from README (registry retired)

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,9 +7,8 @@
 High-quality APIs for [Deno](https://deno.com/) and the web. Use fearlessly.
 
 > [!IMPORTANT]
-> Newer versions of the Standard Library are now hosted on
-> [JSR](https://jsr.io/@std). Older versions up till 0.224.0 are still available
-> at [deno.land/std](https://deno.land/std).
+> The Standard Library is now hosted on [JSR](https://jsr.io/@std). The legacy
+> deno.land/std registry has been retired and no longer serves any packages.
 
 ## Resources
 


### PR DESCRIPTION
## Summary

The README's IMPORTANT notice references `https://deno.land/std`, which now returns HTTP 404. The deno.land/x registry has been retired and no longer serves packages.

## Changes

Updated the IMPORTANT notice to drop the dead link and the now-false 'older versions up till 0.224.0 are still available at deno.land/std' claim, while keeping the working `https://jsr.io/@std` link.

```diff
 > [!IMPORTANT]
-> Newer versions of the Standard Library are now hosted on
-> [JSR](https://jsr.io/@std). Older versions up till 0.224.0 are still available
-> at [deno.land/std](https://deno.land/std).
+> The Standard Library is now hosted on [JSR](https://jsr.io/@std). The legacy
+> deno.land/std registry has been retired and no longer serves any packages.
```

## Verification

- `https://deno.land/std` returns 404 (curl HEAD + GET)
- `https://jsr.io/@std` returns 200 (still the canonical home)