### PR TITLE
chore: enable no-node-globals and no-process-global lint rules

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -52,6 +52,8 @@
       "include": [
         "camelcase",
         "no-import-prefix",
+        "no-node-globals",
+        "no-process-global",
         "no-sync-fn-in-async-fn",
         "single-var-declarator",
         "no-console"


### PR DESCRIPTION
Enables the `no-node-globals` and `no-process-global` lint rules proposed in #7251. Both already pass: `deno lint` reports zero violations across 1169 files, so this is a config-only change.

Type checking doesn't reliably catch a bare `process` or `Buffer`. Any npm dependency can pull `@types/node` into the type graph, and from that point the reference type-checks silently. `_tools/check_browser_compat.ts` skips tests and `_`-prefixed files by design. The lint rules close that gap for every file, on every PR.

The `ban-untagged-todo` part of #7251 comes as a separate PR, since it touches code.

I used Claude Code to help investigate and write this change.