### PR TITLE
docs(uuid): document that v7 UUIDs are not monotonic within a millisecond

### DIFF
--- a/uuid/v7.ts
+++ b/uuid/v7.ts
@@ -6,6 +6,10 @@
  *
  * UUID Version 7 is defined in {@link https://www.rfc-editor.org/rfc/rfc9562.html#section-5.7 | RFC 9562}.
  *
+ * UUIDv7 values sort by creation time at millisecond precision. Values
+ * generated within the same millisecond sort in arbitrary order relative to
+ * each other, see {@linkcode generate} for details.
+ *
  * ```ts
  * import { generate, validate, extractTimestamp } from "@std/uuid/v7";
  * import { assert, assertEquals } from "@std/assert";
@@ -45,6 +49,11 @@ export function validate(id: string): boolean {
 
 /**
  * Generates a {@link https://www.rfc-editor.org/rfc/rfc9562.html#section-5.7 | UUIDv7}.
+ *
+ * All bits after the 48-bit timestamp are random, so UUIDs generated within
+ * the same millisecond do not sort in generation order: this implementation
+ * uses none of the optional monotonicity methods of
+ * {@link https://www.rfc-editor.org/rfc/rfc9562.html#section-6.2 | RFC 9562 section 6.2}.
  *
  * @throws {RangeError} If the timestamp is not a non-negative integer.
  *


### PR DESCRIPTION
Documents an existing limitation of `@std/uuid/v7`. No code changes.

`generate()` fills everything after the 48-bit timestamp with random bits. In RFC 9562 terms it uses none of the optional monotonicity methods from section 6.2, so two UUIDs created in the same millisecond sort in arbitrary order relative to each other. Sortability is the main reason people reach for v7, and neither the module doc nor the `generate()` doc mentioned the caveat. Now both do, with a link to the RFC section.

If in-millisecond ordering is ever wanted, a counter (method 1 or 2 of section 6.2) can ship as an additive option without changing the current API. This PR takes no position on whether that is worth doing.

I used Claude Code to help investigate and write this change.
