### PR TITLE
feat(yaml): stabilize `quoteStyle` option for `stringify()`

### DIFF
--- a/yaml/stringify.ts
+++ b/yaml/stringify.ts
@@ -85,6 +85,14 @@ export type StringifyOptions = {
    * @default {false}
    */
   condenseFlow?: boolean;
+  /**
+   * Strings will be quoted using this quoting style.
+   * If you specify single quotes, double quotes will still be used
+   * for non-printable characters.
+   *
+   * @default {`'`}
+   */
+  quoteStyle?: "'" | '"';
 };
 
 /**

--- a/yaml/stringify_test.ts
+++ b/yaml/stringify_test.ts
@@ -869,15 +869,15 @@ Deno.test({
 });
 
 Deno.test({
-  name: "(unstable) stringify() handles quoteStyle",
+  name: "stringify() handles quoteStyle",
   fn() {
     const object = { url: "https://example.com" };
     assertEquals(
-      unstableStringify(object, { quoteStyle: '"' }),
+      stringify(object, { quoteStyle: '"' }),
       `url: "https://example.com"\n`,
     );
     assertEquals(
-      unstableStringify(object, { quoteStyle: "'" }),
+      stringify(object, { quoteStyle: "'" }),
       `url: 'https://example.com'\n`,
     );
   },

--- a/yaml/unstable_stringify.ts
+++ b/yaml/unstable_stringify.ts
@@ -14,15 +14,6 @@ export type { ImplicitType, KindType, RepresentFn, SchemaType, Type };
 /** Options for {@linkcode stringify}. */
 export type StringifyOptions = StableStringifyOptions & {
   /**
-   * Strings will be quoted using this quoting style.
-   * If you specify single quotes, double quotes will still be used
-   * for non-printable characters.
-   *
-   * @default {`'`}
-   */
-  quoteStyle?: "'" | '"';
-
-  /**
    * Extra types to be added to the schema.
    */
   extraTypes?: ImplicitType[];


### PR DESCRIPTION
Promotes the `quoteStyle` option from `unstable_stringify.ts` into the stable `StringifyOptions`. No behavior change: `DumperState` already handled the option, so this only moves the type, its doc comment, and the test.

`quoteStyle` has been unstable since May 2025 (#6666). No open issues against it, no changes since it landed. It has baked long enough.

`extraTypes` stays unstable on purpose: its shape may still change depending on how #7020 (explicit tag support) resolves.

Tested by switching the existing quoteStyle test from the unstable import to the stable one. All 45 tests in `yaml/stringify_test.ts` pass.
