### PR TITLE
test(jsonc): make the JSONTestSuite harness compare parsed values

### DIFF
--- a/jsonc/testdata/JSONTestSuite/test.ts
+++ b/jsonc/testdata/JSONTestSuite/test.ts
@@ -18,7 +18,9 @@ function getError<T>(
 
 // Make sure that the JSON.parse and JSONC.parse results match.
 for await (
-  const dirEntry of walk(fromFileUrl(new URL("./", import.meta.url)))
+  const dirEntry of walk(fromFileUrl(new URL("./", import.meta.url)), {
+    exts: [".json"],
+  })
 ) {
   if (!dirEntry.isFile) {
     continue;
@@ -30,12 +32,12 @@ for await (
     async fn() {
       const text = await Deno.readTextFile(dirEntry.path);
 
-      const [hasJsonError, jsonError, jsonResult] = getError(() => {
-        JSON.parse(text);
-      });
-      const [hasJsoncError, jsoncError, jsoncResult] = getError(() => {
-        JSONC.parse(text);
-      });
+      const [hasJsonError, jsonError, jsonResult] = getError(() =>
+        JSON.parse(text)
+      );
+      const [hasJsoncError, jsoncError, jsoncResult] = getError(() =>
+        JSONC.parse(text)
+      );
 
       // If an error occurs in JSON.parse() but no error occurs in JSONC.parse(), or vice versa, an error is thrown.
       if (hasJsonError !== hasJsoncError) {


### PR DESCRIPTION
The JSONTestSuite harness has never compared a parsed value. This makes it compare them.

`getError(() => { JSON.parse(text); })` uses a block body with no `return`, so `jsonResult` and `jsoncResult` come back `undefined` every time. The `assertEquals(jsonResult, jsoncResult)` on line 47 has been comparing `undefined` to `undefined` since it was written. The `test_transform/` corpus exists for exactly this check (number precision, duplicate keys, NFC/NFD keys, invalid codepoints) and none of it was running.

Switching to expression bodies returns the values.

Second fix: `walk()` had no extension filter, so `README.md` and `test.ts` were registered as JSON fixtures. Both parsers reject them, so they "passed". Added `exts: [".json"]`, which is why the count drops from 408 to 406.

**Does this catch a real bug?** No. Everything still passes, so nothing was hiding. To confirm the assertion is live rather than merely present, I sabotaged the jsonc result and watched 159 tests fail, the 159 fixtures that parse successfully under both parsers. That same sabotage passed clean before this change.

No production code touched.

One follow-up I left out on purpose: the harness only checks *whether* something threw, never the type. That hides two fixtures, `n_structure_100000_opening_arrays.json` and `n_structure_open_array_object.json`, where jsonc throws `RangeError` and `JSON.parse` throws `SyntaxError`. Asserting the error type means first deciding what jsonc owes on recursion depth, so it gets its own issue rather than riding along here.

I used Claude Code to help investigate and write this change.
