### PR TITLE
fix(async/unstable): evaluate circuit breaker failure rate on success

### DIFF
--- a/async/unstable_circuit_breaker.ts
+++ b/async/unstable_circuit_breaker.ts
@@ -758,8 +758,7 @@ export class CircuitBreaker<T = unknown> {
     const failureCount = this.#failures.total;
 
     const shouldOpen = previousState === "half_open" ||
-      (totalRequests >= this.#minimumThroughput &&
-        failureCount / totalRequests >= this.#failureRateThreshold);
+      this.#exceedsFailureRate();
 
     const existingOpenedAt = this.#state.state === "open"
       ? this.#state.openedAt
@@ -790,9 +789,33 @@ export class CircuitBreaker<T = unknown> {
     }
   }
 
-  /** Records a success and potentially closes the circuit from half-open. */
+  /** Whether the window has enough requests and the rate meets the threshold. */
+  #exceedsFailureRate(): boolean {
+    const totalRequests = this.#requests.total;
+    return totalRequests >= this.#minimumThroughput &&
+      this.#failures.total / totalRequests >= this.#failureRateThreshold;
+  }
+
+  /**
+   * Records a success. Closes the circuit from half-open once enough
+   * successes accrue. In closed state, a success can still be the request
+   * that lifts the window over `minimumThroughput`, so the rate is evaluated.
+   */
   #handleSuccess(previousState: CircuitState): void {
-    if (previousState === "closed") return;
+    if (previousState === "closed") {
+      if (this.#state.state !== "closed" || !this.#exceedsFailureRate()) {
+        return;
+      }
+      this.#state = {
+        ...this.#state,
+        state: "open",
+        openedAt: Date.now(),
+        consecutiveSuccesses: 0,
+      };
+      this.#onStateChange?.("closed", "open");
+      this.#onOpen?.(this.#failures.total, this.#requests.total);
+      return;
+    }
     if (this.#state.state !== "half_open") return;
 
     const newSuccessCount = this.#state.consecutiveSuccesses + 1;

--- a/async/unstable_circuit_breaker_test.ts
+++ b/async/unstable_circuit_breaker_test.ts
@@ -428,6 +428,36 @@ Deno.test("CircuitBreaker.execute() frees half_open concurrency slot on failure"
   assertEquals(breaker.state, "closed");
 });
 
+Deno.test("CircuitBreaker.execute() opens when a success brings the window to minimumThroughput", async () => {
+  const opens: [number, number][] = [];
+  const changes: string[] = [];
+  const breaker = new CircuitBreaker({
+    failureRateThreshold: 0.5,
+    minimumThroughput: 3,
+    onOpen: (failures, requests) => opens.push([failures, requests]),
+    onStateChange: (from, to) => changes.push(`${from}->${to}`),
+  });
+
+  await failN(breaker, 2);
+  assertEquals(breaker.state, "closed");
+
+  await succeedN(breaker, 1);
+  assertEquals(breaker.state, "open");
+  assertEquals(opens, [[2, 3]]);
+  assertEquals(changes, ["closed->open"]);
+});
+
+Deno.test("CircuitBreaker.execute() stays closed when a success keeps the rate below the threshold", async () => {
+  const breaker = new CircuitBreaker({
+    failureRateThreshold: 0.5,
+    minimumThroughput: 3,
+  });
+
+  await failN(breaker, 1);
+  await succeedN(breaker, 2);
+  assertEquals(breaker.state, "closed");
+});
+
 Deno.test("CircuitBreaker.execute() prevents stale half_open success from closing after concurrent failure", async () => {
   using time = new FakeTime();
 


### PR DESCRIPTION
A success in closed state returned before the failure rate was checked. When that success was the request that lifted the window to `minimumThroughput`, the circuit stayed closed even though the rate already qualified. With `minimumThroughput: 3` and `failureRateThreshold: 0.5`, failure, failure, success left the circuit closed at a 67% failure rate. The docs say it opens.

Closed-state successes now run the same rate check as failures, and open the circuit with the usual `onStateChange` and `onOpen` callbacks when it qualifies. The check is factored into one helper so both paths agree.

One test covers the trip, one covers a success that keeps the rate below the threshold.
