### PR TITLE
chore: enable ban-untagged-todo lint rule and tag existing TODOs

### DIFF
--- a/csv/parse.ts
+++ b/csv/parse.ts
@@ -240,7 +240,7 @@ class Parser {
     } else if (options.fieldsPerRecord === 0) {
       _nbFields = "UNINITIALIZED";
     } else {
-      // TODO: Should we check if it's a valid integer?
+      // TODO(magurotuna): Should we check if it's a valid integer?
       _nbFields = options.fieldsPerRecord;
     }
 

--- a/csv/parse_stream.ts
+++ b/csv/parse_stream.ts
@@ -382,7 +382,7 @@ export class CsvParseStream<
     } else if (this.#options.fieldsPerRecord === 0) {
       this.#fieldsPerRecord = "UNINITIALIZED";
     } else {
-      // TODO: Should we check if it's a valid integer?
+      // TODO(magurotuna): Should we check if it's a valid integer?
       this.#fieldsPerRecord = this.#options.fieldsPerRecord;
     }
 

--- a/deno.json
+++ b/deno.json
@@ -50,6 +50,7 @@
     "rules": {
       "tags": ["recommended", "jsr"],
       "include": [
+        "ban-untagged-todo",
         "camelcase",
         "no-import-prefix",
         "no-sync-fn-in-async-fn",

--- a/dotenv/mod_test.ts
+++ b/dotenv/mod_test.ts
@@ -207,7 +207,7 @@ Deno.test(
   },
 );
 
-//TODO test permissions
+// TODO(cknight): test permissions
 
 Deno.test(
   "loadSync() prevents file system reads of default path parameter values by using explicit null",

--- a/testing/_snapshot_utils.ts
+++ b/testing/_snapshot_utils.ts
@@ -105,5 +105,5 @@ export function getSnapshotNotMatchMessage(
   return getErrorMessage(message, options);
 }
 
-// TODO (WWRS): Remove this when we drop support for Deno 1.x
+// TODO(WWRS): Remove this when we drop support for Deno 1.x
 export const LINT_SUPPORTED = !Deno.version.deno.startsWith("1.");

--- a/toml/_test_utils.ts
+++ b/toml/_test_utils.ts
@@ -34,7 +34,7 @@ export function convertTestCase(v: TestCase): unknown {
         return parseFloat(v.value.replace("inf", "Infinity"));
       case "bool":
         return v.value === "true";
-      // TODO: https://github.com/denoland/std/issues/6591
+      // TODO(4513ECHO): https://github.com/denoland/std/issues/6591
       case "datetime":
       case "datetime-local":
       case "date-local":


### PR DESCRIPTION
Enables the `ban-untagged-todo` lint rule, the second half of #7251. The style guide already requires TODOs to carry a username or issue link; this turns on the rule that enforces it.

Five untagged TODOs had accumulated. Each is now tagged with the username of the commit author who wrote it (via `git blame`): magurotuna (csv/parse.ts, csv/parse_stream.ts), cknight (dotenv/mod_test.ts), WWRS (testing/_snapshot_utils.ts, only needed a space removed), and 4513ECHO (toml/_test_utils.ts). No TODO text changed otherwise.

`deno lint` passes across all 1169 files with the rule on.

I used Claude Code to help investigate and write this change.