### PR TITLE
docs: document the no-assert directive and link the accepted PR title types

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -48,6 +48,11 @@ A change confined to unstable APIs must carry the `/unstable` suffix in its
 scope. Without it, the title reads as a change to stable APIs and inflates the
 package's version bump.
 
+The full lists of accepted title types and scopes live in the
+[`title` workflow](./workflows/title.yml). Note that scopes are kebab-case
+(`data-structures`) even though package directories are snake_case
+(`data_structures`).
+
 ## Suggesting a new feature
 
 When new features are accepted, they are initially accepted as 'unstable'
@@ -209,6 +214,19 @@ So concrete examples are:
  *
  * // Fails at runtime
  * assert(false);
+ * ```
+ */
+````
+
+The documentation checker requires each `ts` snippet to import an assertion from
+`@std/assert`, `@std/expect` or `@std/testing`. When an assertion adds nothing
+to an example, add `no-assert` to the starting delimiter to exempt it. Unlike
+`ignore`, the snippet still runs:
+
+````ts
+/**
+ * ```ts no-assert
+ * (code snippet that runs, but asserts nothing)
  * ```
  */
 ````


### PR DESCRIPTION
Closes the last two gaps between CONTRIBUTING.md and what the tooling enforces.

- The PR titles section now links to the `title` workflow for the full lists of accepted types and scopes. The workflow accepts 13 types. The doc showed 4. A link, not a copy, per #7280. Also notes that scopes are kebab-case (`data-structures`) while directories are snake_case.
- The example snippet section documents `no-assert`, the third fence directive `check_docs.ts` recognizes next to the already-documented `ignore` and `expect-error`.
