### PR TITLE
fix(async/unstable): count circuit breaker requests at completion

### DIFF
--- a/async/unstable_circuit_breaker.ts
+++ b/async/unstable_circuit_breaker.ts
@@ -582,13 +582,11 @@ export class CircuitBreaker<T = unknown> {
       };
     }
 
-    this.#rotateToNow(currentTime);
-    this.#requests.increment();
-
     let result: R;
     try {
       result = await fn();
     } catch (error) {
+      this.#recordRequest();
       if (tryCall(this.#isFailure, error)) {
         this.#handleFailure(error, currentState.state);
       }
@@ -602,6 +600,7 @@ export class CircuitBreaker<T = unknown> {
       }
     }
 
+    this.#recordRequest();
     const isResultFail = tryCall(this.#isResultFailure, result);
     if (isResultFail) {
       this.#handleFailure(undefined, currentState.state);
@@ -714,6 +713,15 @@ export class CircuitBreaker<T = unknown> {
       this.#failures.rotate(steps);
       this.#lastRotationMs += steps * this.#msPerSegment;
     }
+  }
+
+  /**
+   * Counts a completed request. Requests are recorded on completion, in the
+   * same segment as their outcome, so failures can never outnumber requests.
+   */
+  #recordRequest(): void {
+    this.#rotateToNow(Date.now());
+    this.#requests.increment();
   }
 
   /** Resets both counters and the rotation timestamp. */

--- a/async/unstable_circuit_breaker_test.ts
+++ b/async/unstable_circuit_breaker_test.ts
@@ -428,6 +428,68 @@ Deno.test("CircuitBreaker.execute() frees half_open concurrency slot on failure"
   assertEquals(breaker.state, "closed");
 });
 
+Deno.test("CircuitBreaker.execute() counts a request in the same window segment as its outcome", async () => {
+  using time = new FakeTime();
+
+  const samples: [number, number][] = [];
+  const breaker = new CircuitBreaker({
+    failureRateThreshold: 0.5,
+    minimumThroughput: 1,
+    windowMs: 1000,
+    segmentsPerWindow: 10,
+    onFailure: (_error, failures, requests) =>
+      samples.push([failures, requests]),
+  });
+
+  const rejects: ((err: Error) => void)[] = [];
+  const pending = [0, 1].map(() =>
+    breaker.execute(
+      () =>
+        new Promise<string>((_r, rej) => {
+          rejects.push(rej);
+        }),
+    ).catch(() => {})
+  );
+
+  // The whole window expires, then a fresh request rotates the counters.
+  time.tick(1500);
+  await breaker.execute(() => Promise.resolve("ok"));
+
+  for (const reject of rejects) reject(new Error("late"));
+  await Promise.all(pending);
+
+  assertEquals(samples, [[1, 2], [2, 3]]);
+  assertEquals(breaker.state, "open");
+});
+
+Deno.test("CircuitBreaker.execute() evicts expired history before evaluating a delayed failure", async () => {
+  using time = new FakeTime();
+
+  const breaker = new CircuitBreaker({
+    failureRateThreshold: 0.5,
+    minimumThroughput: 2,
+    windowMs: 1000,
+    segmentsPerWindow: 10,
+  });
+
+  await failN(breaker, 1);
+
+  let reject: ((err: Error) => void) | undefined;
+  const pending = breaker.execute(
+    () =>
+      new Promise<string>((_r, rej) => {
+        reject = rej;
+      }),
+  ).catch(() => {});
+
+  // The earlier failure falls out of the window before this one completes.
+  time.tick(5000);
+  reject?.(new Error("late"));
+  await pending;
+
+  assertEquals(breaker.state, "closed");
+});
+
 Deno.test("CircuitBreaker.execute() prevents stale half_open success from closing after concurrent failure", async () => {
   using time = new FakeTime();
 


### PR DESCRIPTION
The circuit breaker counted a request when it was admitted but counted its failure when it completed, and the failure path never rotated the sliding window. Two things went wrong across an `await`:

- A request admitted in one window could fail in the next. After another request rotated the counters, the failure landed with no matching request. Two slow failures after one fresh success reported 2 failures against 1 request and opened the circuit.
- A delayed failure was evaluated against unrotated history, so failures that had already expired still counted toward the rate.

Requests are now counted on completion, right after rotating, so a request and its outcome always land in the same segment. Callbacks still report the same totals for requests that complete in order.

Two tests cover the mismatch and the stale history. Both fail on main.
