### PR TITLE
feat(text): stabilize `truncate()`

### DIFF
--- a/text/deno.json
+++ b/text/deno.json
@@ -18,7 +18,7 @@
     "./unstable-to-sentence-case": "./unstable_to_sentence_case.ts",
     "./to-snake-case": "./to_snake_case.ts",
     "./unstable-to-title-case": "./unstable_to_title_case.ts",
-    "./unstable-truncate": "./unstable_truncate.ts",
+    "./truncate": "./truncate.ts",
     "./word-similarity-sort": "./word_similarity_sort.ts"
   }
 }

--- a/text/mod.ts
+++ b/text/mod.ts
@@ -27,3 +27,4 @@ export * from "./to_camel_case.ts";
 export * from "./to_kebab_case.ts";
 export * from "./to_pascal_case.ts";
 export * from "./to_snake_case.ts";
+export * from "./truncate.ts";

--- a/text/truncate.ts
+++ b/text/truncate.ts
@@ -31,8 +31,6 @@ export interface TruncateOptions {
  * Note: this function is not grapheme-cluster-aware. Combining characters, flag
  * emoji, and ZWJ sequences may still be visually split.
  *
- * @experimental **UNSTABLE**: New API, yet to be vetted.
- *
  * @param str The string to truncate.
  * @param maxLength The maximum length of the returned string (must be a
  * non-negative integer).
@@ -43,7 +41,7 @@ export interface TruncateOptions {
  *
  * @example End truncation (default)
  * ```ts
- * import { truncate } from "@std/text/unstable-truncate";
+ * import { truncate } from "@std/text/truncate";
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals(truncate("Hello, world!", 8), "Hello, …");
@@ -52,7 +50,7 @@ export interface TruncateOptions {
  *
  * @example Middle truncation
  * ```ts
- * import { truncate } from "@std/text/unstable-truncate";
+ * import { truncate } from "@std/text/truncate";
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
@@ -63,7 +61,7 @@ export interface TruncateOptions {
  *
  * @example Start truncation
  * ```ts
- * import { truncate } from "@std/text/unstable-truncate";
+ * import { truncate } from "@std/text/truncate";
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals(
@@ -74,7 +72,7 @@ export interface TruncateOptions {
  *
  * @example Custom suffix
  * ```ts
- * import { truncate } from "@std/text/unstable-truncate";
+ * import { truncate } from "@std/text/truncate";
  * import { assertEquals } from "@std/assert";
  *
  * assertEquals(

--- a/text/truncate_test.ts
+++ b/text/truncate_test.ts
@@ -1,7 +1,7 @@
 // Copyright 2018-2026 the Deno authors. MIT license.
 import { assertEquals } from "@std/assert/equals";
 import { assertThrows } from "@std/assert/throws";
-import { truncate } from "./unstable_truncate.ts";
+import { truncate } from "./truncate.ts";
 
 Deno.test("truncate() returns empty string when maxLength is zero", () => {
   assertEquals(truncate("hello", 0), "");


### PR DESCRIPTION
Promotes `truncate()` to stable after five months unstable with zero bug reports. The new specifier is `@std/text/truncate` and it's now exported from `mod.ts`.

The diff is a rename plus bookkeeping: `unstable_truncate.ts` to `truncate.ts` (test file too), `@experimental` tag dropped, JSDoc import specifiers updated, `deno.json` export swapped. No logic changed. Behavior is identical to what's been on JSR since March (#7052).

One open question from the original request (#6456) is word and grapheme-aware truncation, which this API doesn't do. That's not a blocker: it lands later as an additive `boundary` option defaulting to today's behavior. What stabilization freezes is the defaults, so those are what to review hardest: UTF-16 code-unit measurement (matches every JS string builtin), no whitespace trimming before the suffix, and `…` as the default suffix.

Tested: 19 unit tests and 4 doc examples pass, lint and fmt green.