### PR TITLE
fix(data-structures): support array-like inputs in BinarySearchTree.from() and RedBlackTree.from()

### DIFF
--- a/data_structures/binary_search_tree.ts
+++ b/data_structures/binary_search_tree.ts
@@ -295,7 +295,7 @@ export class BinarySearchTree<T> implements Iterable<T> {
     }
     const values: Iterable<U> = options?.map
       ? Array.from(unmappedValues, options.map, options.thisArg)
-      : unmappedValues as U[];
+      : Array.from(unmappedValues) as unknown as U[];
     for (const value of values) result.insert(value);
     return result;
   }

--- a/data_structures/binary_search_tree_test.ts
+++ b/data_structures/binary_search_tree_test.ts
@@ -317,6 +317,26 @@ Deno.test("BinarySearchTree contains objects", () => {
   assertEquals(tree.isEmpty(), true);
 });
 
+Deno.test("BinarySearchTree.from() handles empty array-like objects", () => {
+  const tree = BinarySearchTree.from<number>({ length: 0 });
+  assertEquals([...tree], []);
+  assertEquals(tree.size, 0);
+});
+
+Deno.test("BinarySearchTree.from() handles array-like objects", () => {
+  const values = { 0: 3, 1: 1, 2: 3, 3: 2, length: 4 };
+  const tree = BinarySearchTree.from(values);
+  assertEquals([...tree], [1, 2, 3]);
+  assertEquals(tree.size, 3);
+});
+
+Deno.test("BinarySearchTree.from() handles array-like objects with a custom comparator", () => {
+  const values = { 0: 3, 1: 1, 2: 3, 3: 2, length: 4 };
+  const tree = BinarySearchTree.from(values, { compare: descend });
+  assertEquals([...tree], [3, 2, 1]);
+  assertEquals(tree.size, 3);
+});
+
 Deno.test("BinarySearchTree.from() handles iterable", () => {
   const values: number[] = [-10, 9, -1, 100, 9, 1, 0, 9, -100, 10, -9];
   const originalValues: number[] = Array.from(values);

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -267,7 +267,7 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
     }
     const values: Iterable<U> = options?.map
       ? Array.from(unmappedValues, options.map, options.thisArg)
-      : Array.from(unmappedValues as ArrayLike<U> | Iterable<U>);
+      : Array.from(unmappedValues) as unknown as U[];
     for (const value of values) result.insert(value);
     return result;
   }

--- a/data_structures/red_black_tree.ts
+++ b/data_structures/red_black_tree.ts
@@ -267,7 +267,7 @@ export class RedBlackTree<T> extends BinarySearchTree<T> {
     }
     const values: Iterable<U> = options?.map
       ? Array.from(unmappedValues, options.map, options.thisArg)
-      : unmappedValues as U[];
+      : Array.from(unmappedValues as ArrayLike<U> | Iterable<U>);
     for (const value of values) result.insert(value);
     return result;
   }

--- a/data_structures/red_black_tree_test.ts
+++ b/data_structures/red_black_tree_test.ts
@@ -312,6 +312,26 @@ Deno.test("RedBlackTree works with object items", () => {
   assertEquals(tree.isEmpty(), true);
 });
 
+Deno.test("RedBlackTree.from() handles empty array-like objects", () => {
+  const tree = RedBlackTree.from<number>({ length: 0 });
+  assertEquals([...tree], []);
+  assertEquals(tree.size, 0);
+});
+
+Deno.test("RedBlackTree.from() handles array-like objects", () => {
+  const values = { 0: 3, 1: 1, 2: 3, 3: 2, length: 4 };
+  const tree = RedBlackTree.from(values);
+  assertEquals([...tree], [1, 2, 3]);
+  assertEquals(tree.size, 3);
+});
+
+Deno.test("RedBlackTree.from() handles array-like objects with a custom comparator", () => {
+  const values = { 0: 3, 1: 1, 2: 3, 3: 2, length: 4 };
+  const tree = RedBlackTree.from(values, { compare: descend });
+  assertEquals([...tree], [3, 2, 1]);
+  assertEquals(tree.size, 3);
+});
+
 Deno.test("RedBlackTree.from() handles Iterable", () => {
   const values: number[] = [-10, 9, -1, 100, 9, 1, 0, 9, -100, 10, -9];
   const originalValues: number[] = Array.from(values);


### PR DESCRIPTION
Fix `BinarySearchTree.from()` and `RedBlackTree.from()` for array-like objects without a mapping function. Both accept `ArrayLike<T>` per their signatures, yet `RedBlackTree.from({ 0: 42, length: 1 })` threw `TypeError: values is not iterable`. Same bug in both classes, since `RedBlackTree` overrides `from()` with a copy of the parent's logic.

Convert unmapped inputs with `Array.from()` before insertion. Three regression tests per class cover empty inputs, sorting and deduplication, and a custom comparator. All six previously failed.

Validation:

- `env -u NO_COLOR deno task ok` on Deno 2.9.6: lint, formatting, browser compatibility, and all tests pass.
- Type-checked and ran the four touched files on Deno 1.46.3 as well. CI's v1.x matrix rejected the earlier `as ArrayLike<U> | Iterable<U>` cast, so the fix now uses the `as unknown as` idiom already used elsewhere in these files.
