### PR TITLE
fix(testing/unstable): report descriptive error when inline snapshot update fails

### DIFF
--- a/testing/unstable_snapshot.ts
+++ b/testing/unstable_snapshot.ts
@@ -160,7 +160,15 @@ function updateSnapshots() {
   );
 }
 globalThis.addEventListener("unload", () => {
-  updateSnapshots();
+  try {
+    updateSnapshots();
+  } catch (error) {
+    const cause = error instanceof Error ? error : new Error(String(error));
+    throw new Error(
+      `assertInlineSnapshot: failed to update snapshots: ${cause.message}`,
+      { cause },
+    );
+  }
 });
 
 /**

--- a/testing/unstable_snapshot_test.ts
+++ b/testing/unstable_snapshot_test.ts
@@ -184,6 +184,52 @@ Deno.test("format", async () => {
   }
 });
 
+Deno.test(
+  "assertInlineSnapshot() reports a descriptive error when update fails",
+  async () => {
+    if (!LINT_SUPPORTED) return;
+
+    const fileContents =
+      `import { assertInlineSnapshot } from "${SNAPSHOT_MODULE_URL}";
+Deno.test("update test", () => {
+  assertInlineSnapshot(1, \`2\`);
+});`;
+
+    const tempDir = await Deno.makeTempDir();
+    const testFile = join(tempDir, "update_test.ts");
+    try {
+      await Deno.writeTextFile(testFile, fileContents);
+
+      // Missing --allow-run makes the post-update `deno fmt` subprocess fail.
+      // The error must surface with a descriptive message and a non-zero exit
+      // code instead of the test runner reporting `error: null`.
+      const command = new Deno.Command(Deno.execPath(), {
+        args: [
+          "test",
+          "--no-lock",
+          "--allow-read",
+          "--allow-write",
+          testFile,
+          "--",
+          "--update",
+        ],
+      });
+      const { code, stderr, stdout } = await command.output();
+      const output = new TextDecoder().decode(stderr) +
+        new TextDecoder().decode(stdout);
+
+      assertEquals(code !== 0, true);
+      assertEquals(
+        output.includes("assertInlineSnapshot: failed to update snapshots"),
+        true,
+      );
+      assertEquals(output.includes("error: null"), false);
+    } finally {
+      await Deno.remove(tempDir, { recursive: true });
+    }
+  },
+);
+
 Deno.test("createAssertInlineSnapshot()", () => {
   const assertMonochromeInlineSnapshot = createAssertInlineSnapshot<string>({
     serializer: stripAnsiCode,


### PR DESCRIPTION
Closes #6746.

When `assertInlineSnapshot()` is run with `--update` and the post-update `deno fmt` subprocess fails (e.g. the test was run without `--allow-run`), the original error was thrown from inside the `unload` handler and surfaced through the test runner as `error: null`, giving the caller no clue what went wrong.

The unload handler now catches errors from `updateSnapshots()` and re-throws them wrapped in an `Error` whose message is prefixed with `assertInlineSnapshot: failed to update snapshots:` and whose `cause` is the original error, so both the runner output and any tooling reading `cause` get the real reason.