### PR TITLE
fix(jsonc): report unterminated strings as unexpected end of input

### DIFF
--- a/jsonc/parse.ts
+++ b/jsonc/parse.ts
@@ -156,12 +156,19 @@ class JsoncParser {
           // '"\\\\\\""' => '\\"'
           // '"\\\\\\\\"' => '\\\\'
           let shouldEscapeNext = false;
+          let hasEndOfString = false;
           i++;
           for (; i < this.#length; i++) { // read until find `"`
             if (this.#text[i] === '"' && !shouldEscapeNext) {
+              hasEndOfString = true;
               break;
             }
             shouldEscapeNext = this.#text[i] === "\\" && !shouldEscapeNext;
+          }
+          if (!hasEndOfString) {
+            throw new SyntaxError(
+              "Cannot parse JSONC: unexpected end of JSONC input",
+            );
           }
           yield {
             type: "String",

--- a/jsonc/parse_test.ts
+++ b/jsonc/parse_test.ts
@@ -100,6 +100,16 @@ Deno.test({
       "Cannot parse JSONC: unexpected end of JSONC input",
     );
     assertInvalidParse(
+      `"abc`,
+      SyntaxError,
+      "Cannot parse JSONC: unexpected end of JSONC input",
+    );
+    assertInvalidParse(
+      `{"a": "b`,
+      SyntaxError,
+      "Cannot parse JSONC: unexpected end of JSONC input",
+    );
+    assertInvalidParse(
       `[]100`,
       SyntaxError,
       'Cannot parse JSONC: unexpected token "100" in JSONC at position 2',


### PR DESCRIPTION
An unterminated string now reports the truncation instead of blaming the token.

Before, `parse('"abc')` threw:

```
Cannot parse JSONC: unexpected token ""abc" in JSONC at position 0
```

Every other truncated input says `Cannot parse JSONC: unexpected end of JSONC input`. Unterminated strings were the exception, and `{"a": "b` had the same problem.

The tokenizer's string branch yields a String token whether or not it found the closing quote. The failure then surfaces downstream, when `JSON.parse` chokes on the token text, so it reads as a bad token rather than a file that stopped early. The fix tracks `hasEndOfString` and throws the end-of-input error, mirroring the `hasEndOfComment` check for unterminated block comments 50 lines above it.

Still a `SyntaxError`. Message only, no type change, no change to any input that parses.

7 lines in `parse.ts`, plus 2 cases in the existing `parse() throws error message` test. #5799 aligned the other jsonc messages the same way.

`deno fmt`, `deno lint`, `deno task lint:docs`, and the jsonc suite (408 tests) all pass.

I used Claude Code to help investigate and write this change.
