### PR TITLE
fix(testing): preserve Date subclass prototype under FakeTime

### DIFF
--- a/testing/time.ts
+++ b/testing/time.ts
@@ -75,10 +75,10 @@ function fakeTimeNow() {
 }
 
 const FakeDate = new Proxy(Date, {
-  construct(_target, args) {
+  construct(_target, args, newTarget) {
     if (args.length === 0) args.push(FakeDate.now());
-    // @ts-expect-error this is a passthrough
-    return new _internals.Date(...args);
+    // Forward newTarget so `class X extends Date` keeps its prototype.
+    return Reflect.construct(_internals.Date, args, newTarget);
   },
   apply(_target, _thisArg, _args) {
     return new _internals.Date(fakeTimeNow()).toString();

--- a/testing/time_test.ts
+++ b/testing/time_test.ts
@@ -107,6 +107,47 @@ Deno.test("FakeTime causes Date function to return the string representation of 
   assertMatch(Date(), /(Fri|Thu) Jan 0(1|2) 1970/);
 });
 
+Deno.test("FakeTime preserves the prototype of Date subclasses", () => {
+  using _time = new FakeTime(24 * 60 * 60 * 1000);
+  class MyDate extends Date {
+    tag = "x";
+  }
+  const date = new MyDate();
+  assertInstanceOf(date, MyDate);
+  assertStrictEquals(Object.getPrototypeOf(date), MyDate.prototype);
+  assertEquals(date.tag, "x");
+  assertEquals(date.toISOString(), "1970-01-02T00:00:00.000Z");
+  assertEquals(new MyDate(1000).getTime(), 1000);
+});
+
+Deno.test("FakeTime causes new Date() to track the fake clock", () => {
+  using time = new FakeTime(9001);
+  assertEquals(new Date().getTime(), time.now);
+  time.tick(5000);
+  assertEquals(new Date().getTime(), time.now);
+});
+
+Deno.test("FakeTime passes explicit undefined through to Date", () => {
+  using _time = new FakeTime(9001);
+  assert(Number.isNaN(new Date(undefined as unknown as number).getTime()));
+});
+
+Deno.test("FakeTime constructor captured while faked works after restore", () => {
+  let Captured: DateConstructor;
+  let CapturedSub: new () => Date;
+  {
+    using _time = new FakeTime(9001);
+    Captured = Date;
+    CapturedSub = class extends Date {};
+  }
+  const before = _internals.Date.now();
+  const date = new Captured();
+  const sub = new CapturedSub();
+  assert(date.getTime() >= before);
+  assert(sub.getTime() >= before);
+  assertInstanceOf(sub, CapturedSub);
+});
+
 Deno.test("FakeTime timeout functions unchanged if FakeTime is uninitialized", () => {
   assertStrictEquals(setTimeout, _internals.setTimeout);
   assertStrictEquals(clearTimeout, _internals.clearTimeout);


### PR DESCRIPTION
Under `FakeTime`, `class MyDate extends Date {}` produced a plain `Date`. The `construct` trap on the `Date` proxy dropped `newTarget`, so `new MyDate()` skipped the subclass prototype and its field initializers.

Repro on main:

```ts
using t = new FakeTime(86_400_000);
class MyDate extends Date { tag = "x"; }
const d = new MyDate();
d instanceof MyDate;                            // false
Object.getPrototypeOf(d) === MyDate.prototype;  // false
```

The fix forwards `newTarget` to `Reflect.construct`. When `new.target` is the proxy itself, `Reflect.construct` reads `prototype` through the `get` trap and lands on the real `Date.prototype`, so plain `new Date()` behaves as before. This also drops the `@ts-expect-error` the spread needed.

Nothing else changes. Statics, `Date()` without `new`, `instanceof` for real instances, and argument passthrough all resolve the same way they did.

Tests added: subclass keeps its prototype and fields, zero-arg construction tracks `tick()`, `new Date(undefined)` stays invalid, and a constructor captured while faked still works after `restore()`. The subclass test fails on main.
