### PR TITLE
docs(jsonc): document the accepted JSONC dialect and the TypeError from `new`

### DIFF
--- a/jsonc/mod.ts
+++ b/jsonc/mod.ts
@@ -6,6 +6,10 @@
  * {@link https://code.visualstudio.com/docs/languages/json#_json-with-comments | JSONC}
  * (JSON with comments).
  *
+ * On top of what JSON allows, this module accepts line comments (`//`), block
+ * comments, and a trailing comma after the last member of an object or array.
+ * Comments are discarded when parsing.
+ *
  * Currently, this module only provides a means of parsing JSONC. JSONC
  * serialization is not yet supported.
  *

--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -7,6 +7,10 @@ export type { JsonValue };
 /**
  * Converts a JSON with Comments (JSONC) string into an object.
  *
+ * On top of what JSON allows, line comments (`//`), block comments, and a
+ * trailing comma after the last member of an object or array are accepted.
+ * Comments are discarded.
+ *
  * @example Usage
  * ```ts
  * import { parse } from "@std/jsonc";
@@ -18,6 +22,7 @@ export type { JsonValue };
  * ```
  *
  * @throws {SyntaxError} If the JSONC string is invalid.
+ * @throws {TypeError} If called with `new`.
  * @param text A valid JSONC string.
  * @returns The parsed JsonValue from the JSONC string.
  */


### PR DESCRIPTION
Documents what `@std/jsonc` accepts. Doc comments only, no behavior change.

The module doc linked to the VS Code JSONC page and left it at that, so the dialect was never stated in std's own docs. That got worse when `allowTrailingComma` was removed in #5119: trailing commas became unconditional, and nothing said so. Both `jsonc/mod.ts` and `parse()` now spell out the three additions over JSON (line comments, block comments, trailing comma after the last member) and note that comments are discarded.

`parse()` also gains a `@throws` line for the `TypeError` it raises when called with `new`. The `new.target` guard is there in the code and covered by a test in `parse_test.ts`, but only `SyntaxError` was documented.

One thing I left alone. CONTRIBUTING.md says `@param`/`@returns` come before `@example`, and jsonc does the opposite. So does most of the repo: 478 doc blocks put `@example` first against 335 that don't, and sibling `yaml/parse.ts` uses the same layout as jsonc. Reordering one module would be churn, not a fix.

`deno fmt`, `deno lint`, `deno task lint:docs`, and the jsonc suite (408 tests) all pass.

I used Claude Code to help investigate and write this change.
