### PR TITLE
docs(uuid): fix stale v1 JSDoc and remove unnecessary casts from examples

### DIFF
--- a/uuid/mod.ts
+++ b/uuid/mod.ts
@@ -49,7 +49,7 @@ import {
  * import { assert } from "@std/assert";
  *
  * const uuid = v1.generate();
- * assert(v1.validate(uuid as string));
+ * assert(v1.validate(uuid));
  * ```
  */
 export const v1 = {
@@ -123,7 +123,7 @@ export const v5 = {
  *
  * const TIMESTAMP = 1527897600000;
  * const uuid = v7.generate(TIMESTAMP); // optional timestamp, otherwise defaults to Date.now();
- * assert(v7.validate(uuid as string));
+ * assert(v7.validate(uuid));
  * assertEquals(v7.extractTimestamp(uuid), TIMESTAMP);
  * ```
  */

--- a/uuid/unstable_v6.ts
+++ b/uuid/unstable_v6.ts
@@ -97,7 +97,7 @@ export interface GenerateOptions {
  * };
  *
  * const uuid = generate(options);
- * assert(validate(uuid as string));
+ * assert(validate(uuid));
  * ```
  */
 export function generate(options: GenerateOptions = {}): string {

--- a/uuid/v1.ts
+++ b/uuid/v1.ts
@@ -55,7 +55,7 @@ export interface GenerateOptions {
    */
   msecs?: number;
   /**
-   * The number of nanoseconds to add to {@linkcode V1Options.msecs}
+   * The number of nanoseconds to add to {@linkcode GenerateOptions.msecs}
    * (0 - 10,000).
    *
    * @see {@link https://www.rfc-editor.org/rfc/rfc4122#section-4.1.4}
@@ -65,7 +65,7 @@ export interface GenerateOptions {
   random?: number[];
   /**
    * A function that returns an array of 16 random bytes (0 - 255).
-   * Alternative to {@linkcode V1Options.random}.
+   * Alternative to {@linkcode GenerateOptions.random}.
    */
   rng?: () => number[];
 }
@@ -76,7 +76,7 @@ export interface GenerateOptions {
  *
  * @param options Can use RFC time sequence values as overwrites.
  *
- * @returns Returns a UUIDv1 string or an array of 16 bytes.
+ * @returns Returns a UUIDv1 string.
  *
  * @example Usage
  * ```ts
@@ -91,7 +91,7 @@ export interface GenerateOptions {
  * };
  *
  * const uuid = generate(options);
- * assert(validate(uuid as string));
+ * assert(validate(uuid));
  * ```
  */
 export function generate(options: GenerateOptions = {}): string {


### PR DESCRIPTION
Fixes doc rot in `@std/uuid` left behind by an old API change. No code changes.

`v1.generate()` used to return `string | number[]`. The union is long gone, but three traces of it survived:

- Two `{@linkcode V1Options.*}` references in `v1.ts` point at an interface that was renamed to `GenerateOptions`, so the links render dead on JSR.
- The `@returns` doc still says "a UUIDv1 string or an array of 16 bytes". It returns a string.
- Four examples (v1, v6, and two in `mod.ts`) cast `validate(uuid as string)`. The casts are no-ops now, and they teach readers to distrust a return type that is plain `string`.

All doc examples still compile and pass: `deno test --doc uuid/` is green, 66 tests.

I used Claude Code to help investigate and write this change.
