### PR TITLE
feat(http/unstable): accept `HeadersInit` for `serveDir` and `serveFile` headers

### DIFF
--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -1272,6 +1272,29 @@ Deno.test("(unstable) serveDir() sets headers from a Headers instance", async ()
   assertEquals(res.headers.get("x-custom-header"), "hi");
 });
 
+Deno.test("(unstable) serveFile() sends custom headers from a legacy string array", async () => {
+  const req = new Request("http://localhost/testdata/test_file.txt");
+  const res = await unstableServeFile(req, TEST_FILE_PATH, {
+    headers: ["X-Extra: extra header"],
+  });
+
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("x-extra"), "extra header");
+  assertEquals(await res.text(), TEST_FILE_TEXT);
+});
+
+Deno.test("(unstable) serveDir() sets headers from a legacy string array", async () => {
+  const req = new Request("http://localhost/test_file.txt");
+  const res = await unstableServeDir(req, {
+    ...serveDirOptions,
+    headers: ["cache-control: max-age=100", "x-custom-header: hi"],
+  });
+  await res.body?.cancel();
+
+  assertEquals(res.headers.get("cache-control"), "max-age=100");
+  assertEquals(res.headers.get("x-custom-header"), "hi");
+});
+
 Deno.test("(unstable) serveDir() does not set headers on redirect responses", async () => {
   const req = new Request(
     "http://localhost/%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..",

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -23,7 +23,10 @@ import { MINUTE } from "@std/datetime/constants";
 import { getAvailablePort } from "@std/net/get-available-port";
 import { concat } from "@std/bytes/concat";
 import { lessThan, parse as parseSemver } from "@std/semver";
-import { serveDir as unstableServeDir } from "./unstable_file_server.ts";
+import {
+  serveDir as unstableServeDir,
+  type ServeDirOptions as UnstableServeDirOptions,
+} from "./unstable_file_server.ts";
 import { serveFile as unstableServeFile } from "./unstable_file_server.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
@@ -1205,7 +1208,7 @@ Deno.test("serveDir() handles HEAD request for missing file", async () => {
 Deno.test("(unstable) serveDir() serves files without the need of html extension when cleanUrls=true", async () => {
   const req = new Request("http://localhost/hello");
   const res = await unstableServeDir(req, {
-    ...serveDirOptions,
+    ...serveDirOptions as UnstableServeDirOptions,
     cleanUrls: true,
   });
   const downloadedFile = await res.text();
@@ -1219,7 +1222,7 @@ Deno.test("(unstable) serveDir() serves files without the need of html extension
 Deno.test("(unstable) serveDir() does not shadow existing files and directory if cleanUrls=true", async () => {
   const req = new Request("http://localhost/test_clean_urls");
   const res = await unstableServeDir(req, {
-    ...serveDirOptions,
+    ...serveDirOptions as UnstableServeDirOptions,
     cleanUrls: true,
   });
 
@@ -1227,13 +1230,61 @@ Deno.test("(unstable) serveDir() does not shadow existing files and directory if
   assertEquals(res.headers.has("location"), true);
 });
 
-Deno.test("(unstable) serveFile() sends custom headers", async () => {
+Deno.test("(unstable) serveFile() sends custom headers from a record", async () => {
   const req = new Request("http://localhost/testdata/test_file.txt");
   const res = await unstableServeFile(req, TEST_FILE_PATH, {
-    headers: ["X-Extra: extra header"],
+    headers: { "X-Extra": "extra header" },
   });
 
   assertEquals(res.status, 200);
   assertEquals(res.headers.get("X-Extra"), "extra header");
   assertEquals(await res.text(), TEST_FILE_TEXT);
+});
+
+Deno.test("(unstable) serveFile() sends custom headers from a Headers instance", async () => {
+  const req = new Request("http://localhost/testdata/test_file.txt");
+  const res = await unstableServeFile(req, TEST_FILE_PATH, {
+    headers: new Headers([["X-Extra", "extra header"]]),
+  });
+
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("x-extra"), "extra header");
+  assertEquals(await res.text(), TEST_FILE_TEXT);
+});
+
+Deno.test("(unstable) serveDir() sets headers from a record", async () => {
+  const req = new Request("http://localhost/test_file.txt");
+  const res = await unstableServeDir(req, {
+    ...serveDirOptions as UnstableServeDirOptions,
+    headers: { "cache-control": "max-age=100", "x-custom-header": "hi" },
+  });
+  await res.body?.cancel();
+
+  assertEquals(res.headers.get("cache-control"), "max-age=100");
+  assertEquals(res.headers.get("x-custom-header"), "hi");
+});
+
+Deno.test("(unstable) serveDir() sets headers from a Headers instance", async () => {
+  const req = new Request("http://localhost/test_file.txt");
+  const res = await unstableServeDir(req, {
+    ...serveDirOptions as UnstableServeDirOptions,
+    headers: new Headers({ "x-custom-header": "hi" }),
+  });
+  await res.body?.cancel();
+
+  assertEquals(res.headers.get("x-custom-header"), "hi");
+});
+
+Deno.test("(unstable) serveDir() does not set headers on redirect responses", async () => {
+  const req = new Request(
+    "http://localhost/%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..",
+  );
+  const res = await unstableServeDir(req, {
+    ...serveDirOptions as UnstableServeDirOptions,
+    headers: { "x-custom-header": "hi" },
+  });
+  await res.body?.cancel();
+
+  assertEquals(res.status, 301);
+  assertEquals(res.headers.has("x-custom-header"), false);
 });

--- a/http/file_server_test.ts
+++ b/http/file_server_test.ts
@@ -23,21 +23,18 @@ import { MINUTE } from "@std/datetime/constants";
 import { getAvailablePort } from "@std/net/get-available-port";
 import { concat } from "@std/bytes/concat";
 import { lessThan, parse as parseSemver } from "@std/semver";
-import {
-  serveDir as unstableServeDir,
-  type ServeDirOptions as UnstableServeDirOptions,
-} from "./unstable_file_server.ts";
+import { serveDir as unstableServeDir } from "./unstable_file_server.ts";
 import { serveFile as unstableServeFile } from "./unstable_file_server.ts";
 
 const moduleDir = dirname(fromFileUrl(import.meta.url));
 const testdataDir = resolve(moduleDir, "testdata");
-const serveDirOptions: ServeDirOptions = {
+const serveDirOptions = {
   quiet: true,
   fsRoot: testdataDir,
   showDirListing: true,
   showDotfiles: true,
   enableCors: true,
-};
+} satisfies ServeDirOptions;
 const denoVersion = parseSemver(Deno.version.deno);
 const isCanary = denoVersion.build ? denoVersion.build.length > 0 : false;
 // FileInfo.mode is not available on Windows before Deno 2.1.0
@@ -1208,7 +1205,7 @@ Deno.test("serveDir() handles HEAD request for missing file", async () => {
 Deno.test("(unstable) serveDir() serves files without the need of html extension when cleanUrls=true", async () => {
   const req = new Request("http://localhost/hello");
   const res = await unstableServeDir(req, {
-    ...serveDirOptions as UnstableServeDirOptions,
+    ...serveDirOptions,
     cleanUrls: true,
   });
   const downloadedFile = await res.text();
@@ -1222,7 +1219,7 @@ Deno.test("(unstable) serveDir() serves files without the need of html extension
 Deno.test("(unstable) serveDir() does not shadow existing files and directory if cleanUrls=true", async () => {
   const req = new Request("http://localhost/test_clean_urls");
   const res = await unstableServeDir(req, {
-    ...serveDirOptions as UnstableServeDirOptions,
+    ...serveDirOptions,
     cleanUrls: true,
   });
 
@@ -1255,7 +1252,7 @@ Deno.test("(unstable) serveFile() sends custom headers from a Headers instance",
 Deno.test("(unstable) serveDir() sets headers from a record", async () => {
   const req = new Request("http://localhost/test_file.txt");
   const res = await unstableServeDir(req, {
-    ...serveDirOptions as UnstableServeDirOptions,
+    ...serveDirOptions,
     headers: { "cache-control": "max-age=100", "x-custom-header": "hi" },
   });
   await res.body?.cancel();
@@ -1267,7 +1264,7 @@ Deno.test("(unstable) serveDir() sets headers from a record", async () => {
 Deno.test("(unstable) serveDir() sets headers from a Headers instance", async () => {
   const req = new Request("http://localhost/test_file.txt");
   const res = await unstableServeDir(req, {
-    ...serveDirOptions as UnstableServeDirOptions,
+    ...serveDirOptions,
     headers: new Headers({ "x-custom-header": "hi" }),
   });
   await res.body?.cancel();
@@ -1280,7 +1277,7 @@ Deno.test("(unstable) serveDir() does not set headers on redirect responses", as
     "http://localhost/%2F..%2F..%2F..%2F..%2F..%2F..%2F..%2F..",
   );
   const res = await unstableServeDir(req, {
-    ...serveDirOptions as UnstableServeDirOptions,
+    ...serveDirOptions,
     headers: { "x-custom-header": "hi" },
   });
   await res.body?.cancel();

--- a/http/unstable_file_server.ts
+++ b/http/unstable_file_server.ts
@@ -77,6 +77,10 @@ export interface ServeDirOptions
   cleanUrls?: boolean;
   /** Headers to add to each response.
    *
+   * Values are appended to the response, not replaced, so passing a header
+   * the file server already sets (e.g. `cache-control`) yields a
+   * comma-joined value rather than overriding it.
+   *
    * @default {[]}
    */
   headers?: HeadersInit;
@@ -85,6 +89,10 @@ export interface ServeDirOptions
 /** Interface for serveFile options. */
 export interface ServeFileOptions extends StableServeFileOptions {
   /** Headers to add to each response.
+   *
+   * Values are appended to the response, not replaced, so passing a header
+   * the file server already sets (e.g. `cache-control`) yields a
+   * comma-joined value rather than overriding it.
    *
    * @default {[]}
    */

--- a/http/unstable_file_server.ts
+++ b/http/unstable_file_server.ts
@@ -6,6 +6,14 @@ import {
   serveFile as stableServeFile,
   type ServeFileOptions as StableServeFileOptions,
 } from "./file_server.ts";
+import { isRedirectStatus } from "./status.ts";
+
+function appendHeaders(target: Headers, headers: HeadersInit): void {
+  const normalized = new Headers(headers);
+  for (const [name, value] of normalized) {
+    target.append(name, value);
+  }
+}
 
 /**
  * Serves the files under the given directory root (opts.fsRoot).
@@ -45,15 +53,21 @@ import {
  * @param opts Additional options.
  * @returns A response for the request.
  */
-export function serveDir(
+export async function serveDir(
   req: Request,
   opts: ServeDirOptions = {},
 ): Promise<Response> {
-  return stableServeDir(req, opts);
+  const { headers, ...rest } = opts;
+  const response = await stableServeDir(req, rest);
+  if (headers && !isRedirectStatus(response.status)) {
+    appendHeaders(response.headers, headers);
+  }
+  return response;
 }
 
 /** Interface for serveDir options. */
-export interface ServeDirOptions extends StableServeDirOptions {
+export interface ServeDirOptions
+  extends Omit<StableServeDirOptions, "headers"> {
   /**
    * Also serves `.html` files without the need for specifying the extension.
    * For example `foo.html` could be accessed through both `/foo` and `/foo.html`.
@@ -61,15 +75,20 @@ export interface ServeDirOptions extends StableServeDirOptions {
    * @default {false}
    */
   cleanUrls?: boolean;
+  /** Headers to add to each response.
+   *
+   * @default {[]}
+   */
+  headers?: HeadersInit;
 }
 
 /** Interface for serveFile options. */
 export interface ServeFileOptions extends StableServeFileOptions {
-  /** Headers to add to each response
+  /** Headers to add to each response.
    *
    * @default {[]}
    */
-  headers?: string[];
+  headers?: HeadersInit;
 }
 
 /**
@@ -96,15 +115,11 @@ export async function serveFile(
   filePath: string,
   options?: ServeFileOptions,
 ): Promise<Response> {
-  const response = await stableServeFile(req, filePath, options);
+  const { headers, ...rest } = options ?? {};
+  const response = await stableServeFile(req, filePath, rest);
 
-  if (options?.headers) {
-    for (const header of options.headers) {
-      const headerSplit = header.split(":");
-      const name = headerSplit[0]!;
-      const value = headerSplit.slice(1).join(":");
-      response.headers.append(name, value);
-    }
+  if (headers) {
+    appendHeaders(response.headers, headers);
   }
 
   return response;

--- a/http/unstable_file_server.ts
+++ b/http/unstable_file_server.ts
@@ -8,9 +8,19 @@ import {
 } from "./file_server.ts";
 import { isRedirectStatus } from "./status.ts";
 
-function appendHeaders(target: Headers, headers: HeadersInit): void {
-  const normalized = new Headers(headers);
-  for (const [name, value] of normalized) {
+function appendHeaders(
+  target: Headers,
+  headers: HeadersInit | string[],
+): void {
+  // Legacy form: a flat array of `"name: value"` strings.
+  if (Array.isArray(headers) && typeof headers[0] === "string") {
+    for (const header of headers as string[]) {
+      const i = header.indexOf(":");
+      target.append(header.slice(0, i), header.slice(i + 1).trimStart());
+    }
+    return;
+  }
+  for (const [name, value] of new Headers(headers as HeadersInit)) {
     target.append(name, value);
   }
 }
@@ -77,26 +87,34 @@ export interface ServeDirOptions
   cleanUrls?: boolean;
   /** Headers to add to each response.
    *
+   * Accepts any {@linkcode HeadersInit}. The legacy flat array of
+   * `"name: value"` strings (e.g. `["X-Extra: extra header"]`) is also
+   * still accepted.
+   *
    * Values are appended to the response, not replaced, so passing a header
    * the file server already sets (e.g. `cache-control`) yields a
    * comma-joined value rather than overriding it.
    *
    * @default {[]}
    */
-  headers?: HeadersInit;
+  headers?: HeadersInit | string[];
 }
 
 /** Interface for serveFile options. */
 export interface ServeFileOptions extends StableServeFileOptions {
   /** Headers to add to each response.
    *
+   * Accepts any {@linkcode HeadersInit}. The legacy flat array of
+   * `"name: value"` strings (e.g. `["X-Extra: extra header"]`) is also
+   * still accepted.
+   *
    * Values are appended to the response, not replaced, so passing a header
    * the file server already sets (e.g. `cache-control`) yields a
    * comma-joined value rather than overriding it.
    *
    * @default {[]}
    */
-  headers?: HeadersInit;
+  headers?: HeadersInit | string[];
 }
 
 /**


### PR DESCRIPTION
Closes #6723.

`ServeDirOptions.headers` and `ServeFileOptions.headers` in `@std/http/unstable-file-server` now accept `HeadersInit` instead of `string[]`, so callers can pass a `Headers` instance, a record, or a list of tuples without hand-rolling `name:value` strings.

The stable `serveDir`/`serveFile` keep their existing `string[]` signature, so the file-server CLI behaviour is unchanged. The unstable wrapper strips `headers` before delegating to the stable implementation and applies them to the response itself (skipping redirect responses, matching the stable behaviour).