### PR TITLE
chore: exclude _tmp from deno config

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -16,8 +16,8 @@
   },
   "unstable": ["webgpu", "fs"],
   "tasks": {
-    "test": "deno test -A --parallel --trace-leaks --coverage --doc --clean --ignore=_tools/",
-    "test:with-unsafe-proto": "deno test --unstable-unsafe-proto --no-check -A --parallel --doc --ignore=_tools/",
+    "test": "deno test -A --parallel --trace-leaks --coverage --doc --clean --ignore=_tools/,_tmp/",
+    "test:with-unsafe-proto": "deno test --unstable-unsafe-proto --no-check -A --parallel --doc --ignore=_tools/,_tmp/",
     "test:tools": "deno test -A --doc _tools/",
     "test:browser": "git grep --name-only \"This module is browser compatible.\" | grep -v deno.json | grep -v .github/workflows | grep -v _tools | grep -v encoding/README.md | grep -v media_types/vendor/update.ts | xargs deno check --config browser-compat.tsconfig.json",
     "test:node": "(cd _tools/node_test_runner && npm install) && node --import ./_tools/node_test_runner/register_deno_shim.mjs ./_tools/node_test_runner/run_test.mjs",
@@ -39,6 +39,7 @@
   },
   "exclude": [
     ".git",
+    "_tmp",
     "jsonc/testdata",
     "toml/testdata",
     "_tools/node_test_runner",


### PR DESCRIPTION
`deno task ok` fails if you leave a markdown file in `_tmp/`.

`_tmp/` is the gitignored agent scratch dir from #7064. `fmt` and `lint` honour `.gitignore` and skip it. `deno test` doesn't, so `--doc` type-checks the TS fences in whatever notes an agent left behind:

```
TS2304 [ERROR]: Cannot find name '_internals'.
    at file:///.../_tmp/fake-time-drop-proxy-design.md#55-72.ts:9:34
```

The `--ignore=_tools/,_tmp/` on the test tasks is the part that fixes it: a CLI `--ignore` replaces the config `exclude` rather than adding to it. The `"_tmp"` in `exclude` covers a bare `deno test` or `deno check`.

Scratch notes are not doctests.

`deno task ok` exits 0 with a design note sitting in `_tmp/`. Nine type errors without the change.
