### PR TITLE
fix(uuid): reject timestamps that exceed 48 bits in v7.generate()

### DIFF
--- a/uuid/v7.ts
+++ b/uuid/v7.ts
@@ -46,7 +46,8 @@ export function validate(id: string): boolean {
 /**
  * Generates a {@link https://www.rfc-editor.org/rfc/rfc9562.html#section-5.7 | UUIDv7}.
  *
- * @throws {RangeError} If the timestamp is not a non-negative integer.
+ * @throws {RangeError} If the timestamp is not an integer between 0 and
+ * 2**48 - 1, the maximum value representable in the UUIDv7 timestamp field.
  *
  * @param timestamp Unix Epoch timestamp in milliseconds.
  *
@@ -62,14 +63,16 @@ export function validate(id: string): boolean {
  * ```
  */
 export function generate(timestamp: number = Date.now()): string {
-  const bytes = new Uint8Array(16);
-  const view = new DataView(bytes.buffer);
-  // Unix timestamp in milliseconds (truncated to 48 bits)
-  if (!Number.isInteger(timestamp) || timestamp < 0) {
+  if (
+    !Number.isInteger(timestamp) || timestamp < 0 || timestamp > 2 ** 48 - 1
+  ) {
     throw new RangeError(
-      `Cannot generate UUID as timestamp must be a non-negative integer: timestamp ${timestamp}`,
+      `Cannot generate UUID as timestamp must be an integer between 0 and 2**48 - 1: timestamp ${timestamp}`,
     );
   }
+  const bytes = new Uint8Array(16);
+  const view = new DataView(bytes.buffer);
+  // Unix timestamp in milliseconds occupies the first 48 bits
   view.setBigUint64(0, BigInt(timestamp) << 16n);
   crypto.getRandomValues(bytes.subarray(6));
   // Version (4 bits) Occupies bits 48 through 51 of octet 6.

--- a/uuid/v7_test.ts
+++ b/uuid/v7_test.ts
@@ -52,18 +52,30 @@ Deno.test("generate() throws on invalid timestamp", () => {
   assertThrows(
     () => generate(-1),
     RangeError,
-    "Cannot generate UUID as timestamp must be a non-negative integer: timestamp -1",
+    "Cannot generate UUID as timestamp must be an integer between 0 and 2**48 - 1: timestamp -1",
   );
   assertThrows(
     () => generate(NaN),
     RangeError,
-    "Cannot generate UUID as timestamp must be a non-negative integer: timestamp NaN",
+    "Cannot generate UUID as timestamp must be an integer between 0 and 2**48 - 1: timestamp NaN",
   );
   assertThrows(
     () => generate(2.3),
     RangeError,
-    "Cannot generate UUID as timestamp must be a non-negative integer: timestamp 2.3",
+    "Cannot generate UUID as timestamp must be an integer between 0 and 2**48 - 1: timestamp 2.3",
   );
+  assertThrows(
+    () => generate(2 ** 48),
+    RangeError,
+    "Cannot generate UUID as timestamp must be an integer between 0 and 2**48 - 1: timestamp 281474976710656",
+  );
+});
+
+Deno.test("generate() supports the maximum 48-bit timestamp", () => {
+  const timestamp = 2 ** 48 - 1;
+  const u = generate(timestamp);
+  assert(validate(u), `${u} is not a valid uuid v7`);
+  assertEquals(extractTimestamp(u), timestamp);
 });
 
 Deno.test("validate() checks if a string is a valid v7 UUID", () => {


### PR DESCRIPTION
`generate()` in `@std/uuid/v7` silently truncates timestamps to 48 bits. This PR makes it throw a `RangeError` instead.

The timestamp is written with `setBigUint64`, which wraps modulo 2^64, so any bit above 48 disappears without a trace:

- `generate(2 ** 48)` returns a UUID whose `extractTimestamp()` is `0`
- `generate(Date.now() * 1000)` (microseconds passed by mistake) returns a UUID carrying a garbage timestamp

Both results pass `validate()`, so nothing downstream catches the corruption.

The fix extends the existing guard: `generate()` already threw `RangeError` for negative and non-integer timestamps, and now also rejects values above `2 ** 48 - 1`. The `@throws` doc states the full range, and tests cover the new throw path plus a round-trip at the maximum value.

On the behavior change: inputs that previously produced a corrupted UUID now throw. An inline comment said "truncated to 48 bits", but the truncation never made it into the public JSDoc, and it breaks the round-trip the tests already assert (`extractTimestamp(generate(t)) === t`). I read that comment as describing the bug, not the contract. Since `2 ** 48 - 1` milliseconds lands in the year 10889, no wall-clock timestamp is affected. Only mistakes are.

I used Claude Code to help investigate and write this change.
